### PR TITLE
UI changes for Kafka Serialization Format selection

### DIFF
--- a/ui/.env.development
+++ b/ui/.env.development
@@ -13,6 +13,9 @@ REACT_APP_PRIVATE_DOCKER_REGISTRIES=
 # Registry to use as default, for display in the UI. If left unset, Docker Hub will be used.
 REACT_APP_DEFAULT_DOCKER_REGISTRY=
 
+# Link to the Turing App User Documentation
 REACT_APP_USER_DOCS_URL=
+# Link to the .proto file used by the Kafka Result Logger when using Protobuf serialization
+REACT_APP_RESULT_LOG_PROTO_URL=
 
 REACT_APP_OAUTH_CLIENT_ID=*** set clientId ***

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -37,7 +37,7 @@ export const appConfig = {
     ? process.env.REACT_APP_PRIVATE_DOCKER_REGISTRIES.split(",")
     : [],
   defaultDockerRegistry:
-      process.env.REACT_APP_DEFAULT_DOCKER_REGISTRY || "docker.io", // User Docker Hub as the default
+    process.env.REACT_APP_DEFAULT_DOCKER_REGISTRY || "docker.io", // User Docker Hub as the default
   scaling: {
     maxAllowedReplica: 10
   }
@@ -46,6 +46,10 @@ export const appConfig = {
 export const sentryConfig = {
   dsn: process.env.REACT_APP_SENTRY_DSN,
   environment: appConfig.environment
+};
+
+export const resultLoggingConfig = {
+  protoUrl: process.env.REACT_APP_RESULT_LOG_PROTO_URL
 };
 
 export const monitoringConfig = {

--- a/ui/src/router/activity_log/events_list/EventsList.scss
+++ b/ui/src/router/activity_log/events_list/EventsList.scss
@@ -1,3 +1,7 @@
 .activityLogEvent {
+  // white-space: pre-wrap renders \n in the text as a new line
   white-space: pre-wrap;
+  // word-break: break-word will prevent the possibility of horizontal scroll
+  // on the text by always breaking when the text overflows
+  word-break: break-word;
 }

--- a/ui/src/router/components/configuration/components/LoggingConfigSection.js
+++ b/ui/src/router/components/configuration/components/LoggingConfigSection.js
@@ -39,7 +39,9 @@ const BigQueryConfigTable = ({
   );
 };
 
-const KafkaConfigTable = ({ kafka_config: { brokers, topic } }) => {
+const KafkaConfigTable = ({
+  kafka_config: { brokers, topic, serialization_format }
+}) => {
   const items = [
     {
       title: "Broker(s)",
@@ -48,6 +50,10 @@ const KafkaConfigTable = ({ kafka_config: { brokers, topic } }) => {
     {
       title: "Topic",
       description: topic
+    },
+    {
+      title: "Serialization Format",
+      description: serialization_format
     }
   ];
 

--- a/ui/src/router/components/form/components/outcome_config/kafka/KafkaConfigPanel.js
+++ b/ui/src/router/components/form/components/outcome_config/kafka/KafkaConfigPanel.js
@@ -4,11 +4,13 @@ import {
   EuiFieldText,
   EuiForm,
   EuiFormRow,
+  EuiLink,
   EuiSpacer,
   EuiSuperSelect
 } from "@elastic/eui";
 import { FormLabelWithToolTip } from "../../../../../../components/form/label_with_tooltip/FormLabelWithToolTip";
 import { useOnChangeHandler } from "../../../../../../components/form/hooks/useOnChangeHandler";
+import { resultLoggingConfig } from "../../../../../../config.js";
 
 const logSerializationFormatOptions = [
   {
@@ -17,7 +19,9 @@ const logSerializationFormatOptions = [
   },
   {
     value: "protobuf",
-    inputDisplay: "Protobuf"
+    inputDisplay: "Protobuf",
+    helpText: "TuringResultLog.proto",
+    helpUrl: resultLoggingConfig.protoUrl
   }
 ];
 
@@ -72,6 +76,8 @@ export const KafkaConfigPanel = ({
           />
         </EuiFormRow>
 
+        <EuiSpacer size="m" />
+
         <EuiFormRow
           fullWidth
           label={
@@ -82,6 +88,19 @@ export const KafkaConfigPanel = ({
           }
           isInvalid={!!errors.serialization_format}
           error={errors.serialization_format}
+          helpText={
+            selectedFormat && !!selectedFormat.helpText ? (
+              !!selectedFormat.helpUrl ? (
+                <EuiLink href={selectedFormat.helpUrl} target="_blank" external>
+                  {selectedFormat.helpText}
+                </EuiLink>
+              ) : (
+                selectedFormat.helpText
+              )
+            ) : (
+              ""
+            )
+          }
           display="row">
           <EuiSuperSelect
             fullWidth

--- a/ui/src/router/components/form/components/outcome_config/kafka/KafkaConfigPanel.js
+++ b/ui/src/router/components/form/components/outcome_config/kafka/KafkaConfigPanel.js
@@ -1,8 +1,25 @@
 import React from "react";
 import { Panel } from "../../Panel";
-import { EuiFieldText, EuiForm, EuiFormRow, EuiSpacer } from "@elastic/eui";
+import {
+  EuiFieldText,
+  EuiForm,
+  EuiFormRow,
+  EuiSpacer,
+  EuiSuperSelect
+} from "@elastic/eui";
 import { FormLabelWithToolTip } from "../../../../../../components/form/label_with_tooltip/FormLabelWithToolTip";
 import { useOnChangeHandler } from "../../../../../../components/form/hooks/useOnChangeHandler";
+
+const logSerializationFormatOptions = [
+  {
+    value: "json",
+    inputDisplay: "JSON"
+  },
+  {
+    value: "protobuf",
+    inputDisplay: "Protobuf"
+  }
+];
 
 export const KafkaConfigPanel = ({
   kafkaConfig,
@@ -10,6 +27,9 @@ export const KafkaConfigPanel = ({
   errors = {}
 }) => {
   const { onChange } = useOnChangeHandler(onChangeHandler);
+  const selectedFormat = logSerializationFormatOptions.find(
+    option => option.value === kafkaConfig.serialization_format
+  );
 
   return (
     <Panel title="Kafka Configuration">
@@ -49,6 +69,28 @@ export const KafkaConfigPanel = ({
             onChange={e => onChange("topic")(e.target.value)}
             isInvalid={!!errors.topic}
             name="kafka-topic"
+          />
+        </EuiFormRow>
+
+        <EuiFormRow
+          fullWidth
+          label={
+            <FormLabelWithToolTip
+              label="Serialization Format *"
+              content="Select the message serialization format to be used when writing to the Kafka topic"
+            />
+          }
+          isInvalid={!!errors.serialization_format}
+          error={errors.serialization_format}
+          display="row">
+          <EuiSuperSelect
+            fullWidth
+            options={logSerializationFormatOptions}
+            valueOfSelected={(selectedFormat || {}).value || ""}
+            onChange={onChange("serialization_format")}
+            isInvalid={!!errors.serialization_format}
+            itemLayoutAlign="top"
+            hasDividers
           />
         </EuiFormRow>
       </EuiForm>

--- a/ui/src/router/components/form/components/outcome_config/kafka/KafkaConfigPanel.js
+++ b/ui/src/router/components/form/components/outcome_config/kafka/KafkaConfigPanel.js
@@ -20,8 +20,13 @@ const logSerializationFormatOptions = [
   {
     value: "protobuf",
     inputDisplay: "Protobuf",
-    helpText: "TuringResultLog.proto",
-    helpUrl: resultLoggingConfig.protoUrl
+    helpText: !!resultLoggingConfig.protoUrl ? (
+      <EuiLink href={resultLoggingConfig.protoUrl} target="_blank" external>
+        TuringResultLog.proto
+      </EuiLink>
+    ) : (
+      ""
+    )
   }
 ];
 
@@ -88,19 +93,7 @@ export const KafkaConfigPanel = ({
           }
           isInvalid={!!errors.serialization_format}
           error={errors.serialization_format}
-          helpText={
-            selectedFormat && !!selectedFormat.helpText ? (
-              !!selectedFormat.helpUrl ? (
-                <EuiLink href={selectedFormat.helpUrl} target="_blank" external>
-                  {selectedFormat.helpText}
-                </EuiLink>
-              ) : (
-                selectedFormat.helpText
-              )
-            ) : (
-              ""
-            )
-          }
+          helpText={(selectedFormat || {}).helpText || ""}
           display="row">
           <EuiSuperSelect
             fullWidth

--- a/ui/src/router/components/form/validation/schema.js
+++ b/ui/src/router/components/form/validation/schema.js
@@ -198,7 +198,11 @@ const kafkaConfigSchema = yup.object().shape({
     .matches(
       kafkaTopicRegex,
       "A valid Kafka topic name may only contain letters, numbers, dot, hyphen or underscore"
-    )
+    ),
+  serialization_format: yup
+    .mixed()
+    .required("Serialzation format should be selected")
+    .oneOf(["json", "protobuf"], "Valid serialzation format should be selected")
 });
 
 export default [

--- a/ui/src/services/router/TuringRouter.js
+++ b/ui/src/services/router/TuringRouter.js
@@ -50,7 +50,7 @@ export class TuringRouter {
         kafka_config: {
           brokers: "",
           topic: "",
-          serialization_format: ""
+          serialization_format: "protobuf"
         }
       }
     };

--- a/ui/src/services/router/TuringRouter.js
+++ b/ui/src/services/router/TuringRouter.js
@@ -49,7 +49,8 @@ export class TuringRouter {
         },
         kafka_config: {
           brokers: "",
-          topic: ""
+          topic: "",
+          serialization_format: ""
         }
       }
     };


### PR DESCRIPTION
This PR adds an option to select the message serialization format, from one of 'JSON' and 'Protobuf', for Kafka Result Logging.

The 2 PRs below added support for Protobuf serialization of Kafka messages:
* https://github.com/gojek/turing/pull/31 (Router)
* https://github.com/gojek/turing/pull/32 (API)

This PR updates the UI with the corresponding changes and is the last of them to complete the Protobuf support for Kafka logger.

### Modifications

* `ui/src/router/components/configuration/components/LoggingConfigSection.js` - Display Serialization Format if Kafka logging has been selected
* `ui/src/router/components/form/components/outcome_config/kafka/KafkaConfigPanel.js` - Add `EuiSuperSelect` to choose the serialization formation
* `ui/src/router/components/form/validation/schema.js` - Define the oneOf validation for the new property
* `ui/src/config.js` - Process `REACT_APP_RESULT_LOG_PROTO_URL`. This will be used in the Edit Router form, to link to the `.proto` file in the Kafka Config panel.

<img width="848" alt="Screenshot 2020-12-08 at 11 21 06 PM" src="https://user-images.githubusercontent.com/23465343/101503996-ad076300-39ad-11eb-9204-7756b0a7882b.png">
