### PR TITLE
Introduce env var TEST_ECHO_IMAGE for API e2e tests

### DIFF
--- a/api/e2e/test/00_all_e2e_test.go
+++ b/api/e2e/test/00_all_e2e_test.go
@@ -4,10 +4,11 @@ package e2e
 
 import (
 	"fmt"
-	"github.com/kelseyhightower/envconfig"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/kelseyhightower/envconfig"
 )
 
 // These constants are set according to the values used by the app,
@@ -34,6 +35,7 @@ type testConfig struct {
 	ClusterName        string `envconfig:"MODEL_CLUSTER_NAME" required:"true"`
 	ProjectID          int    `envconfig:"PROJECT_ID" required:"true"`
 	ProjectName        string `envconfig:"PROJECT_NAME" required:"true"`
+	TestEchoImage      string `envconfig:"TEST_ECHO_IMAGE" default:"kennethreitz/httpbin"`
 	// KubeconfigUseLocal specifies whether the test helper should use local Kube config to
 	// authenticate to the cluster. The Kube config is assumed to be available at $HOME/.kube/config.
 	// If false, the helper will use the cluster credentials from the configured Vault environment.

--- a/api/e2e/test/testdata/create_router_nop_logger_nop_exp.json.tmpl
+++ b/api/e2e/test/testdata/create_router_nop_logger_nop_exp.json.tmpl
@@ -25,7 +25,7 @@
             "result_logger_type": "nop"
         },
         "enricher": {
-            "image": "kennethreitz/httpbin",
+            "image": "{{.TestEchoImage}}",
             "resource_request": {
                 "min_replica": 1,
                 "max_replica": 1,
@@ -45,7 +45,7 @@
         "ensembler": {
             "type": "docker",
             "docker_config": {
-                "image": "kennethreitz/httpbin",
+                "image": "{{.TestEchoImage}}",
                 "resource_request": {
                     "min_replica": 2,
                     "max_replica": 2,

--- a/api/e2e/test/testdata/create_router_with_traffic_rules.json.tmpl
+++ b/api/e2e/test/testdata/create_router_with_traffic_rules.json.tmpl
@@ -63,7 +63,7 @@
         "ensembler": {
             "type": "docker",
             "docker_config": {
-                "image": "kennethreitz/httpbin",
+                "image": "{{.TestEchoImage}}",
                 "resource_request": {
                     "min_replica": 2,
                     "max_replica": 2,

--- a/api/e2e/test/testdata/update_router_high_cpu.json.tmpl
+++ b/api/e2e/test/testdata/update_router_high_cpu.json.tmpl
@@ -25,7 +25,7 @@
             "result_logger_type": "nop"
         },
         "enricher": {
-            "image": "kennethreitz/httpbin",
+            "image": "{{.TestEchoImage}}",
             "resource_request": {
                 "min_replica": 1,
                 "max_replica": 1,
@@ -45,7 +45,7 @@
         "ensembler": {
             "type": "docker",
             "docker_config": {
-                "image": "kennethreitz/httpbin",
+                "image": "{{.TestEchoImage}}",
                 "resource_request": {
                     "min_replica": 2,
                     "max_replica": 2,


### PR DESCRIPTION
This PR copies the relevant changes from internal MR 92, that attempts to minimize the dependency on Docker Hub, in the internal CI / CD pipelines, due to the recent rate limit imposed by Docker. As a result, the env var `TEST_ECHO_IMAGE` has been added to potentially allow the tests to use a different image (from a different repo), among other changes. However, the image name is set to `kennethreitz/httpbin` by default and no changes are done to the Github pipelines at the moment.