### PR TITLE
Bump version for Termination job.

### DIFF
--- a/infra/chart/Chart.yaml
+++ b/infra/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.1.2
+version: 0.1.3


### PR DESCRIPTION
Version bump required for the helm chart release due to the changes in db schema for the termination job.

Changes here: https://github.com/gojek/turing/pull/69/files#diff-fad116ed944370b59b28aea03d283195dc2cb1c304fdaf0d087de781501407cfR6