### PR TITLE
Fix UI error due to invalid type

### DIFF
--- a/ui/src/components/form/context.js
+++ b/ui/src/components/form/context.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, useMemo } from "react";
 import { set } from "./utils";
 import { StackableFunction } from "./functions/stackable_function";
 import { useOnChangeHandler } from "./hooks/useOnChangeHandler";
@@ -19,12 +19,7 @@ export const FormContextProvider = ({ data: initData, ...props }) => {
     [setData]
   );
 
-  // TODO: The eslint rule below is disabled. Consider refactoring to conform to the rule.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const rootHandler = useCallback(new StackableFunction([], handleChanges), [
-    handleChanges
-  ]);
-
+  const rootHandler = useMemo(() => new StackableFunction([], handleChanges), [handleChanges])
   const { onChangeHandler, onChange } = useOnChangeHandler(rootHandler);
 
   return (

--- a/ui/src/components/form/context.js
+++ b/ui/src/components/form/context.js
@@ -19,7 +19,9 @@ export const FormContextProvider = ({ data: initData, ...props }) => {
     [setData]
   );
 
-  const rootHandler = useCallback(() => new StackableFunction([], handleChanges), [
+  // TODO: The eslint rule below is disabled. Consider refactoring to conform to the rule.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const rootHandler = useCallback(new StackableFunction([], handleChanges), [
     handleChanges
   ]);
 


### PR DESCRIPTION
Pull request https://github.com/gojek/turing/pull/36 updates `react-scripts` package to v4, which enables eslint rule `react-hooks/exhaustive-deps`.

To conform to this rule, this patch is added:

```diff
- const rootHandler = useCallback(new StackableFunction([], handleChanges), [handleChanges]);
+ const rootHandler = useCallback(() => new StackableFunction([], handleChanges), [handleChanges]);
```
But this introduces UI error when editing a router:
![Screenshot from 2020-12-22 11-40-30](https://user-images.githubusercontent.com/5300554/102846300-8c79e700-444a-11eb-871f-97eed459340f.png)

This PR updated the patch to use `useMemo` instead of `useCallback`