### PR TITLE
Add data migration script for kafka log config

### DIFF
--- a/api/db-migrations/000007_log_config_kafka_serialization_format.down.sql
+++ b/api/db-migrations/000007_log_config_kafka_serialization_format.down.sql
@@ -1,14 +1,5 @@
 -- Remove 'serialization_format' field in 'kafka_config'
 
 UPDATE router_versions
-SET log_config = (SELECT json_build_object(
-    'log_level', log_config -> 'log_level',
-        'jaeger_enabled', log_config -> 'jaeger_enabled',
-        'result_logger_type', log_config -> 'result_logger_type',
-        'custom_metrics_enabled', log_config -> 'custom_metrics_enabled',
-        'fiber_debug_log_enabled', log_config -> 'fiber_debug_log_enabled',
-        'kafka_config', json_build_object(
-            'topic', log_config -> 'kafka_config' -> 'topic',
-            'brokers', log_config -> 'kafka_config' -> 'brokers')
-))
+SET log_config = (SELECT log_config #- '{kafka_config,serialization_format}')
 WHERE log_config->>'result_logger_type' = 'kafka';

--- a/api/db-migrations/000007_log_config_kafka_serialization_format.down.sql
+++ b/api/db-migrations/000007_log_config_kafka_serialization_format.down.sql
@@ -1,0 +1,14 @@
+-- Remove 'serialization_format' field in 'kafka_config'
+
+UPDATE router_versions
+SET log_config = (SELECT json_build_object(
+    'log_level', log_config -> 'log_level',
+        'jaeger_enabled', log_config -> 'jaeger_enabled',
+        'result_logger_type', log_config -> 'result_logger_type',
+        'custom_metrics_enabled', log_config -> 'custom_metrics_enabled',
+        'fiber_debug_log_enabled', log_config -> 'fiber_debug_log_enabled',
+        'kafka_config', json_build_object(
+            'topic', log_config -> 'kafka_config' -> 'topic',
+            'brokers', log_config -> 'kafka_config' -> 'brokers')
+))
+WHERE log_config->>'result_logger_type' = 'kafka';

--- a/api/db-migrations/000007_log_config_kafka_serialization_format.up.sql
+++ b/api/db-migrations/000007_log_config_kafka_serialization_format.up.sql
@@ -1,0 +1,23 @@
+-- Update log_config field value in router_versions table for 'kafka' logger type
+-- by adding 'serialization_format' in the 'kafka_config' field value. This is 
+-- to support multiple serialization format 'json' / 'protobuf' in newer
+-- version of Turing.
+--
+-- In previous SQL schema, there is no 'serialization_format' field and it is assumed
+-- to always be JSON. Hence, this migration script will set the 'serialization_format'
+-- for all existing rows to 'json'. 
+
+UPDATE router_versions
+SET log_config = (SELECT json_build_object(
+    'log_level', log_config -> 'log_level',
+    'jaeger_enabled', log_config -> 'jaeger_enabled',
+    'result_logger_type', log_config -> 'result_logger_type',
+    'custom_metrics_enabled', log_config -> 'custom_metrics_enabled',
+    'fiber_debug_log_enabled', log_config -> 'fiber_debug_log_enabled',
+    'kafka_config', json_build_object(
+        'serialization_format', 'json',
+        'topic', log_config -> 'kafka_config' -> 'topic',
+        'brokers', log_config -> 'kafka_config' -> 'brokers')
+))
+WHERE log_config->>'result_logger_type' = 'kafka' AND
+      log_config->'kafka_config'->>'serialization_format' IS NULL;

--- a/api/db-migrations/000007_log_config_kafka_serialization_format.up.sql
+++ b/api/db-migrations/000007_log_config_kafka_serialization_format.up.sql
@@ -8,16 +8,8 @@
 -- for all existing rows to 'json'. 
 
 UPDATE router_versions
-SET log_config = (SELECT json_build_object(
-    'log_level', log_config -> 'log_level',
-    'jaeger_enabled', log_config -> 'jaeger_enabled',
-    'result_logger_type', log_config -> 'result_logger_type',
-    'custom_metrics_enabled', log_config -> 'custom_metrics_enabled',
-    'fiber_debug_log_enabled', log_config -> 'fiber_debug_log_enabled',
-    'kafka_config', json_build_object(
-        'serialization_format', 'json',
-        'topic', log_config -> 'kafka_config' -> 'topic',
-        'brokers', log_config -> 'kafka_config' -> 'brokers')
-))
+SET log_config = (
+    SELECT jsonb_set(log_config, '{kafka_config,serialization_format}', '"json"'::jsonb)
+)
 WHERE log_config->>'result_logger_type' = 'kafka' AND
       log_config->'kafka_config'->>'serialization_format' IS NULL;


### PR DESCRIPTION
[Recent update](https://github.com/gojek/turing/pull/31) in Turing router add support for multiple Kafka serialization format: json or protobuf
This requires an update to the existing `log_config` data in router version table.  `kafka_config` needs to have `serialization_format` field. This migration ensures that
