### PR TITLE
[BugFix] Fix version comparison of docker ensemblers

### DIFF
--- a/ui/src/services/version/RouterVersion.js
+++ b/ui/src/services/version/RouterVersion.js
@@ -27,7 +27,8 @@ export class RouterVersion {
               config: {
                 client: {
                   id: this.experiment_engine.config.client.username,
-                  encrypted_passkey: this.experiment_engine.config.client.passkey
+                  encrypted_passkey: this.experiment_engine.config.client
+                    .passkey
                 },
                 experiments: this.experiment_engine.config.experiments,
                 variables: this.experiment_engine.config.variables
@@ -57,12 +58,7 @@ export class RouterVersion {
                 }
               : this.ensembler.type === "docker"
               ? {
-                  image: this.ensembler.image,
-                  endpoint: this.ensembler.endpoint,
-                  port: this.ensembler.port,
-                  env: this.ensembler.env,
-                  service_account: this.ensembler.service_account,
-                  resource_request: this.ensembler.resource_request
+                  docker_config: this.ensembler.docker_config
                 }
               : undefined)
           }


### PR DESCRIPTION
The comparison of docker ensemblers in Version Deff View was working incorrectly, because the wrong schema of `ensembler` JSON object was used in `toPrettyYaml` method. This is fixed now

<img width="1088" alt="Screenshot 2021-01-26 at 10 13 35" src="https://user-images.githubusercontent.com/1886194/105818238-5686d000-5fbf-11eb-99a2-a347dc4d28a4.png">


