### PR TITLE
Add trace for response ensembling in Turing router's FanIn

### DIFF
--- a/engines/router/missionctl/fiberapi/fan_in.go
+++ b/engines/router/missionctl/fiberapi/fan_in.go
@@ -18,7 +18,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
-const FanInID = "fanin"
+// FanInID is used to indendify the fan in component when capturing a request span
+const FanInID = "fan_in"
 
 // EnsemblingFanIn combines the results from the fanout with the experiment parameters
 // and forwards to the configured ensembling endpoint


### PR DESCRIPTION
This PR starts a span from the `Aggregate` method in FanIn, to measure the time taken to ensemble the responses.

**Before:**
![Screenshot 2020-11-04 at 11 02 35 AM](https://user-images.githubusercontent.com/23465343/98064443-49a98300-1e8d-11eb-8d5f-edc03f1e3678.png)

<hr/>

**After:**
![Screenshot 2020-11-04 at 11 02 24 AM](https://user-images.githubusercontent.com/23465343/98064446-4b734680-1e8d-11eb-8fed-ae74a1cb9018.png)
