### PR TITLE
Add Serialization property to Kafka Config in Turing API

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1095,12 +1095,18 @@ definitions:
     required:
     - brokers
     - topic
+    - serialization
     properties:
       brokers:
         type: "string"
         description: Comma-separated list of host and port pairs that are the addresses of the Kafka brokers.
       topic:
         type: "string"
+      serialization:
+        type: "string"
+        enum:
+        - "json"
+        - "protobuf"
 
   Alert:
     type: "object"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1095,14 +1095,14 @@ definitions:
     required:
     - brokers
     - topic
-    - serialization
+    - serialization_format
     properties:
       brokers:
         type: "string"
         description: Comma-separated list of host and port pairs that are the addresses of the Kafka brokers.
       topic:
         type: "string"
-      serialization:
+      serialization_format:
         type: "string"
         enum:
         - "json"

--- a/api/turing/api/request/request.go
+++ b/api/turing/api/request/request.go
@@ -63,8 +63,9 @@ type BigQueryConfig struct {
 
 // KafkaConfig defines the configs for logging to Kafka
 type KafkaConfig struct {
-	Brokers string `json:"brokers"`
-	Topic   string `json:"topic"`
+	Brokers       string                     `json:"brokers"`
+	Topic         string                     `json:"topic"`
+	Serialization models.SerializationFormat `json:"serialization"`
 }
 
 // EnricherEnsemblerConfig defines the configs for the enricher / ensembler,
@@ -164,8 +165,9 @@ func (r CreateOrUpdateRouterRequest) BuildRouterVersion(
 		}
 	case models.KafkaLogger:
 		rv.LogConfig.KafkaConfig = &models.KafkaConfig{
-			Brokers: r.Config.LogConfig.KafkaConfig.Brokers,
-			Topic:   r.Config.LogConfig.KafkaConfig.Topic,
+			Brokers:       r.Config.LogConfig.KafkaConfig.Brokers,
+			Topic:         r.Config.LogConfig.KafkaConfig.Topic,
+			Serialization: r.Config.LogConfig.KafkaConfig.Serialization,
 		}
 	}
 	if rv.ExperimentEngine.Type != models.ExperimentEngineTypeNop {

--- a/api/turing/api/request/request.go
+++ b/api/turing/api/request/request.go
@@ -63,9 +63,9 @@ type BigQueryConfig struct {
 
 // KafkaConfig defines the configs for logging to Kafka
 type KafkaConfig struct {
-	Brokers       string                     `json:"brokers"`
-	Topic         string                     `json:"topic"`
-	Serialization models.SerializationFormat `json:"serialization"`
+	Brokers             string                     `json:"brokers"`
+	Topic               string                     `json:"topic"`
+	SerializationFormat models.SerializationFormat `json:"serialization_format"`
 }
 
 // EnricherEnsemblerConfig defines the configs for the enricher / ensembler,
@@ -165,9 +165,9 @@ func (r CreateOrUpdateRouterRequest) BuildRouterVersion(
 		}
 	case models.KafkaLogger:
 		rv.LogConfig.KafkaConfig = &models.KafkaConfig{
-			Brokers:       r.Config.LogConfig.KafkaConfig.Brokers,
-			Topic:         r.Config.LogConfig.KafkaConfig.Topic,
-			Serialization: r.Config.LogConfig.KafkaConfig.Serialization,
+			Brokers:             r.Config.LogConfig.KafkaConfig.Brokers,
+			Topic:               r.Config.LogConfig.KafkaConfig.Topic,
+			SerializationFormat: r.Config.LogConfig.KafkaConfig.SerializationFormat,
 		}
 	}
 	if rv.ExperimentEngine.Type != models.ExperimentEngineTypeNop {

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -47,7 +47,7 @@ const (
 	envFluentdTag                   = "APP_FLUENTD_TAG"
 	envKafkaBrokers                 = "APP_KAFKA_BROKERS"
 	envKafkaTopic                   = "APP_KAFKA_TOPIC"
-	envKafkaSerialization           = "APP_KAFKA_SERIALIZATION"
+	envKafkaSerializationFormat     = "APP_KAFKA_SERIALIZATION_FORMAT"
 	envRouterConfigFile             = "ROUTER_CONFIG_FILE"
 	envGoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
 )
@@ -268,7 +268,7 @@ func (sb *clusterSvcBuilder) buildRouterEnvs(
 		envs = append(envs, []corev1.EnvVar{
 			{Name: envKafkaBrokers, Value: logConfig.KafkaConfig.Brokers},
 			{Name: envKafkaTopic, Value: logConfig.KafkaConfig.Topic},
-			{Name: envKafkaSerialization, Value: string(logConfig.KafkaConfig.Serialization)},
+			{Name: envKafkaSerializationFormat, Value: string(logConfig.KafkaConfig.SerializationFormat)},
 		}...)
 	}
 

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -47,6 +47,7 @@ const (
 	envFluentdTag                   = "APP_FLUENTD_TAG"
 	envKafkaBrokers                 = "APP_KAFKA_BROKERS"
 	envKafkaTopic                   = "APP_KAFKA_TOPIC"
+	envKafkaSerialization           = "APP_KAFKA_SERIALIZATION"
 	envRouterConfigFile             = "ROUTER_CONFIG_FILE"
 	envGoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
 )
@@ -267,6 +268,7 @@ func (sb *clusterSvcBuilder) buildRouterEnvs(
 		envs = append(envs, []corev1.EnvVar{
 			{Name: envKafkaBrokers, Value: logConfig.KafkaConfig.Brokers},
 			{Name: envKafkaTopic, Value: logConfig.KafkaConfig.Topic},
+			{Name: envKafkaSerialization, Value: string(logConfig.KafkaConfig.Serialization)},
 		}...)
 	}
 

--- a/api/turing/models/log_config.go
+++ b/api/turing/models/log_config.go
@@ -50,8 +50,8 @@ type KafkaConfig struct {
 	Brokers string `json:"brokers"`
 	// Topic to write logs to
 	Topic string `json:"topic"`
-	// Serialization used for the messages
-	Serialization SerializationFormat `json:"serialization"`
+	// Serialization Format used for the messages
+	SerializationFormat SerializationFormat `json:"serialization_format"`
 }
 
 // LogConfig contains all log configuration necessary for a deployment

--- a/api/turing/models/log_config.go
+++ b/api/turing/models/log_config.go
@@ -23,7 +23,17 @@ const (
 	NopLogger ResultLogger = "nop"
 )
 
-// BigQueryConfig contains the configuration to log results to  BigQuery.
+// SerializationFormat is the type used to capture the supported message serialization formats
+type SerializationFormat string
+
+const (
+	// JSONSerializationFormat formats the message as json, for logging
+	JSONSerializationFormat SerializationFormat = "json"
+	// ProtobufSerializationFormat formats the message using protobuf, for logging
+	ProtobufSerializationFormat SerializationFormat = "protobuf"
+)
+
+// BigQueryConfig contains the configuration to log results to BigQuery.
 type BigQueryConfig struct {
 	// BigQuery table to write to, as a fully qualified BQ Table string.
 	// e.g. project.dataset.table
@@ -34,11 +44,14 @@ type BigQueryConfig struct {
 	BatchLoad bool `json:"batch_load"`
 }
 
+// KafkaConfig contains the configuration to log results to Kafka.
 type KafkaConfig struct {
 	// List of brokers for the kafka to write logs to
 	Brokers string `json:"brokers"`
 	// Topic to write logs to
 	Topic string `json:"topic"`
+	// Serialization used for the messages
+	Serialization SerializationFormat `json:"serialization"`
 }
 
 // LogConfig contains all log configuration necessary for a deployment

--- a/api/turing/models/log_config_test.go
+++ b/api/turing/models/log_config_test.go
@@ -56,9 +56,9 @@ func TestLogConfigValue(t *testing.T) {
 				LogLevel:         routercfg.WarnLevel,
 				ResultLoggerType: KafkaLogger,
 				KafkaConfig: &KafkaConfig{
-					Brokers:       "test-brokers",
-					Topic:         "test-topic",
-					Serialization: "test-serialization",
+					Brokers:             "test-brokers",
+					Topic:               "test-topic",
+					SerializationFormat: "test-serialization",
 				},
 			},
 			expected: string(`{
@@ -70,7 +70,7 @@ func TestLogConfigValue(t *testing.T) {
 				"kafka_config": {
 					"brokers": "test-brokers",
 					"topic": "test-topic",
-					"serialization": "test-serialization"
+					"serialization_format": "test-serialization"
 				}
 			}`),
 		},

--- a/api/turing/models/log_config_test.go
+++ b/api/turing/models/log_config_test.go
@@ -56,8 +56,9 @@ func TestLogConfigValue(t *testing.T) {
 				LogLevel:         routercfg.WarnLevel,
 				ResultLoggerType: KafkaLogger,
 				KafkaConfig: &KafkaConfig{
-					Brokers: "test-brokers",
-					Topic:   "test-topic",
+					Brokers:       "test-brokers",
+					Topic:         "test-topic",
+					Serialization: "test-serialization",
 				},
 			},
 			expected: string(`{
@@ -68,7 +69,8 @@ func TestLogConfigValue(t *testing.T) {
 				"result_logger_type": "kafka",
 				"kafka_config": {
 					"brokers": "test-brokers",
-					"topic": "test-topic"
+					"topic": "test-topic",
+					"serialization": "test-serialization"
 				}
 			}`),
 		},

--- a/api/turing/validation/validator.go
+++ b/api/turing/validation/validator.go
@@ -80,7 +80,7 @@ func validateLogConfig(sl validator.StructLevel) {
 					"kafka_config", "KafkaConfig", "kafka-config-topic-missing", "")
 			}
 			if kafkaConf.Serialization != models.JSONSerializationFormat &&
-				kafkaConf.Serialization != models.JSONSerializationFormat {
+				kafkaConf.Serialization != models.ProtobufSerializationFormat {
 				sl.ReportError(field.KafkaConfig,
 					"kafka_config", "KafkaConfig", "kafka-serialization-oneOf", string(kafkaConf.Serialization))
 			}

--- a/api/turing/validation/validator.go
+++ b/api/turing/validation/validator.go
@@ -79,10 +79,11 @@ func validateLogConfig(sl validator.StructLevel) {
 				sl.ReportError(field.KafkaConfig,
 					"kafka_config", "KafkaConfig", "kafka-config-topic-missing", "")
 			}
-			if kafkaConf.Serialization != models.JSONSerializationFormat &&
-				kafkaConf.Serialization != models.ProtobufSerializationFormat {
+			if kafkaConf.SerializationFormat != models.JSONSerializationFormat &&
+				kafkaConf.SerializationFormat != models.ProtobufSerializationFormat {
 				sl.ReportError(field.KafkaConfig,
-					"kafka_config", "KafkaConfig", "kafka-serialization-oneOf", string(kafkaConf.Serialization))
+					"kafka_config", "KafkaConfig", "kafka-serialization-format-oneOf",
+					string(kafkaConf.SerializationFormat))
 			}
 		}
 		return

--- a/api/turing/validation/validator.go
+++ b/api/turing/validation/validator.go
@@ -68,16 +68,21 @@ func validateLogConfig(sl validator.StructLevel) {
 	case models.KafkaLogger:
 		kafkaConf := field.KafkaConfig
 		if kafkaConf == nil {
-			sl.ReportError(field.BigQueryConfig,
+			sl.ReportError(field.KafkaConfig,
 				"kafka_config", "KafkaConfig", "kafka-config-missing", "")
 		} else {
 			if len(kafkaConf.Brokers) == 0 {
-				sl.ReportError(field.BigQueryConfig,
+				sl.ReportError(field.KafkaConfig,
 					"kafka_config", "KafkaConfig", "kafka-config-brokers-missing", "")
 			}
 			if len(kafkaConf.Topic) == 0 {
-				sl.ReportError(field.BigQueryConfig,
+				sl.ReportError(field.KafkaConfig,
 					"kafka_config", "KafkaConfig", "kafka-config-topic-missing", "")
+			}
+			if kafkaConf.Serialization != models.JSONSerializationFormat &&
+				kafkaConf.Serialization != models.JSONSerializationFormat {
+				sl.ReportError(field.KafkaConfig,
+					"kafka_config", "KafkaConfig", "kafka-serialization-oneOf", string(kafkaConf.Serialization))
 			}
 		}
 		return

--- a/api/turing/validation/validator_test.go
+++ b/api/turing/validation/validator_test.go
@@ -84,9 +84,9 @@ func TestValidateLogConfig(t *testing.T) {
 			input: request.LogConfig{
 				ResultLoggerType: "kafka",
 				KafkaConfig: &request.KafkaConfig{
-					Brokers:       "broker1,broker2",
-					Topic:         "topic",
-					Serialization: "json",
+					Brokers:             "broker1,broker2",
+					Topic:               "topic",
+					SerializationFormat: "json",
 				},
 			},
 			hasErr: false,
@@ -103,8 +103,8 @@ func TestValidateLogConfig(t *testing.T) {
 			input: request.LogConfig{
 				ResultLoggerType: "kafka",
 				KafkaConfig: &request.KafkaConfig{
-					Topic:         "topic",
-					Serialization: "json",
+					Topic:               "topic",
+					SerializationFormat: "json",
 				},
 			},
 			hasErr: true,
@@ -114,8 +114,8 @@ func TestValidateLogConfig(t *testing.T) {
 			input: request.LogConfig{
 				ResultLoggerType: "kafka",
 				KafkaConfig: &request.KafkaConfig{
-					Brokers:       "broker1,broker2",
-					Serialization: "json",
+					Brokers:             "broker1,broker2",
+					SerializationFormat: "json",
 				},
 			},
 			hasErr: true,
@@ -125,9 +125,9 @@ func TestValidateLogConfig(t *testing.T) {
 			input: request.LogConfig{
 				ResultLoggerType: "kafka",
 				KafkaConfig: &request.KafkaConfig{
-					Brokers:       "broker1,broker2",
-					Topic:         "topic",
-					Serialization: "test",
+					Brokers:             "broker1,broker2",
+					Topic:               "topic",
+					SerializationFormat: "test",
 				},
 			},
 			hasErr: true,

--- a/api/turing/validation/validator_test.go
+++ b/api/turing/validation/validator_test.go
@@ -4,8 +4,9 @@ package validation_test
 
 import (
 	"errors"
-	"github.com/gojek/turing/engines/router"
 	"testing"
+
+	"github.com/gojek/turing/engines/router"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,8 +84,9 @@ func TestValidateLogConfig(t *testing.T) {
 			input: request.LogConfig{
 				ResultLoggerType: "kafka",
 				KafkaConfig: &request.KafkaConfig{
-					Brokers: "broker1,broker2",
-					Topic:   "topic",
+					Brokers:       "broker1,broker2",
+					Topic:         "topic",
+					Serialization: "json",
 				},
 			},
 			hasErr: false,
@@ -101,7 +103,8 @@ func TestValidateLogConfig(t *testing.T) {
 			input: request.LogConfig{
 				ResultLoggerType: "kafka",
 				KafkaConfig: &request.KafkaConfig{
-					Topic: "topic",
+					Topic:         "topic",
+					Serialization: "json",
 				},
 			},
 			hasErr: true,
@@ -111,7 +114,20 @@ func TestValidateLogConfig(t *testing.T) {
 			input: request.LogConfig{
 				ResultLoggerType: "kafka",
 				KafkaConfig: &request.KafkaConfig{
-					Brokers: "broker1,broker2",
+					Brokers:       "broker1,broker2",
+					Serialization: "json",
+				},
+			},
+			hasErr: true,
+		},
+		{
+			name: "kafka_invalid_config_invalid_serialization",
+			input: request.LogConfig{
+				ResultLoggerType: "kafka",
+				KafkaConfig: &request.KafkaConfig{
+					Brokers:       "broker1,broker2",
+					Topic:         "topic",
+					Serialization: "test",
 				},
 			},
 			hasErr: true,


### PR DESCRIPTION
This PR adds the `SerializationFormat` property to the Kafka Config processed by the Turing API, which will allow for setting this value on the Turing Router (implemented in [PR](https://github.com/gojek/turing/pull/31)).

Originally, Kafka result logging was only supported in JSON format. With this change, result logging to Kafka topics can be configured for one of 'json' or 'protobuf' formats.

**Note on DB Migration:**
When these changes are integrated and deployed, the data in the existing Turing database would need to be updated to set `serialization_format: "json"` in the Kafka Config, for the router versions using Kafka as the result logger.