### PR TITLE
Update apiVersion for Knative serving from v1alpha1 to v1

### DIFF
--- a/api/e2e/test/helpers_cluster_test.go
+++ b/api/e2e/test/helpers_cluster_test.go
@@ -18,12 +18,12 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	knservingclientset "knative.dev/serving/pkg/client/clientset/versioned"
-	knservingclient "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+	knservingclient "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
 )
 
 // TestClusterClients holds the Clients for K8s / KNative resource groups
 type TestClusterClients struct {
-	KnServingClient       knservingclient.ServingV1alpha1Interface
+	KnServingClient       knservingclient.ServingV1Interface
 	K8sCoreClient         corev1.CoreV1Interface
 	K8sAppsClient         appsv1.AppsV1Interface
 	IstioNetworkingClient networkingv1alpha3.NetworkingV1alpha3Interface
@@ -80,7 +80,7 @@ func newClusterClients(cfg *testConfig) (*TestClusterClients, error) {
 		return nil, err
 	}
 	return &TestClusterClients{
-		KnServingClient:       knsClientSet.ServingV1alpha1(),
+		KnServingClient:       knsClientSet.ServingV1(),
 		K8sCoreClient:         k8sClientset.CoreV1(),
 		K8sAppsClient:         k8sClientset.AppsV1(),
 		IstioNetworkingClient: istioClientset,

--- a/api/turing/cluster/controller.go
+++ b/api/turing/cluster/controller.go
@@ -21,9 +21,9 @@ import (
 	rest "k8s.io/client-go/rest"
 
 	"knative.dev/pkg/kmp"
-	knservingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	knservingclientset "knative.dev/serving/pkg/client/clientset/versioned"
-	knservingclient "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+	knservingclient "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
 
 	"github.com/gojek/mlp/pkg/vault"
 	"github.com/gojek/turing/api/turing/config"
@@ -75,7 +75,7 @@ type Controller interface {
 
 // controller implements the Controller interface
 type controller struct {
-	knServingClient knservingclient.ServingV1alpha1Interface
+	knServingClient knservingclient.ServingV1Interface
 	k8sCoreClient   corev1.CoreV1Interface
 	k8sAppsClient   appsv1.AppsV1Interface
 	istioClient     networkingv1alpha3.NetworkingV1alpha3Interface
@@ -111,7 +111,7 @@ func newController(clusterCfg clusterConfig) (Controller, error) {
 	}
 
 	return &controller{
-		knServingClient: knsClientSet.ServingV1alpha1(),
+		knServingClient: knsClientSet.ServingV1(),
 		k8sCoreClient:   k8sClientset.CoreV1(),
 		k8sAppsClient:   k8sClientset.AppsV1(),
 		istioClient:     istioClientSet,
@@ -203,7 +203,7 @@ func (c *controller) DeleteConfigMap(name, namespace string) error {
 
 // Deploy creates / updates a Kubernetes/Knative service with the given specs
 func (c *controller) DeployKnativeService(ctx context.Context, svcConf *KnativeService) error {
-	var existingSvc *knservingv1alpha1.Service
+	var existingSvc *knservingv1.Service
 	var err error
 
 	// Build the deployment specs
@@ -549,7 +549,7 @@ func deploymentReady(deployment *apiappsv1.Deployment) bool {
 	return false
 }
 
-func knServiceSemanticEquals(desiredService, service *knservingv1alpha1.Service) bool {
+func knServiceSemanticEquals(desiredService, service *knservingv1.Service) bool {
 	return equality.Semantic.DeepEqual(
 		desiredService.Spec.ConfigurationSpec,
 		service.Spec.ConfigurationSpec) &&

--- a/api/turing/cluster/controller_test.go
+++ b/api/turing/cluster/controller_test.go
@@ -25,7 +25,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	knservingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	knservingclientset "knative.dev/serving/pkg/client/clientset/versioned/fake"
 )
 
@@ -49,7 +49,7 @@ var reactorVerbs = struct {
 
 const (
 	knativeGroup    = "serving.knative.dev"
-	knativeVersion  = "v1alpha1"
+	knativeVersion  = "v1"
 	knativeResource = "services"
 )
 
@@ -60,7 +60,7 @@ func TestDeployKnativeService(t *testing.T) {
 		Version:  knativeVersion,
 		Resource: knativeResource,
 	}
-	testKnSvc := &knservingv1alpha1.Service{
+	testKnSvc := &knservingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testName,
 		},
@@ -74,11 +74,11 @@ func TestDeployKnativeService(t *testing.T) {
 
 	// Define reactor for a successful get
 	getSuccess := func(action k8stesting.Action) (bool, runtime.Object, error) {
-		return true, &knservingv1alpha1.Service{
+		return true, &knservingv1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testName,
 			},
-			Status: knservingv1alpha1.ServiceStatus{
+			Status: knservingv1.ServiceStatus{
 				Status: duckv1.Status{
 					ObservedGeneration: 1,
 					Conditions: duckv1.Conditions{
@@ -155,11 +155,11 @@ func TestDeployKnativeService(t *testing.T) {
 			monkey.PatchInstanceMethod(
 				reflect.TypeOf(svcConf),
 				"BuildKnativeServiceConfig",
-				func(*KnativeService) *knservingv1alpha1.Service {
+				func(*KnativeService) *knservingv1.Service {
 					return testKnSvc
 				})
 			monkey.Patch(knServiceSemanticEquals,
-				func(*knservingv1alpha1.Service, *knservingv1alpha1.Service) bool {
+				func(*knservingv1.Service, *knservingv1.Service) bool {
 					// Make method return false always, so that an update will be triggered
 					return false
 				})
@@ -1114,7 +1114,7 @@ func createTestKnController(cs *knservingclientset.Clientset, reactors []reactor
 		cs.PrependReactor(reactor.verb, reactor.resource, reactor.rFunc)
 	}
 	// Create clientset
-	client := cs.ServingV1alpha1()
+	client := cs.ServingV1()
 	// Return test controller with a fake knative serving client
 	return &controller{knServingClient: client}
 }

--- a/api/turing/cluster/knative_service.go
+++ b/api/turing/cluster/knative_service.go
@@ -9,7 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
-	knservingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
 // Default values for Knative related resources
@@ -45,7 +44,7 @@ type KnativeService struct {
 
 // Creates a new config object compatible with the knative serving API, from
 // the given config
-func (cfg *KnativeService) BuildKnativeServiceConfig() *knservingv1alpha1.Service {
+func (cfg *KnativeService) BuildKnativeServiceConfig() *knservingv1.Service {
 	// clone creates a copy of a map object
 	clone := func(l map[string]string) map[string]string {
 		ll := map[string]string{}
@@ -66,7 +65,7 @@ func (cfg *KnativeService) BuildKnativeServiceConfig() *knservingv1alpha1.Servic
 	revisionLabels := clone(cfg.Labels)
 	kserviceSpec := cfg.buildSvcSpec(revisionLabels)
 
-	return &knservingv1alpha1.Service{
+	return &knservingv1.Service{
 		ObjectMeta: *kserviceObjectMeta,
 		Spec:       *kserviceSpec,
 	}
@@ -83,7 +82,7 @@ func (cfg *KnativeService) buildSvcObjectMeta(labels map[string]string) *metav1.
 
 func (cfg *KnativeService) buildSvcSpec(
 	labels map[string]string,
-) *knservingv1alpha1.ServiceSpec {
+) *knservingv1.ServiceSpec {
 	// Set max timeout for responding to requests
 	timeout := int64(knativeSvcDefaults.RequestTimeoutSeconds)
 
@@ -120,25 +119,20 @@ func (cfg *KnativeService) buildSvcSpec(
 		container.ReadinessProbe = cfg.buildContainerProbe(readinessProbeType, int(cfg.ProbePort))
 	}
 
-	// Create the Knative service spec
-	revSpec := knservingv1.RevisionSpec{
-		TimeoutSeconds: &timeout,
-		PodSpec: corev1.PodSpec{
-			Containers: []corev1.Container{container},
-			Volumes:    cfg.Volumes,
-		},
-	}
-
-	return &knservingv1alpha1.ServiceSpec{
-		ConfigurationSpec: knservingv1alpha1.ConfigurationSpec{
-			Template: &knservingv1alpha1.RevisionTemplateSpec{
+	return &knservingv1.ServiceSpec{
+		ConfigurationSpec: knservingv1.ConfigurationSpec{
+			Template: knservingv1.RevisionTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        revisionName,
 					Labels:      labels,
 					Annotations: annotations,
 				},
-				Spec: knservingv1alpha1.RevisionSpec{
-					RevisionSpec: revSpec,
+				Spec: knservingv1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{container},
+						Volumes:    cfg.Volumes,
+					},
+					TimeoutSeconds: &timeout,
 				},
 			},
 		},

--- a/api/turing/cluster/knative_service_test.go
+++ b/api/turing/cluster/knative_service_test.go
@@ -14,7 +14,6 @@ import (
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
-	knservingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
 // Define a valid Service configuration for tests
@@ -166,7 +165,7 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 		},
 		Volumes: testValidKnSvc.Volumes,
 	}
-	expected := &knservingv1alpha1.Service{
+	expected := &knservingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-svc",
 			Namespace: "test-namespace",
@@ -175,9 +174,9 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 				"serving.knative.dev/visibility": "cluster-local",
 			},
 		},
-		Spec: knservingv1alpha1.ServiceSpec{
-			ConfigurationSpec: knservingv1alpha1.ConfigurationSpec{
-				Template: &knservingv1alpha1.RevisionTemplateSpec{
+		Spec: knservingv1.ServiceSpec{
+			ConfigurationSpec: knservingv1.ConfigurationSpec{
+				Template: knservingv1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-svc-0",
 						Labels: map[string]string{
@@ -185,11 +184,9 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 						},
 						Annotations: annotations,
 					},
-					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: knservingv1.RevisionSpec{
-							TimeoutSeconds: &timeout,
-							PodSpec:        podSpec,
-						},
+					Spec:       knservingv1.RevisionSpec{
+						PodSpec:        podSpec,
+						TimeoutSeconds: &timeout,
 					},
 				},
 			},


### PR DESCRIPTION
Latest stable version of Knative v0.19 no longer serves apiVersions `v1alpha1` and `v1beta1`.
This PR allows Turing to work with Knative from v0.13 to to least v0.21
https://knative.dev/community/contributing/mechanics/release-versioning-principles/#knative-serving-version-table