### PR TITLE
Make experiment manager registration and configuration consistent with experiment runner

### DIFF
--- a/api/turing/api/appcontext.go
+++ b/api/turing/api/appcontext.go
@@ -53,7 +53,7 @@ func NewAppContext(
 	}
 
 	// Init Experiments Service
-	expSvc, err := service.NewExperimentsService()
+	expSvc, err := service.NewExperimentsService(cfg.Experiment)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed initializing Experiments Service")
 	}

--- a/api/turing/api/appcontext_test.go
+++ b/api/turing/api/appcontext_test.go
@@ -123,7 +123,7 @@ func TestNewAppContext(t *testing.T) {
 		},
 	)
 	monkey.Patch(service.NewExperimentsService,
-		func() (service.ExperimentsService, error) {
+		func(experimentConfig map[string]string) (service.ExperimentsService, error) {
 			return nil, nil
 		},
 	)
@@ -186,7 +186,7 @@ func TestNewAppContext(t *testing.T) {
 	mlpService, err := service.NewMLPService(testCfg.MLPConfig.MLPURL,
 		testCfg.MLPConfig.MLPEncryptionKey, testCfg.MLPConfig.MerlinURL)
 	assert.NoError(t, err)
-	experimentService, err := service.NewExperimentsService()
+	experimentService, err := service.NewExperimentsService(testCfg.Experiment)
 	assert.NoError(t, err)
 	gitlabClient, err := gitlab.NewClient(
 		testCfg.AlertConfig.GitLab.Token,

--- a/api/turing/service/experiment_service.go
+++ b/api/turing/service/experiment_service.go
@@ -55,11 +55,12 @@ type Experiment struct {
 	Treatments []string `json:"treatments"` // List of treatment names (i.e variations) in the experiment.
 }
 
-// NewExperimentsService creates a new experiment service from the given config
-func NewExperimentsService(experimentConfig map[string]string) (ExperimentsService, error) {
+// NewExperimentsService creates a new experiment service from managerConfig.
+// managerConfig is a map of experiment manager name to the JSON string configuration.
+func NewExperimentsService(managerConfig map[string]string) (ExperimentsService, error) {
 	experimentManagers := make(map[string]manager.ExperimentManager)
 
-	for name, config := range experimentConfig {
+	for name, config := range managerConfig {
 		m, err := manager.Get(name, []byte(config))
 		if err != nil {
 			return nil, err

--- a/api/turing/service/experiment_service.go
+++ b/api/turing/service/experiment_service.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/patrickmn/go-cache"
 
-	"github.com/gojek/turing/api/turing/models"
 	"github.com/gojek/turing/engines/experiment/common"
 	"github.com/gojek/turing/engines/experiment/manager"
 )
@@ -40,7 +39,7 @@ type ExperimentsService interface {
 
 type experimentsService struct {
 	// map of engine name -> Experiment Manager
-	experimentManagers map[models.ExperimentEngineType]manager.ExperimentManager
+	experimentManagers map[string]manager.ExperimentManager
 	cache              *cache.Cache
 }
 
@@ -57,8 +56,16 @@ type Experiment struct {
 }
 
 // NewExperimentsService creates a new experiment service from the given config
-func NewExperimentsService() (ExperimentsService, error) {
-	experimentManagers := make(map[models.ExperimentEngineType]manager.ExperimentManager)
+func NewExperimentsService(experimentConfig map[string]string) (ExperimentsService, error) {
+	experimentManagers := make(map[string]manager.ExperimentManager)
+
+	for name, config := range experimentConfig {
+		m, err := manager.Get(name, []byte(config))
+		if err != nil {
+			return nil, err
+		}
+		experimentManagers[name] = m
+	}
 
 	// Initialize the experimentsService with cache
 	svc := &experimentsService{
@@ -69,12 +76,12 @@ func NewExperimentsService() (ExperimentsService, error) {
 	// Populate the cache with the Clients / Experiments info
 	for expEngine, expManager := range svc.experimentManagers {
 		if expManager.GetEngineInfo().ClientSelectionEnabled {
-			_, err := svc.ListClients(string(expEngine))
+			_, err := svc.ListClients(expEngine)
 			if err != nil {
 				return nil, err
 			}
 		} else if expManager.GetEngineInfo().ExperimentSelectionEnabled {
-			_, err := svc.ListExperiments(string(expEngine), "")
+			_, err := svc.ListExperiments(expEngine, "")
 			if err != nil {
 				return nil, err
 			}
@@ -187,7 +194,7 @@ func (es *experimentsService) GetExperimentRunnerConfig(
 func (es *experimentsService) getExperimentManager(
 	engine string,
 ) (manager.ExperimentManager, error) {
-	expManager, ok := es.experimentManagers[models.ExperimentEngineType(engine)]
+	expManager, ok := es.experimentManagers[engine]
 	if !ok {
 		return nil, fmt.Errorf("Unknown experiment engine %s", engine)
 	}

--- a/api/turing/service/experiment_service_test.go
+++ b/api/turing/service/experiment_service_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	tu "github.com/gojek/turing/api/turing/internal/testutils"
-	"github.com/gojek/turing/api/turing/models"
 	"github.com/gojek/turing/engines/experiment/common"
 	"github.com/gojek/turing/engines/experiment/manager"
 	"github.com/gojek/turing/engines/experiment/manager/mocks"
@@ -35,9 +34,9 @@ func TestListEngines(t *testing.T) {
 	expMgr2.On("GetEngineInfo").Return(xpEngineInfo)
 
 	// Create the experiment managers map and the experiment service
-	experimentManagers := make(map[models.ExperimentEngineType]manager.ExperimentManager)
-	experimentManagers[models.ExperimentEngineTypeLitmus] = expMgr1
-	experimentManagers[models.ExperimentEngineTypeXp] = expMgr2
+	experimentManagers := make(map[string]manager.ExperimentManager)
+	experimentManagers["litmus"] = expMgr1
+	experimentManagers["xp"] = expMgr2
 	svc := &experimentsService{
 		experimentManagers: experimentManagers,
 		cache:              cache.New(time.Second, time.Second),
@@ -103,8 +102,8 @@ func TestListClients(t *testing.T) {
 				cacheObj.Set("engine:litmus:clients", "test", cache.DefaultExpiration)
 			}
 			svc := &experimentsService{
-				experimentManagers: map[models.ExperimentEngineType]manager.ExperimentManager{
-					models.ExperimentEngineTypeLitmus: data.expMgr,
+				experimentManagers: map[string]manager.ExperimentManager{
+					"litmus": data.expMgr,
 				},
 				cache: cacheObj,
 			}
@@ -208,8 +207,8 @@ func TestListExperiments(t *testing.T) {
 				cacheObj.Set("engine:litmus:clients:1:experiments", "test", cache.DefaultExpiration)
 			}
 			svc := &experimentsService{
-				experimentManagers: map[models.ExperimentEngineType]manager.ExperimentManager{
-					models.ExperimentEngineTypeLitmus: data.expMgr,
+				experimentManagers: map[string]manager.ExperimentManager{
+					"litmus": data.expMgr,
 				},
 				cache: cacheObj,
 			}
@@ -379,8 +378,8 @@ func TestListVariables(t *testing.T) {
 				cacheObj.Set(data.badCacheKey, "test", cache.DefaultExpiration)
 			}
 			svc := &experimentsService{
-				experimentManagers: map[models.ExperimentEngineType]manager.ExperimentManager{
-					models.ExperimentEngineTypeLitmus: data.expMgr,
+				experimentManagers: map[string]manager.ExperimentManager{
+					"litmus": data.expMgr,
 				},
 				cache: cacheObj,
 			}
@@ -418,8 +417,8 @@ func TestValidateExperimentConfig(t *testing.T) {
 	expMgr.On("ValidateExperimentConfig", manager.Engine{Name: "Litmus"}, manager.TuringExperimentConfig{}).Return(nil)
 	// Create test experiment service
 	expSvc := &experimentsService{
-		experimentManagers: map[models.ExperimentEngineType]manager.ExperimentManager{
-			models.ExperimentEngineTypeLitmus: expMgr,
+		experimentManagers: map[string]manager.ExperimentManager{
+			"litmus": expMgr,
 		},
 	}
 
@@ -463,8 +462,8 @@ func TestGetExperimentRunnerConfig(t *testing.T) {
 	expMgr.On("GetExperimentRunnerConfig", *testCfg).Return(expectedResult, nil)
 	// Create test experiment service
 	expSvc := &experimentsService{
-		experimentManagers: map[models.ExperimentEngineType]manager.ExperimentManager{
-			models.ExperimentEngineTypeLitmus: expMgr,
+		experimentManagers: map[string]manager.ExperimentManager{
+			"litmus": expMgr,
 		},
 	}
 

--- a/engines/experiment/common/web_utils.go
+++ b/engines/experiment/common/web_utils.go
@@ -58,4 +58,3 @@ func getValueFromJSONPayload(body []byte, key string) (string, error) {
 			"Field %s can not be parsed as string value, unsupported type: %s", key, typez.String())
 	}
 }
-

--- a/engines/experiment/manager/manager.go
+++ b/engines/experiment/manager/manager.go
@@ -37,6 +37,7 @@ type ExperimentManager interface {
 }
 
 var managersLock sync.Mutex
+
 // managers contain all the registered experiment managers by name.
 var managers = make(map[string]Factory)
 

--- a/engines/experiment/manager/manager.go
+++ b/engines/experiment/manager/manager.go
@@ -1,6 +1,11 @@
 package manager
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+)
 
 // ExperimentManager describes the methods to be implemented by an experiment engine's Manager,
 // providing access to the information required to set up experiments on Turing.
@@ -29,4 +34,51 @@ type ExperimentManager interface {
 	// ValidateExperimentConfig validates the given Turing experiment config for the expected data and format,
 	// based on the given engine properties
 	ValidateExperimentConfig(Engine, TuringExperimentConfig) error
+}
+
+var managersLock sync.Mutex
+var managers = make(map[string]Factory)
+
+// Factory creates an experiment manager from the provided config.
+//
+// Config is a raw encoded JSON value. The experiment manager implementation
+// for each experiment engine should provide a schema and example
+// of the JSON value to explain the usage.
+type Factory func(config json.RawMessage) (ExperimentManager, error)
+
+// Register an experiment manager with the provided name and factory function.
+//
+// For registration to be properly recorded, Register function should be called in the init
+// phase of the Go execution. The init function is usually defined in the package where
+// the manager is implemented. The name of the experiment manager should be unique
+// across all implementations. Registering multiple experiment managers with the
+// same name will return an error.
+func Register(name string, factory Factory) error {
+	managersLock.Lock()
+	defer managersLock.Unlock()
+
+	name = strings.ToLower(name)
+	if _, found := managers[name]; found {
+		return fmt.Errorf("experiment manager %q was registered twice", name)
+	}
+
+	managers[name] = factory
+	return nil
+}
+
+// Get an experiment manager that has been registered.
+//
+// The manager will be initialized with the provided config using the registered factory function.
+// Retrieving an experiment manager that is not registered will return an error.
+func Get(name string, config json.RawMessage) (ExperimentManager, error) {
+	managersLock.Lock()
+	defer managersLock.Unlock()
+
+	name = strings.ToLower(name)
+	m, ok := managers[name]
+	if !ok {
+		return nil, fmt.Errorf("no experiment manager found for name %s", name)
+	}
+
+	return m(config)
 }

--- a/engines/experiment/manager/manager.go
+++ b/engines/experiment/manager/manager.go
@@ -37,6 +37,7 @@ type ExperimentManager interface {
 }
 
 var managersLock sync.Mutex
+// managers contain all the registered experiment managers by name.
 var managers = make(map[string]Factory)
 
 // Factory creates an experiment manager from the provided config.
@@ -68,8 +69,8 @@ func Register(name string, factory Factory) error {
 
 // Get an experiment manager that has been registered.
 //
-// The manager will be initialized with the provided config using the registered factory function.
-// Retrieving an experiment manager that is not registered will return an error.
+// The manager will be initialized using the registered factory function with the provided config.
+// Retrieving an experiment manager that is not yet registered will return an error.
 func Get(name string, config json.RawMessage) (ExperimentManager, error) {
 	managersLock.Lock()
 	defer managersLock.Unlock()

--- a/engines/experiment/manager/manager_test.go
+++ b/engines/experiment/manager/manager_test.go
@@ -1,0 +1,108 @@
+package manager
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+type fakeManager struct {
+	config json.RawMessage
+}
+
+func (fm fakeManager) IsCacheEnabled() bool {
+	return false
+}
+
+func (fm fakeManager) GetEngineInfo() Engine {
+	return Engine{Name: "fake"}
+}
+
+func (fm fakeManager) ListClients() ([]Client, error) {
+	return []Client{}, nil
+}
+
+func (fm fakeManager) ListExperiments() ([]Experiment, error) {
+	return []Experiment{}, nil
+}
+
+func (fm fakeManager) ListExperimentsForClient(client Client) ([]Experiment, error) {
+	return []Experiment{}, nil
+}
+
+func (fm fakeManager) ListVariablesForClient(client Client) ([]Variable, error) {
+	return []Variable{}, nil
+}
+
+func (fm fakeManager) ListVariablesForExperiments(experiments []Experiment) (map[string][]Variable, error) {
+	return map[string][]Variable{}, nil
+}
+
+func (fm fakeManager) GetExperimentRunnerConfig(config TuringExperimentConfig) (json.RawMessage, error) {
+	return nil, nil
+}
+
+func (fm fakeManager) ValidateExperimentConfig(engine Engine, config TuringExperimentConfig) error {
+	return nil
+}
+
+func newFakeManager(config json.RawMessage) (ExperimentManager, error) {
+	return fakeManager{config: config}, nil
+}
+
+func TestRegisterAndGet(t *testing.T) {
+	tests := []struct {
+		name            string
+		managerName     string
+		managerFactory  Factory
+		managerConfig   json.RawMessage
+		skipRegister    bool
+		want            ExperimentManager
+		wantRegisterErr bool
+		wantGetErr      bool
+	}{
+		{
+			name:           "successful registration and retrieval of fakeManager",
+			managerName:    "fakeManager",
+			managerFactory: newFakeManager,
+			managerConfig:  []byte(`{"foo":"bar"}`),
+			want:           fakeManager{config: []byte(`{"foo":"bar"}`)},
+		},
+		{
+			name:            "failed multiple registrations of fakeManager",
+			managerName:     "fakeManager",
+			managerFactory:  newFakeManager,
+			managerConfig:   []byte(`{"foo":"bar"}`),
+			want:            fakeManager{config: []byte(`{"foo":"bar"}`)},
+			wantRegisterErr: true,
+		},
+		{
+			name:         "failed retrieval of non-registered manager",
+			managerName:  "nonRegisteredRunner",
+			skipRegister: true,
+			wantGetErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.skipRegister {
+				err := Register(tt.managerName, tt.managerFactory)
+
+				if (err != nil) != tt.wantRegisterErr {
+					t.Errorf("Register() error = %v, wantErr %v", err, tt.wantRegisterErr)
+					return
+				}
+			}
+
+			got, err := Get(tt.managerName, tt.managerConfig)
+			if (err != nil) != tt.wantGetErr {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantGetErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Get() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/engines/experiment/manager/manager_test.go
+++ b/engines/experiment/manager/manager_test.go
@@ -1,52 +1,19 @@
-package manager
+package manager_test
 
 import (
 	"encoding/json"
+	"github.com/gojek/turing/engines/experiment/manager"
+	"github.com/gojek/turing/engines/experiment/manager/mocks"
 	"reflect"
 	"testing"
 )
 
 type fakeManager struct {
+	*mocks.ExperimentManager
 	config json.RawMessage
 }
 
-func (fm fakeManager) IsCacheEnabled() bool {
-	return false
-}
-
-func (fm fakeManager) GetEngineInfo() Engine {
-	return Engine{Name: "fake"}
-}
-
-func (fm fakeManager) ListClients() ([]Client, error) {
-	return []Client{}, nil
-}
-
-func (fm fakeManager) ListExperiments() ([]Experiment, error) {
-	return []Experiment{}, nil
-}
-
-func (fm fakeManager) ListExperimentsForClient(client Client) ([]Experiment, error) {
-	return []Experiment{}, nil
-}
-
-func (fm fakeManager) ListVariablesForClient(client Client) ([]Variable, error) {
-	return []Variable{}, nil
-}
-
-func (fm fakeManager) ListVariablesForExperiments(experiments []Experiment) (map[string][]Variable, error) {
-	return map[string][]Variable{}, nil
-}
-
-func (fm fakeManager) GetExperimentRunnerConfig(config TuringExperimentConfig) (json.RawMessage, error) {
-	return nil, nil
-}
-
-func (fm fakeManager) ValidateExperimentConfig(engine Engine, config TuringExperimentConfig) error {
-	return nil
-}
-
-func newFakeManager(config json.RawMessage) (ExperimentManager, error) {
+func newFakeManager(config json.RawMessage) (manager.ExperimentManager, error) {
 	return fakeManager{config: config}, nil
 }
 
@@ -54,10 +21,10 @@ func TestRegisterAndGet(t *testing.T) {
 	tests := []struct {
 		name            string
 		managerName     string
-		managerFactory  Factory
+		managerFactory  manager.Factory
 		managerConfig   json.RawMessage
 		skipRegister    bool
-		want            ExperimentManager
+		want            manager.ExperimentManager
 		wantRegisterErr bool
 		wantGetErr      bool
 	}{
@@ -86,7 +53,7 @@ func TestRegisterAndGet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if !tt.skipRegister {
-				err := Register(tt.managerName, tt.managerFactory)
+				err := manager.Register(tt.managerName, tt.managerFactory)
 
 				if (err != nil) != tt.wantRegisterErr {
 					t.Errorf("Register() error = %v, wantErr %v", err, tt.wantRegisterErr)
@@ -94,7 +61,7 @@ func TestRegisterAndGet(t *testing.T) {
 				}
 			}
 
-			got, err := Get(tt.managerName, tt.managerConfig)
+			got, err := manager.Get(tt.managerName, tt.managerConfig)
 			if (err != nil) != tt.wantGetErr {
 				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantGetErr)
 				return

--- a/engines/experiment/manager/manager_test.go
+++ b/engines/experiment/manager/manager_test.go
@@ -2,10 +2,11 @@ package manager_test
 
 import (
 	"encoding/json"
-	"github.com/gojek/turing/engines/experiment/manager"
-	"github.com/gojek/turing/engines/experiment/manager/mocks"
 	"reflect"
 	"testing"
+
+	"github.com/gojek/turing/engines/experiment/manager"
+	"github.com/gojek/turing/engines/experiment/manager/mocks"
 )
 
 type fakeManager struct {

--- a/engines/experiment/manager/manager_test.go
+++ b/engines/experiment/manager/manager_test.go
@@ -78,7 +78,7 @@ func TestRegisterAndGet(t *testing.T) {
 		},
 		{
 			name:         "failed retrieval of non-registered manager",
-			managerName:  "nonRegisteredRunner",
+			managerName:  "nonRegisteredManager",
 			skipRegister: true,
 			wantGetErr:   true,
 		},


### PR DESCRIPTION
`experiment.manager` package is missing:

1. `Register` function  that different experiment managers implementation should call to register themselves.
2. `Get` function that the users of experiment managers should call to retrieve and initialize the registered experiment managers.

This pull request add those 2 functions similar to how they are implemented in `experiment.runner` so experiment runners and managers behaviour is consistent.

https://github.com/gojek/turing/blob/84d3c6bcc1e020d117fc9becbbe4dc88567f3045/engines/experiment/runner/runner.go#L42

https://github.com/gojek/turing/blob/84d3c6bcc1e020d117fc9becbbe4dc88567f3045/engines/experiment/runner/runner.go#L57

Experiment service constructor in `api` module is also updated so that the experiment managers in the service are retrieved using the `manager.Get` function as expected.