### PR TITLE
Terminate ensembling job

### DIFF
--- a/api/db-migrations/000009_ensembling_job.up.sql
+++ b/api/db-migrations/000009_ensembling_job.up.sql
@@ -3,6 +3,7 @@ CREATE TYPE ensembling_job_status as ENUM (
     'running',
     'completed',
     'failed',
+    'terminating',
     'terminated',
     'failed_submission',
     'failed_building',

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -23,8 +23,8 @@ paths:
   # J O B S
   "/projects/{project_id}/jobs":
     $ref: "openapi/jobs.yaml#/paths/~1projects~1{project_id}~1jobs"
-  "/projects/{project_id}/jobs/{id}":
-    $ref: "openapi/jobs.yaml#/paths/~1projects~1{project_id}~1jobs~1{id}"
+  "/projects/{project_id}/jobs/{job_id}":
+    $ref: "openapi/jobs.yaml#/paths/~1projects~1{project_id}~1jobs~1{job_id}"
 
   # A L E R T S
   "/projects/{project_id}/routers/{router_id}/alerts":

--- a/api/openapi/jobs.yaml
+++ b/api/openapi/jobs.yaml
@@ -66,7 +66,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/EnsemblingJobPaginatedResults"
 
-  "/projects/{project_id}/jobs/{id}":
+  "/projects/{project_id}/jobs/{job_id}":
     get:
       tags: *tags
       operationId: "GetEnsemblingJob"
@@ -78,7 +78,7 @@ paths:
             $ref: "#/components/schemas/Id"
           required: true
         - in: path
-          name: id
+          name: job_id
           schema:
             $ref: "#/components/schemas/Id"
           required: true
@@ -95,7 +95,7 @@ paths:
     delete:
       tags: *tags
       operationId: "DeleteEnsemblingJob"
-      summary: Deletee an ongoing Ensembling Job.
+      summary: Delete an ongoing Ensembling Job.
       parameters:
         - in: path
           name: project_id
@@ -103,7 +103,7 @@ paths:
             $ref: "#/components/schemas/Id"
           required: true
         - in: path
-          name: id
+          name: job_id
           schema:
             $ref: "#/components/schemas/Id"
           required: true

--- a/api/openapi/jobs.yaml
+++ b/api/openapi/jobs.yaml
@@ -26,7 +26,7 @@ paths:
             schema:
               $ref: "#/components/schemas/EnsemblingJob"
       responses:
-        "202":
+        202:
           description: Accepted.
           content:
             application/json:
@@ -59,7 +59,7 @@ paths:
             items:
               $ref: "#/components/schemas/EnsemblerJobStatus"
       responses:
-        "200":
+        200:
           description: A JSON object, that represents paginated results response
           content:
             application/json:
@@ -83,12 +83,44 @@ paths:
             $ref: "#/components/schemas/Id"
           required: true
       responses:
-        "200":
+        200:
           description: A JSON object representing an Ensembling Job
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/EnsemblingJob"
+        404:
+          description: "Invalid ensembling job"
+
+    delete:
+      tags: *tags
+      operationId: "DeleteEnsemblingJob"
+      summary: Deletee an ongoing Ensembling Job.
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            $ref: "#/components/schemas/Id"
+          required: true
+        - in: path
+          name: id
+          schema:
+            $ref: "#/components/schemas/Id"
+          required: true
+      responses:
+        202:
+          description: Accepted.
+          content:
+            application/json:
+              schema:
+                type: "object"
+                properties:
+                  id:
+                    $ref: "#/components/schemas/Id"
+        400:
+          description: "Invalid ensembling job"
+        404:
+          description: "Ensembling job not found"
 
 components:
   schemas:

--- a/api/turing/api/ensembling_job_api.go
+++ b/api/turing/api/ensembling_job_api.go
@@ -135,10 +135,10 @@ func (c EnsemblingJobController) DeleteEnsemblingJob(
 		},
 	)
 	if err != nil {
-		return NotFound("ensembler not found", err.Error())
+		return NotFound("ensembling job not found", err.Error())
 	}
 
-	err = c.EnsemblingJobService.DeleteEnsemblingJob(ensemblingJob)
+	err = c.EnsemblingJobService.MarkEnsemblingJobForTermination(ensemblingJob)
 	if err != nil {
 		return InternalServerError("unable to delete ensembling job", err.Error())
 	}
@@ -166,12 +166,12 @@ func (c EnsemblingJobController) Routes() []Route {
 		},
 		{
 			method:  http.MethodGet,
-			path:    "/projects/{project_id}/jobs/{id}",
+			path:    "/projects/{project_id}/jobs/{job_id}",
 			handler: c.GetEnsemblingJob,
 		},
 		{
 			method:  http.MethodDelete,
-			path:    "/projects/{project_id}/jobs/{id}",
+			path:    "/projects/{project_id}/jobs/{job_id}",
 			handler: c.DeleteEnsemblingJob,
 		},
 	}
@@ -181,5 +181,5 @@ func (c EnsemblingJobController) Routes() []Route {
 // from query params for the GET ensembling job method
 type GetEnsemblingJobOptions struct {
 	ProjectID *models.ID `schema:"project_id" validate:"required"`
-	ID        *models.ID `schema:"id" validate:"required"`
+	ID        *models.ID `schema:"job_id" validate:"required"`
 }

--- a/api/turing/api/ensembling_job_api.go
+++ b/api/turing/api/ensembling_job_api.go
@@ -161,13 +161,18 @@ func (c EnsemblingJobController) Routes() []Route {
 		},
 		{
 			method:  http.MethodGet,
+			path:    "/projects/{project_id}/jobs",
+			handler: c.ListEnsemblingJobs,
+		},
+		{
+			method:  http.MethodGet,
 			path:    "/projects/{project_id}/jobs/{id}",
 			handler: c.GetEnsemblingJob,
 		},
 		{
-			method:  http.MethodGet,
-			path:    "/projects/{project_id}/jobs",
-			handler: c.ListEnsemblingJobs,
+			method:  http.MethodDelete,
+			path:    "/projects/{project_id}/jobs/{id}",
+			handler: c.DeleteEnsemblingJob,
 		},
 	}
 }

--- a/api/turing/api/ensembling_job_api_test.go
+++ b/api/turing/api/ensembling_job_api_test.go
@@ -395,7 +395,7 @@ func TestEnsemblingJobController_GetEnsemblingJob(t *testing.T) {
 	}{
 		"success | nominal": {
 			params: RequestVars{
-				"id":         {"1"},
+				"job_id":     {"1"},
 				"project_id": {"1"},
 			},
 			ensemblingJobService: func() service.EnsemblingJobService {
@@ -417,7 +417,7 @@ func TestEnsemblingJobController_GetEnsemblingJob(t *testing.T) {
 		},
 		"failure | no such ensembling job": {
 			params: RequestVars{
-				"id":         {"1"},
+				"job_id":     {"1"},
 				"project_id": {"1"},
 			},
 			ensemblingJobService: func() service.EnsemblingJobService {
@@ -433,7 +433,7 @@ func TestEnsemblingJobController_GetEnsemblingJob(t *testing.T) {
 		},
 		"failure | missing project_id": {
 			params: RequestVars{
-				"id": {"1"},
+				"job_id": {"1"},
 			},
 			ensemblingJobService: func() service.EnsemblingJobService {
 				svc := &mocks.EnsemblingJobService{}
@@ -744,13 +744,13 @@ func TestEnsemblingJobController_DeleteEnsemblingJob(t *testing.T) {
 					nil,
 				)
 				svc.On(
-					"DeleteEnsemblingJob",
+					"MarkEnsemblingJobForTermination",
 					mock.Anything,
 				).Return(nil)
 				return svc
 			},
 			params: RequestVars{
-				"id":         {"1"},
+				"job_id":     {"1"},
 				"project_id": {"1"},
 			},
 			expectedResponseCode: 202,
@@ -766,11 +766,11 @@ func TestEnsemblingJobController_DeleteEnsemblingJob(t *testing.T) {
 				return svc
 			},
 			params: RequestVars{
-				"id":         {"1"},
+				"job_id":     {"1"},
 				"project_id": {"1"},
 			},
 			expectedResponseCode: 404,
-			expectedBody:         NotFound("ensembler not found", fmt.Errorf("hello").Error()),
+			expectedBody:         NotFound("ensembling job not found", fmt.Errorf("hello").Error()),
 		},
 		"failure | internal server error": {
 			ensemblingJobService: func() service.EnsemblingJobService {
@@ -780,13 +780,13 @@ func TestEnsemblingJobController_DeleteEnsemblingJob(t *testing.T) {
 					nil,
 				)
 				svc.On(
-					"DeleteEnsemblingJob",
+					"MarkEnsemblingJobForTermination",
 					mock.Anything,
 				).Return(fmt.Errorf("hello"))
 				return svc
 			},
 			params: RequestVars{
-				"id":         {"1"},
+				"job_id":     {"1"},
 				"project_id": {"1"},
 			},
 			expectedResponseCode: 500,

--- a/api/turing/batch/ensembling/controller.go
+++ b/api/turing/batch/ensembling/controller.go
@@ -69,7 +69,9 @@ func (c *ensemblingController) Delete(namespace string, ensemblingJob *models.En
 	sa, err := c.clusterController.GetSparkApplication(namespace, ensemblingJob.Name)
 	if err != nil {
 		c.cleanup(ensemblingJob.Name, namespace)
-		return err
+		// Not found, we do not consider this as an error because its just no further
+		// action required on this part.
+		return nil
 	}
 	c.cleanup(ensemblingJob.Name, namespace)
 	return c.clusterController.DeleteSparkApplication(namespace, sa.Name)

--- a/api/turing/batch/ensembling/controller_test.go
+++ b/api/turing/batch/ensembling/controller_test.go
@@ -673,7 +673,7 @@ func TestDelete(t *testing.T) {
 			},
 			hasErr: false,
 		},
-		"failure | no such job": {
+		"success | no such job": {
 			clusterController: func() cluster.Controller {
 				ctrler := &clustermock.Controller{}
 				ctrler.On("DeleteSecret", mock.Anything, mock.Anything).Return(nil)
@@ -685,7 +685,9 @@ func TestDelete(t *testing.T) {
 				)
 				return ctrler
 			},
-			hasErr: true,
+			// It is important that no action is to be done, we ignore the error
+			// Just that there is no further action required on the delete function
+			hasErr: false,
 		},
 	}
 	for name, tt := range tests {

--- a/api/turing/batch/ensembling/mock_ensembling_controller.go
+++ b/api/turing/batch/ensembling/mock_ensembling_controller.go
@@ -26,6 +26,20 @@ func (_m *MockEnsemblingController) Create(request *CreateEnsemblingJobRequest) 
 	return r0
 }
 
+// Delete provides a mock function with given fields: namespace, ensemblingJob
+func (_m *MockEnsemblingController) Delete(namespace string, ensemblingJob *models.EnsemblingJob) error {
+	ret := _m.Called(namespace, ensemblingJob)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *models.EnsemblingJob) error); ok {
+		r0 = rf(namespace, ensemblingJob)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetStatus provides a mock function with given fields: namespace, ensemblingJob
 func (_m *MockEnsemblingController) GetStatus(namespace string, ensemblingJob *models.EnsemblingJob) (SparkApplicationState, error) {
 	ret := _m.Called(namespace, ensemblingJob)

--- a/api/turing/batch/ensembling/runner.go
+++ b/api/turing/batch/ensembling/runner.go
@@ -15,13 +15,13 @@ import (
 var pageOne = 1
 
 type ensemblingJobRunner struct {
-	ensemblingController      EnsemblingController
-	ensemblingJobService      service.EnsemblingJobService
-	mlpService                service.MLPService
-	imageBuilder              imagebuilder.ImageBuilder
-	batchSize                 int
-	maxRetryCount             int
-	imageBuildTimeoutDuration time.Duration
+	ensemblingController           EnsemblingController
+	ensemblingJobService           service.EnsemblingJobService
+	mlpService                     service.MLPService
+	imageBuilder                   imagebuilder.ImageBuilder
+	recordsToProcessInOneIteration int
+	maxRetryCount                  int
+	imageBuildTimeoutDuration      time.Duration
 }
 
 // NewBatchEnsemblingJobRunner creates a new batch ensembling job runner
@@ -31,18 +31,18 @@ func NewBatchEnsemblingJobRunner(
 	ensemblingJobService service.EnsemblingJobService,
 	mlpService service.MLPService,
 	imageBuilder imagebuilder.ImageBuilder,
-	batchSize int,
+	recordsToProcessInOneIteration int,
 	maxRetryCount int,
 	imageBuildTimeoutDuration time.Duration,
 ) batchrunner.BatchJobRunner {
 	return &ensemblingJobRunner{
-		ensemblingController:      ensemblingController,
-		ensemblingJobService:      ensemblingJobService,
-		mlpService:                mlpService,
-		imageBuilder:              imageBuilder,
-		batchSize:                 batchSize,
-		maxRetryCount:             maxRetryCount,
-		imageBuildTimeoutDuration: imageBuildTimeoutDuration,
+		ensemblingController:           ensemblingController,
+		ensemblingJobService:           ensemblingJobService,
+		mlpService:                     mlpService,
+		imageBuilder:                   imageBuilder,
+		recordsToProcessInOneIteration: recordsToProcessInOneIteration,
+		maxRetryCount:                  maxRetryCount,
+		imageBuildTimeoutDuration:      imageBuildTimeoutDuration,
 	}
 }
 
@@ -61,7 +61,7 @@ func (r *ensemblingJobRunner) updateStatus() {
 	optionsJobRunning := service.EnsemblingJobListOptions{
 		PaginationOptions: service.PaginationOptions{
 			Page:     &pageOne,
-			PageSize: &r.batchSize,
+			PageSize: &r.recordsToProcessInOneIteration,
 		},
 		Statuses: []models.Status{
 			models.JobRunning,
@@ -91,7 +91,7 @@ func (r *ensemblingJobRunner) updateStatus() {
 	optionsJobBuildingImage := service.EnsemblingJobListOptions{
 		PaginationOptions: service.PaginationOptions{
 			Page:     &pageOne,
-			PageSize: &r.batchSize,
+			PageSize: &r.recordsToProcessInOneIteration,
 		},
 		Statuses: []models.Status{
 			models.JobBuildingImage,
@@ -105,7 +105,7 @@ func (r *ensemblingJobRunner) updateStatus() {
 	optionsJobTerminatingImage := service.EnsemblingJobListOptions{
 		PaginationOptions: service.PaginationOptions{
 			Page:     &pageOne,
-			PageSize: &r.batchSize,
+			PageSize: &r.recordsToProcessInOneIteration,
 		},
 		Statuses: []models.Status{
 			models.JobTerminating,
@@ -224,7 +224,7 @@ func (r *ensemblingJobRunner) processJobs() {
 	options := service.EnsemblingJobListOptions{
 		PaginationOptions: service.PaginationOptions{
 			Page:     &pageOne,
-			PageSize: &r.batchSize,
+			PageSize: &r.recordsToProcessInOneIteration,
 		},
 		Statuses: []models.Status{
 			models.JobPending,

--- a/api/turing/batch/ensembling/runner.go
+++ b/api/turing/batch/ensembling/runner.go
@@ -236,6 +236,7 @@ func (r *ensemblingJobRunner) processJobs() {
 	ensemblingJobsPaginated, err := r.ensemblingJobService.List(options)
 	if err != nil {
 		log.Errorf("unable to query ensembling jobs: %v", err)
+		return
 	}
 
 	if ensemblingJobsPaginated.Results == nil {

--- a/api/turing/batch/ensembling/runner.go
+++ b/api/turing/batch/ensembling/runner.go
@@ -334,7 +334,10 @@ func (r *ensemblingJobRunner) terminateJob(ensemblingJob *models.EnsemblingJob, 
 	}
 
 	// Delete record
-	r.ensemblingJobService.Delete(ensemblingJob)
+	err := r.ensemblingJobService.Delete(ensemblingJob)
+	if err != nil {
+		log.Errorf("unable to delete ensembling job %v", err)
+	}
 }
 
 // terminateIfRequired returns true if the process should drop what it is doing.

--- a/api/turing/batch/ensembling/runner_test.go
+++ b/api/turing/batch/ensembling/runner_test.go
@@ -84,6 +84,11 @@ func TestRun(t *testing.T) {
 					},
 				}, nil)
 
+				svc.On("FindByID", mock.Anything, mock.Anything).Return(
+					&models.EnsemblingJob{},
+					nil,
+				)
+
 				return svc
 			},
 			mlpService: func() service.MLPService {
@@ -154,6 +159,11 @@ func TestRun(t *testing.T) {
 					},
 				}, nil)
 
+				svc.On("FindByID", mock.Anything, mock.Anything).Return(
+					&models.EnsemblingJob{},
+					nil,
+				)
+
 				return svc
 			},
 			mlpService: func() service.MLPService {
@@ -203,6 +213,11 @@ func TestRun(t *testing.T) {
 					"Save",
 					mock.Anything,
 				).Return(nil)
+
+				svc.On("FindByID", mock.Anything, mock.Anything).Return(
+					&models.EnsemblingJob{},
+					nil,
+				)
 
 				return svc
 			},

--- a/api/turing/cluster/controller.go
+++ b/api/turing/cluster/controller.go
@@ -87,6 +87,7 @@ type Controller interface {
 	CreateRoleBinding(namespace, roleBindingName, serviceAccountName, roleName string) (*apirbacv1.RoleBinding, error)
 	CreateSparkApplication(namespace string, request *CreateSparkRequest) (*apisparkv1beta2.SparkApplication, error)
 	GetSparkApplication(namespace, appName string) (*apisparkv1beta2.SparkApplication, error)
+	DeleteSparkApplication(namespace, appName string) error
 }
 
 // controller implements the Controller interface
@@ -642,6 +643,10 @@ func (c *controller) CreateSparkApplication(
 
 func (c *controller) GetSparkApplication(namespace, appName string) (*apisparkv1beta2.SparkApplication, error) {
 	return c.k8sSparkOperator.SparkApplications(namespace).Get(appName, metav1.GetOptions{})
+}
+
+func (c *controller) DeleteSparkApplication(namespace, appName string) error {
+	return c.k8sSparkOperator.SparkApplications(namespace).Delete(appName, &metav1.DeleteOptions{})
 }
 
 // waitKnativeServiceReady waits for the given knative service to become ready, until the

--- a/api/turing/cluster/controller_test.go
+++ b/api/turing/cluster/controller_test.go
@@ -877,6 +877,27 @@ func TestGetSparkApplication(t *testing.T) {
 	})
 }
 
+func TestDeleteSparkApplication(t *testing.T) {
+	namespace := "test-ns"
+	appName := "bicycle"
+	t.Run("Success | nominal", func(t *testing.T) {
+		cs := fake.NewSimpleClientset()
+		cs.PrependReactor(
+			reactorVerbs.Get,
+			"sparkapplication",
+			func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, nil
+			},
+		)
+		sparkClientSet := sparkOpFake.Clientset{}
+		c := &controller{
+			k8sSparkOperator: sparkClientSet.SparkoperatorV1beta2(),
+		}
+		err := c.DeleteSparkApplication(namespace, appName)
+		assert.Nil(t, err)
+	})
+}
+
 func TestCreateNamespace(t *testing.T) {
 	namespace := "test-ns"
 	nsResource := schema.GroupVersionResource{

--- a/api/turing/cluster/mocks/controller.go
+++ b/api/turing/cluster/mocks/controller.go
@@ -310,6 +310,20 @@ func (_m *Controller) DeleteSecret(secretName string, namespace string) error {
 	return r0
 }
 
+// DeleteSparkApplication provides a mock function with given fields: namespace, appName
+func (_m *Controller) DeleteSparkApplication(namespace string, appName string) error {
+	ret := _m.Called(namespace, appName)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(namespace, appName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeployKnativeService provides a mock function with given fields: ctx, svc
 func (_m *Controller) DeployKnativeService(ctx context.Context, svc *cluster.KnativeService) error {
 	ret := _m.Called(ctx, svc)

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -181,12 +181,10 @@ func (ib *imageBuilder) waitForJobToFinish(job *apibatchv1.Job) error {
 	for {
 		select {
 		case <-timeout:
-			log.Errorf("timeout waiting for kaniko job completion %s", job.Name)
 			return ErrTimeoutBuildingImage
 		case <-ticker.C:
 			j, err := ib.clusterController.GetJob(ib.imageConfig.BuildNamespace, job.Name)
 			if err != nil {
-				log.Errorf("unable to get job status for job %s: %v", job.Name, err)
 				return ErrUnableToBuildImage
 			}
 
@@ -194,7 +192,6 @@ func (ib *imageBuilder) waitForJobToFinish(job *apibatchv1.Job) error {
 				// successfully created pod
 				return nil
 			} else if j.Status.Failed == 1 {
-				log.Errorf("failed building OCI image %s: %v", job.Name, j.Status)
 				return ErrUnableToBuildImage
 			}
 		}
@@ -378,8 +375,9 @@ func (ib *imageBuilder) DeleteImageBuildingJob(
 	)
 	if err != nil {
 		// Not found.
-		return err
+		return nil
 	}
 	// Delete job
-	return ib.clusterController.DeleteJob(job.Name, ib.imageConfig.BuildNamespace)
+	err = ib.clusterController.DeleteJob(ib.imageConfig.BuildNamespace, job.Name)
+	return err
 }

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -71,6 +71,11 @@ type ImageBuilder interface {
 		modelName string,
 		versionID models.ID,
 	) (JobStatus, error)
+	DeleteImageBuildingJob(
+		projectName string,
+		modelName string,
+		versionID models.ID,
+	) error
 }
 
 type nameGenerator interface {
@@ -355,4 +360,26 @@ func (ib *imageBuilder) GetImageBuildingJobStatus(
 	}
 
 	return JobStatusUnknown, nil
+}
+
+func (ib *imageBuilder) DeleteImageBuildingJob(
+	projectName string,
+	modelName string,
+	versionID models.ID,
+) error {
+	kanikoJobName := ib.nameGenerator.generateBuilderJobName(
+		projectName,
+		modelName,
+		versionID,
+	)
+	job, err := ib.clusterController.GetJob(
+		ib.imageConfig.BuildNamespace,
+		kanikoJobName,
+	)
+	if err != nil {
+		// Not found.
+		return err
+	}
+	// Delete job
+	return ib.clusterController.DeleteJob(job.Name, ib.imageConfig.BuildNamespace)
 }

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -185,6 +185,7 @@ func (ib *imageBuilder) waitForJobToFinish(job *apibatchv1.Job) error {
 		case <-ticker.C:
 			j, err := ib.clusterController.GetJob(ib.imageConfig.BuildNamespace, job.Name)
 			if err != nil {
+				log.Errorf("unable to get job status for job %s: %v", job.Name, err)
 				return ErrUnableToBuildImage
 			}
 
@@ -192,6 +193,7 @@ func (ib *imageBuilder) waitForJobToFinish(job *apibatchv1.Job) error {
 				// successfully created pod
 				return nil
 			} else if j.Status.Failed == 1 {
+				log.Errorf("failed building OCI image %s: %v", job.Name, j.Status)
 				return ErrUnableToBuildImage
 			}
 		}

--- a/api/turing/imagebuilder/mocks/image_builder.go
+++ b/api/turing/imagebuilder/mocks/image_builder.go
@@ -35,6 +35,20 @@ func (_m *ImageBuilder) BuildImage(request imagebuilder.BuildImageRequest) (stri
 	return r0, r1
 }
 
+// DeleteImageBuildingJob provides a mock function with given fields: projectName, modelName, versionID
+func (_m *ImageBuilder) DeleteImageBuildingJob(projectName string, modelName string, versionID models.ID) error {
+	ret := _m.Called(projectName, modelName, versionID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, models.ID) error); ok {
+		r0 = rf(projectName, modelName, versionID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetImageBuildingJobStatus provides a mock function with given fields: projectName, modelName, versionID
 func (_m *ImageBuilder) GetImageBuildingJobStatus(projectName string, modelName string, versionID models.ID) (imagebuilder.JobStatus, error) {
 	ret := _m.Called(projectName, modelName, versionID)

--- a/api/turing/models/ensembling_job.go
+++ b/api/turing/models/ensembling_job.go
@@ -99,7 +99,7 @@ type BatchEnsemblingJobResources struct {
 // JobRunning --▶ JobFailed
 //     |
 //     |
-//     |--▶ JobTerminated
+//     |--▶ JobTerminating --▶ JobTerminated
 //     |
 //     |
 //     ▼
@@ -113,6 +113,8 @@ const (
 	JobBuildingImage Status = "building"
 	// JobRunning is when the job has been picked up and running.
 	JobRunning Status = "running"
+	// JobTerminating is when the job has been requested to terminate.
+	JobTerminating Status = "terminating"
 	// JobTerminated is when the job has stopped. This is a terminal state.
 	JobTerminated Status = "terminated"
 	// JobCompleted is when the job has successfully completed. This is a terminal state.

--- a/api/turing/service/ensembling_job_service.go
+++ b/api/turing/service/ensembling_job_service.go
@@ -29,7 +29,8 @@ type EnsemblingJobListOptions struct {
 
 // EnsemblingJobService is the data access object for the EnsemblingJob from the db.
 type EnsemblingJobService interface {
-	Save(ensembler *models.EnsemblingJob) error
+	Save(ensemblingJob *models.EnsemblingJob) error
+	Delete(ensemblingJob *models.EnsemblingJob) error
 	FindByID(id models.ID, options EnsemblingJobFindByIDOptions) (*models.EnsemblingJob, error)
 	List(options EnsemblingJobListOptions) (*PaginatedResults, error)
 	CreateEnsemblingJob(
@@ -58,6 +59,10 @@ func (s *ensemblingJobService) Save(ensemblingJob *models.EnsemblingJob) error {
 	return s.db.Save(ensemblingJob).Error
 }
 
+func (s *ensemblingJobService) Delete(ensemblingJob *models.EnsemblingJob) error {
+	return s.db.Delete(ensemblingJob).Error
+}
+
 func (s *ensemblingJobService) FindByID(
 	id models.ID,
 	options EnsemblingJobFindByIDOptions,
@@ -72,7 +77,7 @@ func (s *ensemblingJobService) FindByID(
 	result := query.First(&ensemblingJob)
 
 	if err := result.Error; err != nil {
-		return &ensemblingJob, err
+		return nil, err
 	}
 
 	return &ensemblingJob, nil

--- a/api/turing/service/ensembling_job_service.go
+++ b/api/turing/service/ensembling_job_service.go
@@ -37,6 +37,7 @@ type EnsemblingJobService interface {
 		projectID models.ID,
 		ensembler *models.PyFuncEnsembler,
 	) (*models.EnsemblingJob, error)
+	DeleteEnsemblingJob(ensemblingJob *models.EnsemblingJob) error
 }
 
 // NewEnsemblingJobService creates a new ensembling job service
@@ -158,4 +159,9 @@ func (s *ensemblingJobService) CreateEnsemblingJob(
 	}
 
 	return job, nil
+}
+
+func (s *ensemblingJobService) DeleteEnsemblingJob(job *models.EnsemblingJob) error {
+	job.Status = models.JobTerminating
+	return s.Save(job)
 }

--- a/api/turing/service/ensembling_job_service.go
+++ b/api/turing/service/ensembling_job_service.go
@@ -38,7 +38,7 @@ type EnsemblingJobService interface {
 		projectID models.ID,
 		ensembler *models.PyFuncEnsembler,
 	) (*models.EnsemblingJob, error)
-	DeleteEnsemblingJob(ensemblingJob *models.EnsemblingJob) error
+	MarkEnsemblingJobForTermination(ensemblingJob *models.EnsemblingJob) error
 }
 
 // NewEnsemblingJobService creates a new ensembling job service
@@ -166,7 +166,7 @@ func (s *ensemblingJobService) CreateEnsemblingJob(
 	return job, nil
 }
 
-func (s *ensemblingJobService) DeleteEnsemblingJob(job *models.EnsemblingJob) error {
+func (s *ensemblingJobService) MarkEnsemblingJobForTermination(job *models.EnsemblingJob) error {
 	job.Status = models.JobTerminating
 	return s.Save(job)
 }

--- a/api/turing/service/ensembling_job_service_test.go
+++ b/api/turing/service/ensembling_job_service_test.go
@@ -367,7 +367,7 @@ func TestCreateEnsemblingJob(t *testing.T) {
 	})
 }
 
-func TestDeleteEnsemblingJob(t *testing.T) {
+func TestMarkEnsemblingJobForTermination(t *testing.T) {
 	t.Run("success | delete ensembling job", func(t *testing.T) {
 		database.WithTestDatabase(t, func(t *testing.T, db *gorm.DB) {
 			ensemblingJobService := NewEnsemblingJobService(db, "dev")
@@ -381,7 +381,7 @@ func TestDeleteEnsemblingJob(t *testing.T) {
 			assert.NotEqual(t, models.ID(0), ensemblingJob.ID)
 
 			// Delete job
-			err = ensemblingJobService.DeleteEnsemblingJob(ensemblingJob)
+			err = ensemblingJobService.MarkEnsemblingJobForTermination(ensemblingJob)
 			assert.NoError(t, err)
 
 			// Query back job to check if terminated

--- a/api/turing/service/ensembling_job_service_test.go
+++ b/api/turing/service/ensembling_job_service_test.go
@@ -394,3 +394,31 @@ func TestDeleteEnsemblingJob(t *testing.T) {
 		})
 	})
 }
+
+func TestPhysicalDeleteEnsemblingJob(t *testing.T) {
+	t.Run("success | delete ensembling job", func(t *testing.T) {
+		database.WithTestDatabase(t, func(t *testing.T, db *gorm.DB) {
+			ensemblingJobService := NewEnsemblingJobService(db, "dev")
+
+			// Save job
+			projectID := models.ID(1)
+			ensemblerID := models.ID(1000)
+			ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, "test-ensembler", false)
+			err := ensemblingJobService.Save(ensemblingJob)
+			assert.NoError(t, err)
+			assert.NotEqual(t, models.ID(0), ensemblingJob.ID)
+
+			// Delete job
+			err = ensemblingJobService.Delete(ensemblingJob)
+			assert.NoError(t, err)
+
+			// Query back job to check if job is no longer there
+			found, err := ensemblingJobService.FindByID(
+				ensemblingJob.ID,
+				EnsemblingJobFindByIDOptions{ProjectID: &projectID},
+			)
+			assert.NotNil(t, err)
+			assert.Nil(t, found)
+		})
+	})
+}

--- a/api/turing/service/mocks/ensembling_job_service.go
+++ b/api/turing/service/mocks/ensembling_job_service.go
@@ -14,13 +14,13 @@ type EnsemblingJobService struct {
 	mock.Mock
 }
 
-// CreateEnsemblingJob provides a mock function with given fields: request, projectID, ensembler
-func (_m *EnsemblingJobService) CreateEnsemblingJob(request *models.EnsemblingJob, projectID models.ID, ensembler *models.PyFuncEnsembler) (*models.EnsemblingJob, error) {
-	ret := _m.Called(request, projectID, ensembler)
+// CreateEnsemblingJob provides a mock function with given fields: job, projectID, ensembler
+func (_m *EnsemblingJobService) CreateEnsemblingJob(job *models.EnsemblingJob, projectID models.ID, ensembler *models.PyFuncEnsembler) (*models.EnsemblingJob, error) {
+	ret := _m.Called(job, projectID, ensembler)
 
 	var r0 *models.EnsemblingJob
 	if rf, ok := ret.Get(0).(func(*models.EnsemblingJob, models.ID, *models.PyFuncEnsembler) *models.EnsemblingJob); ok {
-		r0 = rf(request, projectID, ensembler)
+		r0 = rf(job, projectID, ensembler)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.EnsemblingJob)
@@ -29,12 +29,26 @@ func (_m *EnsemblingJobService) CreateEnsemblingJob(request *models.EnsemblingJo
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(*models.EnsemblingJob, models.ID, *models.PyFuncEnsembler) error); ok {
-		r1 = rf(request, projectID, ensembler)
+		r1 = rf(job, projectID, ensembler)
 	} else {
 		r1 = ret.Error(1)
 	}
 
 	return r0, r1
+}
+
+// DeleteEnsemblingJob provides a mock function with given fields: ensemblingJob
+func (_m *EnsemblingJobService) DeleteEnsemblingJob(ensemblingJob *models.EnsemblingJob) error {
+	ret := _m.Called(ensemblingJob)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*models.EnsemblingJob) error); ok {
+		r0 = rf(ensemblingJob)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // FindByID provides a mock function with given fields: id, options

--- a/api/turing/service/mocks/ensembling_job_service.go
+++ b/api/turing/service/mocks/ensembling_job_service.go
@@ -51,20 +51,6 @@ func (_m *EnsemblingJobService) Delete(ensemblingJob *models.EnsemblingJob) erro
 	return r0
 }
 
-// DeleteEnsemblingJob provides a mock function with given fields: ensemblingJob
-func (_m *EnsemblingJobService) DeleteEnsemblingJob(ensemblingJob *models.EnsemblingJob) error {
-	ret := _m.Called(ensemblingJob)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*models.EnsemblingJob) error); ok {
-		r0 = rf(ensemblingJob)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // FindByID provides a mock function with given fields: id, options
 func (_m *EnsemblingJobService) FindByID(id models.ID, options service.EnsemblingJobFindByIDOptions) (*models.EnsemblingJob, error) {
 	ret := _m.Called(id, options)
@@ -109,6 +95,20 @@ func (_m *EnsemblingJobService) List(options service.EnsemblingJobListOptions) (
 	}
 
 	return r0, r1
+}
+
+// MarkEnsemblingJobForTermination provides a mock function with given fields: ensemblingJob
+func (_m *EnsemblingJobService) MarkEnsemblingJobForTermination(ensemblingJob *models.EnsemblingJob) error {
+	ret := _m.Called(ensemblingJob)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*models.EnsemblingJob) error); ok {
+		r0 = rf(ensemblingJob)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Save provides a mock function with given fields: ensemblingJob

--- a/api/turing/service/mocks/ensembling_job_service.go
+++ b/api/turing/service/mocks/ensembling_job_service.go
@@ -37,6 +37,20 @@ func (_m *EnsemblingJobService) CreateEnsemblingJob(job *models.EnsemblingJob, p
 	return r0, r1
 }
 
+// Delete provides a mock function with given fields: ensemblingJob
+func (_m *EnsemblingJobService) Delete(ensemblingJob *models.EnsemblingJob) error {
+	ret := _m.Called(ensemblingJob)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*models.EnsemblingJob) error); ok {
+		r0 = rf(ensemblingJob)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteEnsemblingJob provides a mock function with given fields: ensemblingJob
 func (_m *EnsemblingJobService) DeleteEnsemblingJob(ensemblingJob *models.EnsemblingJob) error {
 	ret := _m.Called(ensemblingJob)
@@ -97,13 +111,13 @@ func (_m *EnsemblingJobService) List(options service.EnsemblingJobListOptions) (
 	return r0, r1
 }
 
-// Save provides a mock function with given fields: ensembler
-func (_m *EnsemblingJobService) Save(ensembler *models.EnsemblingJob) error {
-	ret := _m.Called(ensembler)
+// Save provides a mock function with given fields: ensemblingJob
+func (_m *EnsemblingJobService) Save(ensemblingJob *models.EnsemblingJob) error {
+	ret := _m.Called(ensemblingJob)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*models.EnsemblingJob) error); ok {
-		r0 = rf(ensembler)
+		r0 = rf(ensemblingJob)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
This PR adds the `DELETE` `/projects/{project_id}/jobs/{id}` to terminate a job.

The API accepts a request to delete the record and sets the status to `terminating`. The batch runners will periodly check if it is time to delete the associated Kubernetes resources (Job and SparkApplication) before physically deleting the record from the database.

Checks have to be done at different stages of the orchestration process, making sure that is no race conditions (I have tested this extensively) during the termination process and building process.