### PR TITLE
[BugFix] fix monitoring link when no specific revision is selected

### DIFF
--- a/ui/src/hooks/useMonitoring.js
+++ b/ui/src/hooks/useMonitoring.js
@@ -30,7 +30,7 @@ export const useMonitoring = () => {
   const { project } = useContext(CurrentProjectContext);
 
   const getMonitoringDashboardUrl = useCallback(
-    (envName, routerName, revision="$_all") => {
+    (envName, routerName, revision = "$__all") => {
       const clusterName = getEnvironmentCluster(envName, environments);
       const projectName = !!project ? project.name : undefined;
       return getMonitoringLink(clusterName, projectName, routerName, revision);


### PR DESCRIPTION
The placeholder for "any" revision in the monitoring dashboard should be `$__all`, instead of `$_all`