### PR TITLE
Fix: Change building of ensembler image from master branch to main.

### DIFF
--- a/.github/workflows/engines-batch-ensembler.yaml
+++ b/.github/workflows/engines-batch-ensembler.yaml
@@ -61,7 +61,7 @@ jobs:
         github.event_name == 'push' &&
         github.event.pull_request.head.repo.full_name == github.repository
       ) || (
-        github.ref == 'refs/heads/master'
+        github.ref == 'refs/heads/main'
       )
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
I forgot master branch is now called main in Github. This fixes the builds for the ensembling job that are supposed to be for main branch.