### PR TITLE
Bump version of Turing charts.

### DIFF
--- a/infra/chart/Chart.yaml
+++ b/infra/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.1.1
+version: 0.1.2


### PR DESCRIPTION
The migrations are failing in newer installs because the DB migrations are not in sync. This will update the chart versions so that db migrations are in sync with the codebase.