### PR TITLE
Fix text overflow bug in the UI panels

### DIFF
--- a/ui/src/router/components/configuration/components/docker_config_section/DockerConfigViewGroup.js
+++ b/ui/src/router/components/configuration/components/docker_config_section/DockerConfigViewGroup.js
@@ -8,9 +8,9 @@ import { ResourcesConfigTable } from "../ResourcesConfigTable";
 export const DockerConfigViewGroup = ({ componentName, dockerConfig }) => {
   return (
     <EuiFlexGroup direction="row" wrap>
-      <EuiFlexItem grow={3}>
+      <EuiFlexItem grow={3} className="euiFlexItem--childFlexPanel">
         <EuiFlexGroup direction="row" wrap>
-          <EuiFlexItem grow={2}>
+          <EuiFlexItem grow={2} className="euiFlexItem--childFlexPanel">
             <ConfigSectionPanel>
               <EuiFlexGroup direction="column" gutterSize="m">
                 <EuiFlexItem>

--- a/ui/src/router/components/configuration/components/section.scss
+++ b/ui/src/router/components/configuration/components/section.scss
@@ -1,5 +1,13 @@
 @import "~@elastic/eui/src/global_styling/mixins/typography";
 
+// When text is truncated in a child flex element, the auto-calculated min width is wider than
+// its parent container which can break the layout. To prevent this, the min-width attribute
+// is expected to be set to a fixed value.
+// Ref: https://css-tricks.com/flexbox-truncated-text/
+.euiFlexItem {
+  min-width: 0;
+}
+
 .euiPanel--configSection {
   .euiDescriptionList.euiDescriptionList--responsiveColumn {
     > * {

--- a/ui/src/router/components/configuration/components/section.scss
+++ b/ui/src/router/components/configuration/components/section.scss
@@ -4,7 +4,7 @@
 // its parent container which can break the layout. To prevent this, the min-width attribute
 // is expected to be set to a fixed value.
 // Ref: https://css-tricks.com/flexbox-truncated-text/
-.euiFlexItem {
+.euiFlexItem.euiFlexItem--childFlexPanel {
   min-width: 0;
 }
 


### PR DESCRIPTION
This PR fixes a bug in the UI panels where the panel would expand beyond the max screen width when attempting to accommodate a large text.

<img width="862" alt="Screenshot 2020-11-12 at 5 11 56 PM" src="https://user-images.githubusercontent.com/23465343/98919801-3be9a280-250a-11eb-9725-f27a57669e02.png">

The problem arises when applying text truncation inside a child flexbox, from the auto-calculated min width of the container exceeding that of the parent which would break the layout. The recommended fix is to set `min-width` to 0 on the child container.

More info: https://css-tricks.com/flexbox-truncated-text/