### PR TITLE
Add env var to set allowed origins for accessing the API server

### DIFF
--- a/api/turing/cmd/main.go
+++ b/api/turing/cmd/main.go
@@ -93,11 +93,11 @@ func main() {
 		web.ServeReactApp(mux, cfg.TuringUIConfig.Homepage, cfg.TuringUIConfig.AppDirectory)
 	}
 
-	c := cors.New(cors.Options{
+	log.Infof("Listening on port %d", cfg.Port)
+	corsHandler := cors.New(cors.Options{
 		AllowedOrigins: cfg.AllowedOrigins,
 	})
-	log.Infof("Listening on port %d", cfg.Port)
-	if err := http.ListenAndServe(cfg.ListenAddress(), c.Handler(mux)); err != nil {
+	if err := http.ListenAndServe(cfg.ListenAddress(), corsHandler.Handler(mux)); err != nil {
 		log.Errorf("Failed to start turing-api: %s", err)
 	}
 }

--- a/api/turing/cmd/main.go
+++ b/api/turing/cmd/main.go
@@ -93,8 +93,11 @@ func main() {
 		web.ServeReactApp(mux, cfg.TuringUIConfig.Homepage, cfg.TuringUIConfig.AppDirectory)
 	}
 
+	c := cors.New(cors.Options{
+		AllowedOrigins: cfg.AllowedOrigins,
+	})
 	log.Infof("Listening on port %d", cfg.Port)
-	if err := http.ListenAndServe(cfg.ListenAddress(), cors.AllowAll().Handler(mux)); err != nil {
+	if err := http.ListenAndServe(cfg.ListenAddress(), c.Handler(mux)); err != nil {
 		log.Errorf("Failed to start turing-api: %s", err)
 	}
 }

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -35,6 +35,7 @@ func (qty *Quantity) Decode(value string) (err error) {
 // Config is used to parse and store the environment configs
 type Config struct {
 	Port                int                  `envconfig:"turing_port" default:"8080"`
+	AllowedOrigins      []string             `split_words:"true" default:"*"`
 	AuthConfig          *AuthorizationConfig `envconfig:"authorization" validate:"required"`
 	DbConfig            *DatabaseConfig      `envconfig:"turing_database"`
 	DeployConfig        *DeploymentConfig    `envconfig:"deployment"`

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -38,6 +38,7 @@ var requiredEnvs = map[string]string{
 }
 
 var optionalEnvs = map[string]string{
+	"ALLOWED_ORIGINS":                              "http://foo.com,http://bar.com",
 	"TURING_PORT":                                  "5000",
 	"TURING_DATABASE_PORT":                         "5433",
 	"TURING_ROUTER_FIBER_DEBUG_LOG_ENABLED":        "false",
@@ -74,7 +75,8 @@ func TestInitConfigDefaultEnvs(t *testing.T) {
 	timeout, _ := time.ParseDuration("10s")
 	delTimeout, _ := time.ParseDuration("1s")
 	expected := Config{
-		Port: 8080,
+		Port:           8080,
+		AllowedOrigins: []string{"*"},
 		AuthConfig: &AuthorizationConfig{
 			Enabled: true,
 			URL:     "test-auth-url",
@@ -148,7 +150,8 @@ func TestInitConfigEnv(t *testing.T) {
 	timeout, _ := time.ParseDuration("10s")
 	delTimeout, _ := time.ParseDuration("1s")
 	expected := Config{
-		Port: 5000,
+		Port:           5000,
+		AllowedOrigins: []string{"http://foo.com", "http://bar.com"},
 		AuthConfig: &AuthorizationConfig{
 			Enabled: false,
 			URL:     "test-auth-url",


### PR DESCRIPTION
This PR introduces a new env var `ALLOWED_ORIGINS` to the Turing API so that only trusted origins can make requests to the Turing API server via the browser. By default, this value will be set to `*` which is effectively the same as the previous `cors.AllowAll()`.