### PR TITLE
Backport internal pull request 64 and 72

### DIFF
--- a/api/turing/service/experiment_service.go
+++ b/api/turing/service/experiment_service.go
@@ -418,8 +418,6 @@ func (es *experimentsService) getExperimentsWithCache(
 	for _, eID := range experimentIDs {
 		if e, found := expIDMap[eID]; found {
 			filteredExperiments = append(filteredExperiments, e)
-		} else {
-			return []manager.Experiment{}, fmt.Errorf("Could not find experiment %s", eID)
 		}
 	}
 	return filteredExperiments, nil

--- a/engines/router/missionctl/handlers/internal_api_test.go
+++ b/engines/router/missionctl/handlers/internal_api_test.go
@@ -46,49 +46,41 @@ func TestVersionAPI(t *testing.T) {
 }
 
 func TestNewHealthcheckHandler(t *testing.T) {
-	tests := []struct {
-		name        string
+	tests := map[string]struct {
 		serviceURLs []string
 		wantCode    int
 	}{
-		{
-			name:        "Nil seviceURLs",
+		"Nil seviceURLs": {
 			serviceURLs: nil,
 			wantCode:    http.StatusOK,
 		},
-		{
-			name:        "Empty seviceURLs",
+		"Empty seviceURLs": {
 			serviceURLs: []string{},
 			wantCode:    http.StatusOK,
 		},
-		{
-			name:        "Empty string seviceURLs",
+		"Empty string seviceURLs": {
 			serviceURLs: []string{""},
 			wantCode:    http.StatusOK,
 		},
-		{
-			name:        "Resolvable seviceURLs",
-			serviceURLs: []string{"http://example.com", "http://google.com"},
+		"Resolvable seviceURLs": {
+			serviceURLs: []string{""},
 			wantCode:    http.StatusOK,
 		},
-		{
-			name:        "All non-resolvable seviceURLs",
+		"All non-resolvable seviceURLs": {
 			serviceURLs: []string{"http://ttthis-host-should-not-exist.com"},
 			wantCode:    http.StatusServiceUnavailable,
 		},
-		{
-			name:        "Some non-resolvable seviceURLs",
+		"Some non-resolvable seviceURLs": {
 			serviceURLs: []string{"http://ttthis-host-should-not-exist.com", "http://google.com"},
 			wantCode:    http.StatusServiceUnavailable,
 		},
-		{
-			name:        "Invalid seviceURLs",
+		"Invalid seviceURLs": {
 			serviceURLs: []string{"invalid-url"},
 			wantCode:    http.StatusServiceUnavailable,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
 			handler := newHealthcheckHandler(tt.serviceURLs).(http.Handler)
 			req, err := http.NewRequest("GET", "/ready", nil)
 			if err != nil {


### PR DESCRIPTION
PR 64:

Select experiment engine > select a client and one or more experiments > select a different client without clearing the client selection intermediately - API response error from Get Variables, that the experiment id is not found. This happens because the client id is first updated which causes the variables list to refresh (with the new client id and old experiment ids), before the experiment list is updated. This is temporarily fixed in the API by ignoring experiment ids that cannot be found when both client id and experiment ids are set, in the call to get experiment variables.

PR 72:

Check that service URLs are resolvable in the Turing router readiness check. This is to prevent the router from accepting requests before ensembler or enricher hosts are resolvable.