### PR TITLE
Bump version of Turing's chart

### DIFF
--- a/infra/chart/Chart.yaml
+++ b/infra/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.1.0
+version: 0.1.1


### PR DESCRIPTION
In the [previous MR](https://github.com/gojek/turing/pull/60), the Helm chart of Turing was changed, however the version of it remained the same. This resulted in the [failure](https://github.com/gojek/turing/actions/runs/897393012) of the Github workflow, caused by the fact, that Git tag with the current version already exists in the repo. 

This is an expected behaviour of [chart-releaser-action](https://github.com/helm/chart-releaser-action), because it checks the diff of the chart itself and creates a new Github release whenever the changes are detected. If release with the same chart version already exists, then this translates into an observed failure. Meaning, that Chart's version should always be updated if chart files were changed.