### PR TITLE
Get additional info on deployment failures

### DIFF
--- a/api/turing/cluster/controller.go
+++ b/api/turing/cluster/controller.go
@@ -20,7 +20,7 @@ import (
 
 	rest "k8s.io/client-go/rest"
 
-	knativeapis "knative.dev/pkg/apis"
+	knapis "knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
 	knservingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 	knservingclientset "knative.dev/serving/pkg/client/clientset/versioned"
@@ -491,13 +491,13 @@ func (c *controller) waitKnativeServiceReady(
 		case <-ctx.Done():
 			terminationMessage := c.getKnativePodTerminationMessage(svcName, namespace)
 			if terminationMessage == "" {
-				// Pod was not created (as with invalid image names), get most recent status message
-				// from the knative service
+				// Pod was not created (as with invalid image names), get status message from the knative service.
+				// We expect a condition of type ConfigurationsReady that is not met (IsFalse).
 				svc, err := services.Get(svcName, metav1.GetOptions{})
 				if err != nil {
 					terminationMessage = err.Error()
 				} else {
-					failedCondition := svc.Status.GetCondition(knativeapis.ConditionType("ConfigurationsReady"))
+					failedCondition := svc.Status.GetCondition(knapis.ConditionType("ConfigurationsReady"))
 					if failedCondition != nil && failedCondition.IsFalse() {
 						terminationMessage = failedCondition.GetMessage()
 					} else {

--- a/api/turing/cluster/controller.go
+++ b/api/turing/cluster/controller.go
@@ -20,6 +20,7 @@ import (
 
 	rest "k8s.io/client-go/rest"
 
+	knativeapis "knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
 	knservingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 	knservingclientset "knative.dev/serving/pkg/client/clientset/versioned"
@@ -489,6 +490,21 @@ func (c *controller) waitKnativeServiceReady(
 		select {
 		case <-ctx.Done():
 			terminationMessage := c.getKnativePodTerminationMessage(svcName, namespace)
+			if terminationMessage == "" {
+				// Pod was not created (as with invalid image names), get most recent status message
+				// from the knative service
+				svc, err := services.Get(svcName, metav1.GetOptions{})
+				if err != nil {
+					terminationMessage = err.Error()
+				} else {
+					failedCondition := svc.Status.GetCondition(knativeapis.ConditionType("ConfigurationsReady"))
+					if failedCondition != nil && failedCondition.IsFalse() {
+						terminationMessage = failedCondition.GetMessage()
+					} else {
+						terminationMessage = "cause unknown"
+					}
+				}
+			}
 			return fmt.Errorf("timeout waiting for service %s to be ready: %s", svcName, terminationMessage)
 		case <-ticker.C:
 			svc, err := services.Get(svcName, metav1.GetOptions{})

--- a/api/turing/cluster/controller_test.go
+++ b/api/turing/cluster/controller_test.go
@@ -1153,6 +1153,31 @@ func TestGetKnativePodTerminationMessage(t *testing.T) {
 	assert.Equal(t, "Test Termination Message", msg)
 }
 
+func TestGetKnServiceStatusSummary(t *testing.T) {
+	svc := &knservingv1alpha1.Service{
+		Status: knservingv1alpha1.ServiceStatus{
+			Status: duckv1.Status{
+				ObservedGeneration: 1,
+				Conditions: duckv1.Conditions{
+					apis.Condition{
+						Type:   apis.ConditionReady,
+						Status: corev1.ConditionTrue,
+					},
+					apis.Condition{
+						Type:    apis.ConditionSucceeded,
+						Status:  corev1.ConditionFalse,
+						Message: "Test Message",
+					},
+				},
+			},
+		},
+	}
+
+	expectedSummary := "Type: Ready, Status: true. \nType: Succeeded, Status: false. Test Message"
+	summary := getKnServiceStatusMessages(svc)
+	assert.Equal(t, expectedSummary, summary)
+}
+
 func createTestKnController(cs *knservingclientset.Clientset, reactors []reactor) *controller {
 	// Add reactors
 	for _, reactor := range reactors {

--- a/ui/src/components/expandable_container/ExpandableContainer.js
+++ b/ui/src/components/expandable_container/ExpandableContainer.js
@@ -1,11 +1,5 @@
 import React, { Fragment, useRef } from "react";
-import {
-  EuiButton,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiLink,
-  EuiSpacer
-} from "@elastic/eui";
+import { EuiButton, EuiFlexItem, EuiLink, EuiSpacer } from "@elastic/eui";
 import classNames from "classnames";
 import { useToggle } from "@gojek/mlp-ui";
 
@@ -27,21 +21,19 @@ export const ExpandableContainer = ({
       className={classNames("expandableContainer", {
         "expandableContainer-isOpen": isExpanded
       })}>
-      <EuiFlexGroup direction="row" gutterSize="xs" alignItems="left">
-        <EuiFlexItem grow={true} className="euiFlexItem--childFlexPanel">
-          <div
-            className={classNames("expandableContainer__childWrapper", {
-              scrollableContainer: isScrollable
-            })}
-            style={{
-              height: isExpanded
-                ? contentHeight
-                : Math.min(contentHeight, maxHeight)
-            }}>
-            <div ref={contentRef}>{children}</div>
-          </div>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFlexItem grow={true} className="euiFlexItem--childFlexPanel">
+        <div
+          className={classNames("expandableContainer__childWrapper", {
+            scrollableContainer: isScrollable
+          })}
+          style={{
+            height: isExpanded
+              ? contentHeight
+              : Math.min(contentHeight, maxHeight)
+          }}>
+          <div ref={contentRef}>{children}</div>
+        </div>
+      </EuiFlexItem>
 
       {contentHeight > maxHeight && (
         <Fragment>

--- a/ui/src/components/expandable_container/ExpandableContainer.js
+++ b/ui/src/components/expandable_container/ExpandableContainer.js
@@ -1,9 +1,9 @@
 import React, { Fragment, useRef } from "react";
 import {
   EuiButton,
-  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiSpacer
 } from "@elastic/eui";
 import classNames from "classnames";
@@ -14,7 +14,8 @@ import useDimension from "../../hooks/useDimension";
 
 export const ExpandableContainer = ({
   maxHeight = 300,
-  buttonSize = "l",
+  isScrollable = true,
+  toggleKind = "button", // "button" | "text"
   children
 }) => {
   const contentRef = useRef();
@@ -29,7 +30,9 @@ export const ExpandableContainer = ({
       <EuiFlexGroup direction="row" gutterSize="xs" alignItems="left">
         <EuiFlexItem grow={true} className="euiFlexItem--childFlexPanel">
           <div
-            className="expandableContainer__childWrapper"
+            className={classNames("expandableContainer__childWrapper", {
+              scrollableContainer: isScrollable
+            })}
             style={{
               height: isExpanded
                 ? contentHeight
@@ -38,28 +41,24 @@ export const ExpandableContainer = ({
             <div ref={contentRef}>{children}</div>
           </div>
         </EuiFlexItem>
-
-        {contentHeight > maxHeight && buttonSize === "s" && (
-          <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              onClick={toggle}
-              iconType={`arrow${isExpanded ? "Up" : "Right"}`}
-              aria-label="Next"
-            />
-          </EuiFlexItem>
-        )}
       </EuiFlexGroup>
 
-      {contentHeight > maxHeight && buttonSize === "l" && (
+      {contentHeight > maxHeight && (
         <Fragment>
           <EuiSpacer size="s" />
           <div className="expandableContainer__triggerWrapper">
-            <EuiButton
-              fullWidth
-              onClick={toggle}
-              iconType={`arrow${isExpanded ? "Up" : "Right"}`}>
-              {isExpanded ? "Collapse" : "Expand"}
-            </EuiButton>
+            {toggleKind === "button" ? (
+              <EuiButton
+                fullWidth
+                onClick={toggle}
+                iconType={`arrow${isExpanded ? "Up" : "Right"}`}>
+                {isExpanded ? "Collapse" : "Expand"}
+              </EuiButton>
+            ) : (
+              <EuiLink type="button" onClick={toggle}>
+                {isExpanded ? "Show less" : "Show more"}
+              </EuiLink>
+            )}
           </div>
         </Fragment>
       )}

--- a/ui/src/components/expandable_container/ExpandableContainer.js
+++ b/ui/src/components/expandable_container/ExpandableContainer.js
@@ -1,12 +1,22 @@
 import React, { Fragment, useRef } from "react";
-import { EuiButton, EuiSpacer } from "@elastic/eui";
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer
+} from "@elastic/eui";
 import classNames from "classnames";
 import { useToggle } from "@gojek/mlp-ui";
 
 import "./ExpandableDescriptionList.scss";
 import useDimension from "../../hooks/useDimension";
 
-export const ExpandableContainer = ({ maxHeight = 300, children }) => {
+export const ExpandableContainer = ({
+  maxHeight = 300,
+  buttonSize = "l",
+  children
+}) => {
   const contentRef = useRef();
   const [isExpanded, toggle] = useToggle();
   const { height: contentHeight } = useDimension(contentRef);
@@ -16,16 +26,31 @@ export const ExpandableContainer = ({ maxHeight = 300, children }) => {
       className={classNames("expandableContainer", {
         "expandableContainer-isOpen": isExpanded
       })}>
-      <div
-        className="expandableContainer__childWrapper"
-        style={{
-          height: isExpanded
-            ? contentHeight
-            : Math.min(contentHeight, maxHeight)
-        }}>
-        <div ref={contentRef}>{children}</div>
-      </div>
-      {contentHeight > maxHeight && (
+      <EuiFlexGroup direction="row" gutterSize="xs" alignItems="left">
+        <EuiFlexItem grow={true} className="euiFlexItem--childFlexPanel">
+          <div
+            className="expandableContainer__childWrapper"
+            style={{
+              height: isExpanded
+                ? contentHeight
+                : Math.min(contentHeight, maxHeight)
+            }}>
+            <div ref={contentRef}>{children}</div>
+          </div>
+        </EuiFlexItem>
+
+        {contentHeight > maxHeight && buttonSize === "s" && (
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              onClick={toggle}
+              iconType={`arrow${isExpanded ? "Up" : "Right"}`}
+              aria-label="Next"
+            />
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+
+      {contentHeight > maxHeight && buttonSize === "l" && (
         <Fragment>
           <EuiSpacer size="s" />
           <div className="expandableContainer__triggerWrapper">

--- a/ui/src/components/expandable_container/ExpandableDescriptionList.scss
+++ b/ui/src/components/expandable_container/ExpandableDescriptionList.scss
@@ -2,7 +2,7 @@
 
 .expandableContainer__childWrapper {
   height: 0;
-  overflow-y: auto;
+  overflow: hidden;
   transform: translatez(0);
   transition: height $euiAnimSpeedNormal $euiAnimSlightResistance;
 }

--- a/ui/src/components/expandable_container/ExpandableDescriptionList.scss
+++ b/ui/src/components/expandable_container/ExpandableDescriptionList.scss
@@ -1,10 +1,19 @@
 @import "~@elastic/eui/src/global_styling/variables/animations";
 
-.expandableContainer__childWrapper {
-  height: 0;
+@mixin expandable-container-closed {
+  margin: 0;
+  padding: 0;
+  list-style: none;
   overflow: hidden;
-  transform: translatez(0);
-  transition: height $euiAnimSpeedNormal $euiAnimSlightResistance;
+}
+
+.expandableContainer__childWrapper {
+  @include expandable-container-closed;
+}
+
+.expandableContainer__childWrapper.scrollableContainer {
+  @include expandable-container-closed;
+  overflow-y: auto;
 }
 
 .expandableContainer.expandableContainer-isOpen {

--- a/ui/src/router/activity_log/events_list/EventsList.js
+++ b/ui/src/router/activity_log/events_list/EventsList.js
@@ -4,6 +4,7 @@ import { DateFromNow } from "@gojek/mlp-ui";
 import { Status } from "../../../services/status/Status";
 import PulseLoader from "react-spinners/PulseLoader";
 import { ExpandableContainer } from "../../../components/expandable_container/ExpandableContainer";
+import "./EventsList.scss";
 
 const infoColor = "#abe095";
 
@@ -32,7 +33,7 @@ export const EventsList = ({ events, status }) => {
           type="update"
           timestamp={<DateFromNow date={event.created_at} size={"s"} />}>
           <ExpandableContainer maxHeight={43} buttonSize="s">
-            {event.message}
+            <span className="activityLogEvent">{event.message}</span>
           </ExpandableContainer>
         </EuiComment>
       ))}

--- a/ui/src/router/activity_log/events_list/EventsList.js
+++ b/ui/src/router/activity_log/events_list/EventsList.js
@@ -3,6 +3,7 @@ import { EuiBadge, EuiComment } from "@elastic/eui";
 import { DateFromNow } from "@gojek/mlp-ui";
 import { Status } from "../../../services/status/Status";
 import PulseLoader from "react-spinners/PulseLoader";
+import { ExpandableContainer } from "../../../components/expandable_container/ExpandableContainer";
 
 const infoColor = "#abe095";
 
@@ -30,7 +31,9 @@ export const EventsList = ({ events, status }) => {
           timelineIcon={timelineIcon(event)}
           type="update"
           timestamp={<DateFromNow date={event.created_at} size={"s"} />}>
-          {event.message}
+          <ExpandableContainer maxHeight={43} buttonSize="s">
+            {event.message}
+          </ExpandableContainer>
         </EuiComment>
       ))}
       {status === Status.PENDING && (

--- a/ui/src/router/activity_log/events_list/EventsList.js
+++ b/ui/src/router/activity_log/events_list/EventsList.js
@@ -32,7 +32,10 @@ export const EventsList = ({ events, status }) => {
           timelineIcon={timelineIcon(event)}
           type="update"
           timestamp={<DateFromNow date={event.created_at} size={"s"} />}>
-          <ExpandableContainer maxHeight={43} buttonSize="s">
+          <ExpandableContainer
+            maxHeight={43}
+            toggleKind="text"
+            isScrollable={false}>
             <span className="activityLogEvent">{event.message}</span>
           </ExpandableContainer>
         </EuiComment>

--- a/ui/src/router/activity_log/events_list/EventsList.scss
+++ b/ui/src/router/activity_log/events_list/EventsList.scss
@@ -1,0 +1,3 @@
+.activityLogEvent {
+  white-space: pre-wrap;
+}

--- a/ui/src/router/components/configuration/components/section.scss
+++ b/ui/src/router/components/configuration/components/section.scss
@@ -4,7 +4,7 @@
 // its parent container which can break the layout. To prevent this, the min-width attribute
 // is expected to be set to a fixed value.
 // Ref: https://css-tricks.com/flexbox-truncated-text/
-.euiFlexItem--childFlexPanel {
+.euiFlexItem.euiFlexItem--childFlexPanel {
   min-width: 0;
 }
 

--- a/ui/src/router/components/configuration/components/section.scss
+++ b/ui/src/router/components/configuration/components/section.scss
@@ -4,7 +4,7 @@
 // its parent container which can break the layout. To prevent this, the min-width attribute
 // is expected to be set to a fixed value.
 // Ref: https://css-tricks.com/flexbox-truncated-text/
-.euiFlexItem.euiFlexItem--childFlexPanel {
+.euiFlexItem--childFlexPanel {
   min-width: 0;
 }
 
@@ -29,4 +29,8 @@
 
 .euiFlexItem.euiFlexItem--smallPanel {
   min-width: 265px;
+}
+
+.euiFlexItem.euiFlexItem--mediumPanel {
+  min-width: 350px;
 }

--- a/ui/src/router/history/HistoryView.js
+++ b/ui/src/router/history/HistoryView.js
@@ -6,11 +6,11 @@ import { ListRouterVersionsView } from "../versions/list/ListRouterVersionsView"
 export const HistoryView = ({ router, ...props }) => {
   return (
     <EuiFlexGroup direction="row">
-      <EuiFlexItem grow={5}>
+      <EuiFlexItem grow={1} className="euiFlexItem--mediumPanel">
         <ListRouterVersionsView router={router} {...props} />
       </EuiFlexItem>
 
-      <EuiFlexItem grow={3}>
+      <EuiFlexItem grow={1} className="euiFlexItem--mediumPanel">
         <RouterActivityLogView router={router} {...props} />
       </EuiFlexItem>
     </EuiFlexGroup>


### PR DESCRIPTION
This PR implements the API and UI changes for storing additional info on deployment failures in the DB and displaying them as a part of the `Activity Log` panel in the Turing UI.

### API

When a Knative service fails to deploy within the configured timeout, we attempt to get one of the following logs from the Kubernetes resources, before purging them:
* `user-container` termination message - When a container fails to become ready and the pod repeatedly restarts, the termination message holds the relevant logs ([ref](https://github.com/knative/serving/blob/master/pkg/reconciler/revision/resources/deploy.go#L151))
* Knative service status condition - In cases where the pod was never created (such as bad image name for the user-container), the Knative service's statuses may contain some useful info. So, we retrieve all the status transitions from the service.

These changes are implemented in `api/turing/cluster/controller.go`.

### UI

Since container termination logs can be long (up to 2048 characters), the Activity Log panel has been modified to allow for collapsing the logs. By default, only the first 3 lines are visible and the rest can be seen by expanding the log. To achieve this, the message is now being wrapped into an `ExpandableContainer`.
* `ui/src/components/expandable_container/ExpandableContainer.js` - Add properties `isScrollable` (decides whether the content is scrollable and a scrollbar should be added) and `toggleKind` (either "button" or "text", which will use `EuiButton` and `EuiLink`, respectively).

**isScrollable=true, toggleKind="button" (default)**
![Screenshot 2020-12-07 at 3 56 41 PM](https://user-images.githubusercontent.com/23465343/101324732-a988b480-38a5-11eb-94fb-421d4cb87dd3.png)

**isScrollable=false toggleKind="text" (event item collapsed)**
![Screenshot 2020-12-07 at 3 57 23 PM](https://user-images.githubusercontent.com/23465343/101324748-af7e9580-38a5-11eb-8a67-fa87212830b5.png)

**isScrollable=false toggleKind="text" (event item expanded)**
![Screenshot 2020-12-07 at 3 57 38 PM](https://user-images.githubusercontent.com/23465343/101324784-b9a09400-38a5-11eb-941d-889c968fd187.png)

* `ui/src/router/activity_log/events_list/EventsList.js` - Wrap event message into an `ExpandableContainer`
* Styling changes so that the Version History and Activity Log panels are of equal width.
 