### PR TITLE
Add New Relic integration.

### DIFF
--- a/api/turing/cmd/main.go
+++ b/api/turing/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/cors"
 
 	"github.com/gojek/mlp/pkg/authz/enforcer"
+	"github.com/gojek/mlp/pkg/instrumentation/newrelic"
 	"github.com/gojek/mlp/pkg/instrumentation/sentry"
 	"github.com/gojek/turing/api/turing/api"
 	"github.com/gojek/turing/api/turing/config"
@@ -65,6 +66,12 @@ func main() {
 	}
 	db.LogMode(false)
 	defer db.Close()
+
+	// Initialise NewRelic
+	if err := newrelic.InitNewRelic(cfg.NewRelicConfig); err != nil {
+		log.Errorf("Failed to initialize newrelic: %s", err)
+	}
+	defer newrelic.Shutdown(5 * time.Second)
 
 	// Init auth enforcer, vault client
 	var authEnforcer *enforcer.Enforcer

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	DeployConfig        *DeploymentConfig    `validate:"required"`
 	EnsemblingJobConfig *EnsemblingJobConfig `validate:"required"`
 	RouterDefaults      *RouterDefaults      `validate:"required"`
+	NewRelicConfig      newrelic.Config
 	Sentry              sentry.Config
 	VaultConfig         *VaultConfig `validate:"required"`
 	TuringEncryptionKey string       `validate:"required"`
@@ -73,8 +74,7 @@ type Config struct {
 	//
 	// For example:
 	// { "experiment_engine_a": {"client": "foo"}, "experiment_engine_b": {"apikey": 12} }
-	Experiment     map[string]interface{}
-	NewRelicConfig newrelic.Config
+	Experiment map[string]interface{}
 }
 
 // ListenAddress returns the Turing Api app's port

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/gojek/mlp/pkg/instrumentation/newrelic"
 	"github.com/gojek/mlp/pkg/instrumentation/sentry"
 	"github.com/mitchellh/mapstructure"
 
@@ -72,7 +73,8 @@ type Config struct {
 	//
 	// For example:
 	// { "experiment_engine_a": {"client": "foo"}, "experiment_engine_b": {"apikey": 12} }
-	Experiment map[string]interface{}
+	Experiment     map[string]interface{}
+	NewRelicConfig newrelic.Config
 }
 
 // ListenAddress returns the Turing Api app's port

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mitchellh/copystructure"
 	"github.com/mitchellh/mapstructure"
 
+	"github.com/gojek/mlp/pkg/instrumentation/newrelic"
 	"github.com/gojek/mlp/pkg/instrumentation/sentry"
 	tu "github.com/gojek/turing/api/turing/internal/testutils"
 	"github.com/stretchr/testify/assert"
@@ -526,6 +527,12 @@ func TestConfigValidate(t *testing.T) {
 			LogLevel: "DEBUG",
 		},
 		Sentry: sentry.Config{},
+		NewRelicConfig: newrelic.Config{
+			Enabled:           true,
+			AppName:           "test",
+			License:           "test",
+			IgnoreStatusCodes: []int{403, 404},
+		},
 		VaultConfig: &VaultConfig{
 			Address: "http://localhost:8200",
 			Token:   "root",

--- a/api/turing/config/example.yaml
+++ b/api/turing/config/example.yaml
@@ -28,6 +28,19 @@ DeployConfig:
   MaxCPU: "4"
   MaxMemory: "8Gi"
 
+# New Relic Config
+NewRelic:
+  Enabled: true
+  AppName: turing
+  License: <your very secret license key here>
+  IgnoreStatusCodes: 
+    - 400
+    - 401
+    - 403
+    - 404
+    - 405
+    - 412
+
 # Turing router configuration
 RouterDefaults:
   Image: ghcr.io/gojek/turing:latest

--- a/infra/chart/Chart.yaml
+++ b/infra/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.1.1
+version: 0.1.2

--- a/infra/chart/Chart.yaml
+++ b/infra/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.1.2
+version: 0.1.1


### PR DESCRIPTION
New Relic integration has been put added to wrap all handlers, but the init component has not been run, therefore it was not pushing to New Relic. This PR adds the initialisation of New Relic.