### PR TITLE
Add config to set alert playbook URL

### DIFF
--- a/api/turing/api/appcontext.go
+++ b/api/turing/api/appcontext.go
@@ -104,6 +104,7 @@ func NewAppContext(
 		}
 		appContext.AlertService = service.NewGitlabOpsAlertService(db, gitlabClient, cfg.AlertConfig.GitLab.ProjectID,
 			cfg.AlertConfig.GitLab.Branch, cfg.AlertConfig.GitLab.PathPrefix)
+		service.AlertPlaybookURL = cfg.AlertConfig.PlaybookURL
 	}
 
 	// Initialize OpenAPI validation middleware

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -173,8 +173,9 @@ type VaultConfig struct {
 }
 
 type AlertConfig struct {
-	Enabled bool
-	GitLab  *GitlabConfig
+	Enabled     bool
+	GitLab      *GitlabConfig
+	PlaybookURL string // URL that contains documentation on how to resolve triggered alerts
 }
 
 type GitlabConfig struct {

--- a/api/turing/config/example.yaml
+++ b/api/turing/config/example.yaml
@@ -84,6 +84,8 @@ AlertConfig:
     PathPrefix: turing
     ProjectID: "1"
     Token: gitlabtoken
+  # URL that contains documentation on how to resolve triggered alerts
+  PlaybookURL: https://example.com
 
 # MLP API access configuration. Turing uses MLP API to get projects
 # and environments associated with the Turing router: https://github.com/gojek/mlp

--- a/api/turing/models/alert.go
+++ b/api/turing/models/alert.go
@@ -65,7 +65,7 @@ func (alert Alert) Validate() error {
 
 // Group creates an AlertGroup from the Alert specification. An alert group follows the alerting rule format
 // in prometheus: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
-func (alert Alert) Group() schema.AlertGroup {
+func (alert Alert) Group(playbookURL string) schema.AlertGroup {
 	groupName := fmt.Sprintf("%s_%s_%s_%s", alert.Environment, alert.Team, alert.Service, alert.Metric)
 	alerts := make([]schema.Alert, 0)
 
@@ -92,7 +92,7 @@ func (alert Alert) Group() schema.AlertGroup {
 					getAlertUnit(alert.Metric),
 				),
 				"dashboard": "TODO",
-				"playbook":  "TODO",
+				"playbook":  playbookURL,
 			},
 		})
 	}
@@ -120,7 +120,7 @@ func (alert Alert) Group() schema.AlertGroup {
 					getAlertUnit(alert.Metric),
 				),
 				"dashboard": "TODO",
-				"playbook":  "TODO",
+				"playbook":  playbookURL,
 			},
 		})
 	}

--- a/api/turing/models/alert_test.go
+++ b/api/turing/models/alert_test.go
@@ -104,7 +104,7 @@ func TestAlertGroup(t *testing.T) {
 				Annotations: map[string]string{
 					"dashboard":   "TODO",
 					"description": "cpu_util for the past 1m: {{ $value }}%",
-					"playbook":    "TODO",
+					"playbook":    "https://example.com",
 					"summary":     "cpu_util is higher than the threshold: 1%",
 				},
 			},
@@ -125,14 +125,14 @@ func TestAlertGroup(t *testing.T) {
 				Annotations: map[string]string{
 					"dashboard":   "TODO",
 					"description": "cpu_util for the past 1m: {{ $value }}%",
-					"playbook":    "TODO",
+					"playbook":    "https://example.com",
 					"summary":     "cpu_util is higher than the threshold: 1%",
 				},
 			},
 		},
 	}
 
-	assert.Equal(t, expected, alert.Group())
+	assert.Equal(t, expected, alert.Group("https://example.com"))
 }
 
 func TestGetAlertExpr(t *testing.T) {

--- a/api/turing/service/alert_service.go
+++ b/api/turing/service/alert_service.go
@@ -11,6 +11,9 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// AlertPlaybookURL contains URL that documents how to resolve triggered alerts
+var AlertPlaybookURL string
+
 type Metric string
 
 type AlertService interface {
@@ -143,7 +146,7 @@ func (service *gitlabOpsAlertService) createInGitLab(alert models.Alert, authorE
 	alertGroups, err := yaml.Marshal(struct {
 		Groups []interface{} `yaml:"groups"`
 	}{
-		Groups: []interface{}{alert.Group()},
+		Groups: []interface{}{alert.Group(AlertPlaybookURL)},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal AlertGroup into yaml: %s", err)
@@ -175,7 +178,7 @@ func (service *gitlabOpsAlertService) updateInGitLab(alert models.Alert, authorE
 	alertGroups, err := yaml.Marshal(struct {
 		Groups []interface{} `yaml:"groups"`
 	}{
-		Groups: []interface{}{alert.Group()},
+		Groups: []interface{}{alert.Group(AlertPlaybookURL)},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal AlertGroup into yaml: %s", err)

--- a/api/turing/service/alert_service_test.go
+++ b/api/turing/service/alert_service_test.go
@@ -35,7 +35,7 @@ var expectedAlertContent string = strings.Join([]string{
 	`    annotations:`,
 	`      dashboard: TODO`,
 	`      description: 'throughput for the past 5m: {{ $value }}rps'`,
-	`      playbook: TODO`,
+	`      playbook: https://example.com`,
 	`      summary: 'throughput is lower than the threshold: 50rps'`,
 	`  - alert: service_throughput_violation_env`,
 	`    expr: |`,
@@ -51,7 +51,7 @@ var expectedAlertContent string = strings.Join([]string{
 	`    annotations:`,
 	`      dashboard: TODO`,
 	`      description: 'throughput for the past 5m: {{ $value }}rps'`,
-	`      playbook: TODO`,
+	`      playbook: https://example.com`,
 	`      summary: 'throughput is lower than the threshold: 25rps'\n`,
 }, "\\n")
 
@@ -92,8 +92,10 @@ func TestGitlabOpsAlertServiceSave(t *testing.T) {
 		Duration:          "5m",
 	}
 
+	AlertPlaybookURL = "https://example.com"
 	_, err = service.Save(alert, "user@gojek.com")
 	assert.NilError(t, err)
+	AlertPlaybookURL = ""
 
 	err = mockSQL.ExpectationsWereMet()
 	assert.NilError(t, err)
@@ -245,8 +247,10 @@ func TestGitlabOpsAlertServiceUpdate(t *testing.T) {
 		Duration:          "5m",
 	}
 
+	AlertPlaybookURL = "https://example.com"
 	err = service.Update(alert, "user@gojek.com")
 	assert.NilError(t, err)
+	AlertPlaybookURL = ""
 
 	err = mockSQL.ExpectationsWereMet()
 	assert.NilError(t, err)


### PR DESCRIPTION
This playbook URL will be set as one of the annotations in the alert spec, which can then be used to provide extra information to the alert recipient.