### PR TITLE
Add engine, experiment and treatment labels to experiment Prometheus metrics in router

### DIFF
--- a/engines/experiment/runner/types.go
+++ b/engines/experiment/runner/types.go
@@ -6,8 +6,12 @@ import "context"
 type ContextKey string
 
 const (
-	// ExperimentNameKey represents the key for the name of the experiment, stored in the context
+	// ExperimentEngineKey represents the key for the experiment engine name, stored in the context
+	ExperimentEngineKey ContextKey = "experimentEngineKey"
+	// ExperimentNameKey represents the key for the experiment name, stored in the context
 	ExperimentNameKey ContextKey = "experimentNameKey"
+	// TreatmentNameKey represents the key for the treament name, stored in the context
+	TreatmentNameKey ContextKey = "treatmentNameKey"
 )
 
 // Logger interface defines a minimal set of methods expected to be implemented by

--- a/engines/router/missionctl/experiment/interceptors.go
+++ b/engines/router/missionctl/experiment/interceptors.go
@@ -37,10 +37,10 @@ func (i *MetricsInterceptor) AfterCompletion(
 	err error,
 ) {
 	labels := map[string]string{
-		"status": metrics.GetStatusString(err == nil),
-		"engine": "",
+		"status":     metrics.GetStatusString(err == nil),
+		"engine":     "",
 		"experiment": "",
-		"treatment": "",
+		"treatment":  "",
 	}
 
 	if engine, ok := ctx.Value(runner.ExperimentEngineKey).(string); ok {

--- a/engines/router/missionctl/experiment/interceptors.go
+++ b/engines/router/missionctl/experiment/interceptors.go
@@ -36,15 +36,30 @@ func (i *MetricsInterceptor) AfterCompletion(
 	ctx context.Context,
 	err error,
 ) {
+	labels := map[string]string{
+		"status": metrics.GetStatusString(err == nil),
+		"engine": "",
+		"experiment": "",
+		"treatment": "",
+	}
+
+	if engine, ok := ctx.Value(runner.ExperimentEngineKey).(string); ok {
+		labels["engine"] = engine
+	}
+	if experiment, ok := ctx.Value(runner.ExperimentNameKey).(string); ok {
+		labels["experiment"] = experiment
+	}
+	if treatment, ok := ctx.Value(runner.TreatmentNameKey).(string); ok {
+		labels["treatment"] = treatment
+	}
+
 	// Get start time
 	if startTime, ok := ctx.Value(startTimeKey).(time.Time); ok {
 		// Measure the time taken for the experiment run
 		metrics.Glob().MeasureDurationMsSince(
 			metrics.ExperimentEngineRequestMs,
 			startTime,
-			map[string]string{
-				"status": metrics.GetStatusString(err == nil),
-			},
+			labels,
 		)
 	}
 }

--- a/engines/router/missionctl/instrumentation/metrics/prometheus.go
+++ b/engines/router/missionctl/instrumentation/metrics/prometheus.go
@@ -40,7 +40,7 @@ var histogramMap map[MetricName]*prometheus.HistogramVec = map[MetricName]*prome
 		Help:      "Histogram for the runtime (in milliseconds) of Litmus requests.",
 		Buckets:   requestLatencyBuckets,
 	},
-		[]string{"status"},
+		[]string{"status", "engine", "experiment", "treatment"},
 	),
 	RouteRequestDurationMs: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,


### PR DESCRIPTION
This is so that we can filter / group the experiment metrics by the engine name, experiment name and treatment name for better tracking.