### PR TITLE
Prevent caching of index.html when API serves the React App

### DIFF
--- a/api/turing/cmd/main.go
+++ b/api/turing/cmd/main.go
@@ -108,7 +108,7 @@ func main() {
 	mux.Handle("/v1/internal/", http.StripPrefix("/v1/internal", health))
 	mux.Handle("/v1/", http.StripPrefix("/v1", api.NewRouter(appCtx)))
 	// Serve Swagger Spec
-	mux.Handle("/swagger.yaml", web.FileHandler("./swagger.yaml"))
+	mux.Handle("/swagger.yaml", web.FileHandler("./swagger.yaml", false))
 	// Serve UI
 	if cfg.TuringUIConfig.AppDirectory != "" {
 		log.Infof(

--- a/api/turing/web/web.go
+++ b/api/turing/web/web.go
@@ -7,6 +7,9 @@ import (
 
 func FileHandler(path string) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
+		// Ref: https://create-react-app.dev/docs/production-build/#static-file-caching
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		w.Header().Set("Expires", "0") // For proxies
 		http.ServeFile(w, r, path)
 	}
 

--- a/api/turing/web/web.go
+++ b/api/turing/web/web.go
@@ -5,11 +5,13 @@ import (
 	"path"
 )
 
-func FileHandler(path string) http.Handler {
+func FileHandler(path string, disableCaching bool) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		// Ref: https://create-react-app.dev/docs/production-build/#static-file-caching
-		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-		w.Header().Set("Expires", "0") // For proxies
+		if disableCaching == true {
+			// Ref: https://create-react-app.dev/docs/production-build/#static-file-caching
+			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+			w.Header().Set("Expires", "0") // For proxies
+		}
 		http.ServeFile(w, r, path)
 	}
 
@@ -22,7 +24,7 @@ func ServeReactApp(
 	appDir string,
 ) {
 	appDirFs := http.FileServer(http.Dir(appDir))
-	reactEntryHandler := FileHandler(path.Join(appDir, "index.html"))
+	reactEntryHandler := FileHandler(path.Join(appDir, "index.html"), true)
 
 	mux.Handle(
 		homepage+"/",

--- a/api/turing/web/web.go
+++ b/api/turing/web/web.go
@@ -7,7 +7,7 @@ import (
 
 func FileHandler(path string, disableCaching bool) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		if disableCaching == true {
+		if disableCaching {
 			// Ref: https://create-react-app.dev/docs/production-build/#static-file-caching
 			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 			w.Header().Set("Expires", "0") // For proxies

--- a/api/turing/web/web_test.go
+++ b/api/turing/web/web_test.go
@@ -42,6 +42,8 @@ func TestFileHandler(t *testing.T) {
 	resp, httpErr := http.DefaultClient.Get("http://localhost:9999/path")
 	require.NoError(t, httpErr)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "no-cache, no-store, must-revalidate", resp.Header.Get("Cache-Control"))
+	require.Equal(t, "0", resp.Header.Get("Expires"))
 
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	_ = resp.Body.Close()

--- a/api/turing/web/web_test.go
+++ b/api/turing/web/web_test.go
@@ -31,8 +31,8 @@ func TestFileHandler(t *testing.T) {
 	mux := http.NewServeMux()
 
 	filePath := filepath.Join("..", "testdata", "cluster", "servicebuilder", "router_version_basic.json")
-	mux.Handle("/path", web.FileHandler(filePath))
-	mux.Handle("/not-found", web.FileHandler(fmt.Sprintf("%d.file", time.Now().Unix())))
+	mux.Handle("/path", web.FileHandler(filePath, true))
+	mux.Handle("/not-found", web.FileHandler(fmt.Sprintf("%d.file", time.Now().Unix()), false))
 
 	srv := startTestHTTPServer(mux, ":9999")
 	defer func() {


### PR DESCRIPTION
Cache busting in React Apps is typically achieved by the following:
* `build/static/` directory with the CSS, Js and other static files contain a hash of the file contents as the file name suffix. This is handled by `npm run build` for the CRA. ([ref CRA doc](https://create-react-app.dev/docs/production-build))
* `index.html` - this file references the static assets and it is advised that this file is not cached, to prevent serving the older versions of an app ([ref Github Issue](https://github.com/facebook/create-react-app/issues/1910))

For the latter, Chrome usually adds the `max-age=0` header in the request, which, although supposed to trigger revalidation, does not guarantee it. Further, navigations in the same browser sessions, usage of forward/back buttons, etc. may not usually trigger this validation.

![Screenshot 2021-01-05 at 10 43 23 AM](https://user-images.githubusercontent.com/23465343/103609277-72ff9180-4f58-11eb-95d9-569fefd2dbe0.png)

To handle these scenarios, web servers usually set the following cache directives in the response headers:
* must-revalidate - If a cache is fresh, use it and if not, validation MUST be triggered
* no-cache - Page is cacheable but will not be used. Every request triggers a revalidation, even if the cached resource is fresh.
* no-store - Page not cacheable

Per the CRA docs, the `no-cache` directive will suffice in our scenario. But, it is a common (conservative) practice to set a combination of these headers, including `expires=0` ([ref SO answer](https://stackoverflow.com/a/2068407)).

![Screenshot 2021-01-05 at 12 19 22 PM](https://user-images.githubusercontent.com/23465343/103609451-e43f4480-4f58-11eb-8c5f-71847ca4a359.png)

This PR adds the response headers described above to the React App files served by the API.