### PR TITLE
Add GitHub Action for Helm chart release

### DIFF
--- a/.github/workflows/helm-chart.yaml
+++ b/.github/workflows/helm-chart.yaml
@@ -1,0 +1,34 @@
+name: helm-chart
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "turing-chart-{{ .Version }}"
+        with:
+          charts_dir: infra

--- a/infra/chart/README.md
+++ b/infra/chart/README.md
@@ -4,12 +4,6 @@
 
 Turing: ML Experimentation System
 
-## Requirements
-
-| Repository | Name | Version |
-|------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 8.9.8 |
-
 ## Values
 
 | Key | Type | Default | Description |
@@ -37,7 +31,7 @@ Turing: ML Experimentation System
 | turing.image.tag | string | `"latest"` | Docker image tag for Turing API |
 | turing.ingress.class | string | `""` | Ingress class annotation to add to this Ingress rule,  useful when there are multiple ingress controllers installed |
 | turing.ingress.enabled | bool | `false` | Enable ingress to provision Ingress resource for external access to Turing API |
-| turing.ingress.host | string | `""` | Set host value to enable name based virtual hosting. This allows routing HTTP traffic to multiple host names at the same IP address. If no host is specified all inbound HTTP traffic through the ingress IP address. https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting |
+| turing.ingress.host | string | `""` | Set host value to enable name based virtual hosting. This allows routing HTTP traffic to multiple host names at the same IP address. If no host is specified, the ingress rule applies to all inbound HTTP traffic through  the IP address specified. https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting |
 | turing.livenessProbe.path | string | `"/v1/internal/live"` | HTTP path for liveness check |
 | turing.readinessProbe.path | string | `"/v1/internal/ready"` | HTTP path for readiness check |
 | turing.resources | object | `{}` | Resources requests and limits for Turing API. This should be set  according to your cluster capacity and service level objectives. Reference: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |

--- a/infra/chart/requirements.lock
+++ b/infra/chart/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 8.9.8
-digest: sha256:25b3253e545c70586b4ecab2ea190528174fcecadaed6f39741de3a28043b335
-generated: "2020-08-27T20:21:52.110474+05:45"

--- a/infra/chart/requirements.yaml
+++ b/infra/chart/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: postgresql
-    repository: "https://charts.bitnami.com/bitnami"
-    version: 8.9.8


### PR DESCRIPTION
Add GitHub action to release Helm chart. Action is based on
https://github.com/helm/chart-releaser-action

On every push to master, if the Helm chart version is updated, a new GitHub release named `turing-chart-VERSION` will be created. The `index.yaml` for the Helm chart repository will also be updated to reflect this new version. The `index.yaml` will be served using GitHub pages. Once merged, this Helm chart repo will be added to https://artifacthub.io (currently the official site for publishing Helm charts)

Example of Turing chart published on staging artifacthub.
https://staging.artifacthub.io/packages/helm/repo1607517787/turing

The requirements.yaml file is removed because currently the postgresql chart dependency is already embedded in this repo so the requirements.yaml file is not required. Having that file will fail the GitHub action to publish the Helm chart. 