### PR TITLE
Backport internal pull request 79

### DIFF
--- a/api/turing/api/request/request_test.go
+++ b/api/turing/api/request/request_test.go
@@ -155,6 +155,9 @@ func TestRequestBuildRouterVersionWithDefaults(t *testing.T) {
 			Image: "fluentdimage",
 			Tag:   "fluentdtag",
 		},
+		Experiment: map[string]string{
+			"litmus": `{"endpoint":"grpc://test","timeout":"2s"}`,
+		},
 	}
 	projectID := 1
 	router := createOrUpdateRequest.BuildRouter(projectID)
@@ -178,8 +181,8 @@ func TestRequestBuildRouterVersionWithDefaults(t *testing.T) {
 					Endpoint string `json:"endpoint"`
 					Timeout  string `json:"timeout"`
 				}{
-					Endpoint: "",
-					Timeout:  "",
+					Endpoint: "grpc://test",
+					Timeout:  "2s",
 				},
 				Client: manager.Client{
 					ID:       "1",
@@ -293,7 +296,11 @@ func TestRequestBuildRouterVersionWithDefaults(t *testing.T) {
 }
 
 func TestBuildExperimentEngineConfig(t *testing.T) {
-	routerDefaults := &config.RouterDefaults{}
+	routerDefaults := &config.RouterDefaults{
+		Experiment: map[string]string{
+			"xp": `{"endpoint":"http://test","timeout":"3s"}`,
+		},
+	}
 	// Set up mock Crypto service
 	cs := &mocks.CryptoService{}
 	cs.On("Encrypt", "xp-passkey-bad").Return("", errors.New("test-encrypt-error"))
@@ -336,7 +343,10 @@ func TestBuildExperimentEngineConfig(t *testing.T) {
 				Deployment: struct {
 					Endpoint string `json:"endpoint"`
 					Timeout  string `json:"timeout"`
-				}{},
+				}{
+					Endpoint: "http://test",
+					Timeout:  "3s",
+				},
 				Client: manager.Client{
 					Username: "client-name",
 					Passkey:  "xp-passkey",
@@ -395,7 +405,10 @@ func TestBuildExperimentEngineConfig(t *testing.T) {
 				Deployment: struct {
 					Endpoint string `json:"endpoint"`
 					Timeout  string `json:"timeout"`
-				}{},
+				}{
+					Endpoint: "http://test",
+					Timeout:  "3s",
+				},
 				Client: manager.Client{
 					Username: "client-name",
 					Passkey:  "xp-passkey-enc",

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -48,6 +48,15 @@ type Config struct {
 	// SwaggerFile specifies the file path containing OpenAPI spec. This file will be used to configure
 	// OpenAPI validation middleware, which validates HTTP requests against the spec.
 	SwaggerFile string `envconfig:"swagger_file" default:"swagger.yaml"`
+	// Experiment specifies the JSON configuration to set up experiment managers and runners.
+	//
+	// The configuration follows the following format to support different experiment engines
+	// and to allow custom configuration for different engines:
+	// { "<experiment_engine>": <experiment_engine_config>, ... }
+	//
+	// For example:
+	// { "experiment_engine_a": `{"client": "foo"}`, "experiment_engine_b": `{"apikey": 12}` }
+	Experiment map[string]string `envconfig:"experiment"`
 }
 
 // ListenAddress returns the Turing Api app's port
@@ -101,6 +110,20 @@ type RouterDefaults struct {
 	LogLevel string `split_words:"true" default:"INFO"`
 	// Fluentd config for the router
 	FluentdConfig *FluentdConfig `envconfig:"fluentd"`
+	// Experiment specifies the default experiment JSON configuration for different experiment
+	// engines that Turing router supports.
+	//
+	// The JSON configuration follows the following format to support different experiment engines.
+	// { "<experiment_engine>": <experiment_engine_config>, ... }
+	//
+	// Currently the router defaults configuration for each experiment engine is expected to have
+	// "endpoint" and "timeout" fields with string value, in order to follow the configuration
+	// specification for routers.
+	//
+	// For example:
+	// {"experiment_engine_a": `{"endpoint": "http://engine-a.com", "timeout": "500ms"}`,
+	//  "experiment_engine_b": `{"endpoint": "http://engine-b.com", "timeout": "250ms"}`}
+	Experiment map[string]string `envconfig:"experiment"`
 }
 
 // FluentdConfig captures the defaults used by the Turing Router when Fluentd is enabled


### PR DESCRIPTION
Add Experiment field in the Turing API config to allow custom configuration for experiment runners and managers for different experiment engines.