### PR TITLE
Add Turing Helm chart default values and Helm values documentation

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,74 @@
+# turing
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+
+Turing: ML Experimentation System
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | postgresql | 8.9.8 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| dbMigrations.image.tag | string | `"v4.7.1"` | Docker tag for golang-migrate Docker image https://hub.docker.com/r/migrate/migrate |
+| postgresql.persistence.enabled | bool | `true` | Persist Postgresql data in a Persistent Volume Claim  |
+| postgresql.postgresqlDatabase | string | `"turing"` | Database name for Turing Postgresql database |
+| postgresql.postgresqlPassword | string | `nil` | Password for Turing Postgresql database (required) |
+| postgresql.postgresqlUsername | string | `"turing"` | Username for Turing Postgresql database |
+| postgresql.resources | object | `{}` | Resources requests and limits for Turing database. This should be set  according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
+| swaggerUi.apiHost | string | `"127.0.0.1"` | Host for the Swagger UI |
+| swaggerUi.basePath | string | `"/v1"` | Base URL path to serve the Swagger UI |
+| swaggerUi.image | object | `{"tag":"v3.24.3"}` | Docker tag for Swagger UI https://hub.docker.com/r/swaggerapi/swagger-ui |
+| swaggerUi.service.externalPort | int | `8080` | Swagger UI Kubernetes service port number |
+| swaggerUi.service.internalPort | int | `8081` | Swagger UI container port number |
+| turing.config.alert.enabled | bool | `false` | Enable alerting in Turing |
+| turing.config.alert.gitlabBaseurl | string | `nil` | GitLab server URL for GitOps based alerting |
+| turing.config.alert.gitlabBranch | string | `nil` | GitLab branch to commit the alert configuration file |
+| turing.config.alert.gitlabPathprefix | string | `nil` | GitLab path prefix within the project to save the alert configuration file |
+| turing.config.alert.gitlabProjectid | string | `nil` | GitLab project ID |
+| turing.config.alert.gitlabToken | string | `nil` | GitLab token to authentication API request to GitLab |
+| turing.config.authorization.enabled | bool | `false` | Enable authorization middleware in Turing API |
+| turing.config.authorization.serverURL | string | `nil` | Authorization server URL |
+| turing.config.deployment.deletionTimeout | string | `"30s"` | Maximum wait duration to delete Turing router |
+| turing.config.deployment.environmentType | string | `"id-dev"` | Environment name associated with Turing router |
+| turing.config.deployment.gcpProject | string | `""` | Google Cloud Project ID associcated with Turing router |
+| turing.config.deployment.maxCPU | string | `"8"` | Hard limit on the maximum CPU Turing router can request |
+| turing.config.deployment.maxMemory | string | `"8Gi"` | Hard limit on the maximum memory Turing router can request |
+| turing.config.deployment.timeout | string | `"3m"` | Maximum wait duration to create or update Turing router |
+| turing.config.encryption.key | string | `nil` | Encryption key used by Turing to secure sensitive values (required) |
+| turing.config.ingress.enabled | bool | `false` | Enable ingress to provision Ingress resource for external access to Turing API  |
+| turing.config.merlin.endpoint | string | `nil` | Merlin API endpoint (required). Reference: https://github.com/gojek/merlin |
+| turing.config.mlp.encryption.key | string | `nil` | Encryption key used by MLP to secure sensitive values (required) |
+| turing.config.mlp.endpoint | string | `nil` | MLP API endpoint(required). Reference: https://github.com/gojek/mlp |
+| turing.config.newrelic.appname | string | `nil` | Application name monitored in New Relic |
+| turing.config.newrelic.enabled | bool | `false` | Enable integrarion with New Relic application monitoring https://newrelic.com |
+| turing.config.router.customMetrics | bool | `true` | Enable custom metrics |
+| turing.config.router.fiberDebugLog | bool | `true` | Enable debugging for Fiber library used by Turing router |
+| turing.config.router.fluentd.flushIntervalSeconds | int | `90` | How often should Fluentd flush the buffered log |
+| turing.config.router.fluentd.image | string | `nil` | Docker image for Fluentd log forwarder. User is expected to specify the Fluentd image for now as there is no publicly available image.  Currently this is required only if users needs to save Turing logs in BigQuery. |
+| turing.config.router.image.registry | string | `"docker.io/"` | Docker registry for Turing router image. User is expected to override the registry for now as there is no publicly available Turing image |
+| turing.config.router.image.repository | string | `"turing-router"` | Docker image repository for Turing router |
+| turing.config.router.image.tag | string | `"latest"` | Docker image tag for Turing router |
+| turing.config.router.jaeger.collectorEndpoint | string | `nil` | Jaeger tracing collector endpoint  |
+| turing.config.router.jaeger.enabled | bool | `false` | Enable Jaeger tracing |
+| turing.config.router.logLevel | string | `"DEBUG"` | Log level for Turing router |
+| turing.config.sentry.dsn | string | `nil` | Data source name for the Sentry project  |
+| turing.config.sentry.enabled | bool | `false` | Enable integration with Sentry application monitoring https://sentry.io |
+| turing.config.serviceAccount.enabled | bool | `false` | Enable usage of Google Cloud service account JSON key |
+| turing.config.serviceAccount.secretKey | string | `nil` | Secret key for Google Cloud service account JSON key |
+| turing.config.serviceAccount.secretName | string | `nil` | Secret name for Google Cloud service account JSON key |
+| turing.config.vault.address | string | `nil` | Vault server address (required) |
+| turing.config.vault.token | string | `nil` | Vault authentication token (required) |
+| turing.image.registry | string | `"docker.io/"` | Docker registry for Turing API image. User is required to override the registry for now as there is no publicly available Turing image |
+| turing.image.repository | string | `"turing"` | Docker image repository for Turing API |
+| turing.image.tag | string | `"latest"` | Docker image tag for Turing API |
+| turing.livenessProbe.path | string | `"/v1/internal/live"` | HTTP path for liveness check |
+| turing.readinessProbe.path | string | `"/v1/internal/ready"` | HTTP path for readiness check |
+| turing.resources | object | `{}` | Resources requests and limits for Turing API. This should be set  according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
+| turing.service.externalPort | int | `8080` | Turing API Kubernetes service port number |
+| turing.service.internalPort | int | `8080` | Turing API container port number |
+

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -74,12 +74,7 @@ spec:
             successThreshold: {{ default "1" .Values.turing.readinessProbe.successThreshold }}
             timeoutSeconds: {{ default "5" .Values.turing.readinessProbe.timeoutSeconds }}
           resources:
-            requests:
-              cpu: {{ .Values.turing.resources.requests.cpu }}
-              memory: {{ .Values.turing.resources.requests.memory }}
-            limits:
-              cpu: {{ .Values.turing.resources.limits.cpu }}
-              memory: {{ .Values.turing.resources.limits.memory }}
+            {{- toYaml .Values.turing.resources | nindent 12 }}
 {{- if .Values.turing.args }}
           args:
 {{ toYaml .Values.turing.args | indent 10 -}}
@@ -154,7 +149,7 @@ spec:
                   key: key
             {{- end }}
             - name: VAULT_ADDRESS
-              value: "{{ .Values.turing.config.vault.address }}"
+              value: {{ required "turing.config.vault.address is required" .Values.turing.config.vault.address }}
             - name: VAULT_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -166,9 +161,9 @@ spec:
                   key: turing_encryption_key
                   name: {{ template "turing.fullname" .}}-svc-secret
             - name: MERLIN_URL
-              value: {{ .Values.turing.config.merlin.endpoint }}
+              value: {{ required "turing.config.merlin.endpoint is required" .Values.turing.config.merlin.endpoint }}
             - name: MLP_URL
-              value: {{ .Values.turing.config.mlp.endpoint }}
+              value: {{ required "turing.config.mlp.endpoint is required" .Values.turing.config.mlp.endpoint }}
             - name: MLP_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/secrets.yml
+++ b/chart/templates/secrets.yml
@@ -4,9 +4,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "turing.fullname" .}}-svc-secret
 data:
-  vault_token: {{ .Values.turing.config.vault.token | b64enc }}
-  turing_encryption_key: {{ .Values.turing.config.encryption.key | b64enc }}
-  mlp_encryption_key: {{ .Values.turing.config.mlp.encryption.key | b64enc }}
+  vault_token: {{ required "turing.config.vault.token is required" .Values.turing.config.vault.token | b64enc }}
+  turing_encryption_key: {{ required "turing.config.encryption.key is required" .Values.turing.config.encryption.key | b64enc }}
+  mlp_encryption_key: {{ required "turing.config.mlp.encryption.key is required" .Values.turing.config.mlp.encryption.key | b64enc }}
   {{- if .Values.turing.config.alert.enabled }}
   gitlab_token: {{ .Values.turing.config.alert.gitlabToken | b64enc }}
   {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,160 @@
+# This values.yaml file provides default configuration for Turing Helm chart. 
+# It is also currently used to generate README.md using helm-docs
+# https://github.com/norwoodj/helm-docs
+
+turing:
+  image:
+    # -- Docker registry for Turing API image. User is required to override
+    # the registry for now as there is no publicly available Turing image
+    registry: docker.io/
+    # -- Docker image repository for Turing API
+    repository: turing
+    # -- Docker image tag for Turing API
+    tag: latest
+  # -- Resources requests and limits for Turing API. This should be set 
+  # according to your cluster capacity and service level objectives.
+  # Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  resources: {}
+  livenessProbe:
+    # -- HTTP path for liveness check
+    path: "/v1/internal/live"
+  readinessProbe:
+    # -- HTTP path for readiness check
+    path: "/v1/internal/ready"
+  service:
+    # -- Turing API Kubernetes service port number
+    externalPort: 8080
+    # -- Turing API container port number
+    internalPort: 8080
+  config:
+    deployment:
+      # -- Maximum wait duration to create or update Turing router
+      timeout: 3m
+      # -- Maximum wait duration to delete Turing router
+      deletionTimeout: 30s
+      # -- Google Cloud Project ID associcated with Turing router
+      gcpProject: ""
+      # -- Environment name associated with Turing router
+      environmentType: id-dev
+      # -- Hard limit on the maximum CPU Turing router can request
+      maxCPU: "8"
+      # -- Hard limit on the maximum memory Turing router can request
+      maxMemory: "8Gi"
+    router:
+      image:
+        # -- Docker registry for Turing router image. User is expected to override
+        # the registry for now as there is no publicly available Turing image
+        registry: docker.io/
+        # -- Docker image repository for Turing router
+        repository: turing-router
+        # -- Docker image tag for Turing router
+        tag: latest
+      # -- Log level for Turing router
+      logLevel: DEBUG
+      # -- Enable debugging for Fiber library used by Turing router
+      fiberDebugLog: true
+      # -- Enable custom metrics
+      customMetrics: true
+      jaeger:
+        # -- Enable Jaeger tracing
+        enabled: false
+        # -- Jaeger tracing collector endpoint 
+        collectorEndpoint: 
+      fluentd:
+        # -- Docker image for Fluentd log forwarder. User is expected to specify
+        # the Fluentd image for now as there is no publicly available image. 
+        # Currently this is required only if users needs to save Turing logs
+        # in BigQuery.
+        image:
+        # -- How often should Fluentd flush the buffered log
+        flushIntervalSeconds: 90
+    authorization:
+      # -- Enable authorization middleware in Turing API
+      enabled: false
+      # -- Authorization server URL
+      serverURL: 
+    sentry:
+      # -- Enable integration with Sentry application monitoring https://sentry.io
+      enabled: false
+      # -- Data source name for the Sentry project 
+      dsn:
+    newrelic:
+      # -- Enable integrarion with New Relic application monitoring https://newrelic.com
+      enabled: false
+      # -- Application name monitored in New Relic
+      appname: 
+    vault:
+      # -- Vault server address (required)
+      address: 
+      # -- Vault authentication token (required)
+      token: 
+    encryption:
+      # -- Encryption key used by Turing to secure sensitive values (required)
+      key:
+    merlin:
+      # -- Merlin API endpoint (required). Reference: https://github.com/gojek/merlin
+      endpoint:
+    mlp:
+      # -- MLP API endpoint(required). Reference: https://github.com/gojek/mlp
+      endpoint:
+      encryption:
+        # -- Encryption key used by MLP to secure sensitive values (required)
+        key: 
+    alert:
+      # -- Enable alerting in Turing
+      enabled: false
+      # -- GitLab server URL for GitOps based alerting
+      gitlabBaseurl:
+      # -- GitLab project ID
+      gitlabProjectid:
+      # -- GitLab branch to commit the alert configuration file
+      gitlabBranch:
+      # -- GitLab path prefix within the project to save the alert configuration file
+      gitlabPathprefix:
+      # -- GitLab token to authentication API request to GitLab
+      gitlabToken:
+    serviceAccount:
+      # -- Enable usage of Google Cloud service account JSON key
+      enabled: false
+      # -- Secret name for Google Cloud service account JSON key
+      secretName: 
+      # -- Secret key for Google Cloud service account JSON key
+      secretKey:
+    ingress:
+      # -- Enable ingress to provision Ingress resource for external access
+      # to Turing API 
+      enabled: false
+
+dbMigrations:
+  image:
+    # -- Docker tag for golang-migrate Docker image https://hub.docker.com/r/migrate/migrate
+    tag: v4.7.1
+
+swaggerUi:
+  # -- Docker tag for Swagger UI https://hub.docker.com/r/swaggerapi/swagger-ui
+  image:
+    tag: v3.24.3
+  # -- Host for the Swagger UI
+  apiHost: "127.0.0.1"
+  # -- Base URL path to serve the Swagger UI
+  basePath: "/v1"
+  service:
+    # -- Swagger UI container port number
+    internalPort: 8081
+    # -- Swagger UI Kubernetes service port number
+    externalPort: 8080
+
+postgresql:
+  # -- Resources requests and limits for Turing database. This should be set 
+  # according to your cluster capacity and service level objectives.
+  # Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  resources: {}
+  persistence:
+    # -- Persist Postgresql data in a Persistent Volume Claim 
+    enabled: true
+  # -- Database name for Turing Postgresql database
+  postgresqlDatabase: turing
+  # -- Username for Turing Postgresql database
+  postgresqlUsername: turing
+  # -- Password for Turing Postgresql database (required)
+  postgresqlPassword:

--- a/test/e2e/turing.helm-values.yaml
+++ b/test/e2e/turing.helm-values.yaml
@@ -10,40 +10,12 @@ turing:
     limits:
       cpu: 100m
       memory: 128Mi
-  livenessProbe:
-    path: "/v1/internal/live"
-  readinessProbe:
-    path: "/v1/internal/ready"
-  service:
-    externalPort: 8080
-    internalPort: 8080
   config:
-    deployment:
-      timeout: 3m
-      deletionTimeout: 30s
-      gcpProject: ""
-      environmentType: id-dev
-      maxCPU: "8"
-      maxMemory: "8Gi"
     router:
       image:
         registry: localhost:5000/
         repository: turing-router
         tag: latest
-      logLevel: DEBUG
-      fiberDebugLog: true
-      customMetrics: true
-      jaeger:
-        enabled: false
-      fluentd:
-        image: ""
-        flushIntervalSeconds: 90
-    authorization:
-      enabled: false
-    sentry:
-      enabled: false
-    newrelic:
-      enabled: false
     vault:
       address: http://vault:8200
       token: root
@@ -55,25 +27,6 @@ turing:
       endpoint: http://mlp:8080/v1
       encryption:
         key: secret
-    alert:
-      enabled: false
-    serviceAccount:
-      enabled: false
-    ingress:
-      enabled: false
-
-dbMigrations:
-  image:
-    tag: v4.7.1
-
-swaggerUi:
-  image:
-    tag: v3.24.3
-  apiHost: "127.0.0.1"
-  basePath: "/v1"
-  service:
-    internalPort: 8081
-    externalPort: 8080
 
 postgresql:
   resources:


### PR DESCRIPTION
Currently Turing Helm chart is missing the default values and documentation about what values can be provided by the user of Helm chart. This makes usage of chart not user friendly.

- This pull request add resonable default Helm values for relevant fields so that the users of the Helm chart does not need to always provide all the values. This will make deployment configuration simpler. 

- Markdown documentation for the Helm values is also provided, using [helm-docs](https://github.com/norwoodj/helm-docs) to render the document.

- Also removed Helm values in `test/e2e/turing.helm-values.yaml` which are already provided by default, in order to simplify configuration