### PR TITLE
Backport internal pull request 81

### DIFF
--- a/api/turing/service/experiment_service.go
+++ b/api/turing/service/experiment_service.go
@@ -418,6 +418,8 @@ func (es *experimentsService) getExperimentsWithCache(
 	for _, eID := range experimentIDs {
 		if e, found := expIDMap[eID]; found {
 			filteredExperiments = append(filteredExperiments, e)
+		} else {
+			return []manager.Experiment{}, fmt.Errorf("Could not find experiment %s", eID)
 		}
 	}
 	return filteredExperiments, nil


### PR DESCRIPTION
In the Turing API's `getExperimentsWithCache`, if any experiment id requested is not found, return error.

This method is called by `ListVariables` and this change is a precautionary measure, to have the API return an error if info on any unknown experiment id is requested.