### PR TITLE
Add a feature toggle to disable batch ensembling runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ DbConfig:
 DeployConfig:
   EnvironmentType: dev 
 EnsemblingJobConfig:
+  Enabled: true
   DefaultEnvironment: dev
   RecordsToProcessInOneIteration: 10
   MaxRetryCount: 3

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ BatchEnsemblingConfig:
     MaxRetryCount: 3
   ImageBuildingConfig:
     ImageConfig:
-      Registry: ghcr.io
+      DestinationRegistry: ghcr.io
       BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
       BuildNamespace: default
       BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ router Docker image is set to the image built and push from the previous step.
 
 ```yaml
 # config-dev.yaml
-BatchEnsemblerConfig:
+BatchEnsemblingConfig:
   Enabled: true
   JobConfig:
     DefaultEnvironment: dev

--- a/README.md
+++ b/README.md
@@ -158,44 +158,46 @@ router Docker image is set to the image built and push from the previous step.
 
 ```yaml
 # config-dev.yaml
-BatchRunnerConfig:
-  TimeInterval: 10s
+BatchEnsemblerConfig:
+  Enabled: true
+  JobConfig:
+    DefaultEnvironment: dev
+    DefaultConfigurations:
+      SparkConfigAnnotations:
+        "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
+      BatchEnsemblingJobResources:
+        DriverCPURequest: "1"
+        DriverMemoryRequest: "1Gi"
+        ExecutorReplica: 2
+        ExecutorCPURequest: "1"
+        ExecutorMemoryRequest: "1Gi"
+  RunnerConfig:
+    TimeInterval: 10s
+    RecordsToProcessInOneIteration: 10
+    MaxRetryCount: 3
+  ImageBuildingConfig:
+    ImageConfig:
+      Registry: ghcr.io
+      BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
+      BuildNamespace: default
+      BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main
+      DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
+      BuildTimeoutDuration: 20m
+    KanikoConfig:
+      Image: gcr.io/kaniko-project/executor
+      ImageVersion: v1.5.2
+      ResourceRequestsLimits:
+        Requests:
+          CPU: "1"
+          Memory: 1Gi
+        Limits:
+          CPU: "1"
+          Memory: 1Gi
 DbConfig:
   User: turing
   Password: turing
 DeployConfig:
   EnvironmentType: dev 
-EnsemblingJobConfig:
-  Enabled: true
-  DefaultEnvironment: dev
-  RecordsToProcessInOneIteration: 10
-  MaxRetryCount: 3
-  ImageBuilderConfig:
-    Registry: ghcr.io
-    BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
-    BuildNamespace: default
-    BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main
-    DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
-    BuildTimeoutDuration: 20m
-  KanikoConfig:
-    Image: gcr.io/kaniko-project/executor
-    ImageVersion: v1.5.2
-    ResourceRequestsLimits:
-      Requests:
-        CPU: "1"
-        Memory: 1Gi
-      Limits:
-        CPU: "1"
-        Memory: 1Gi
-  DefaultConfigurations:
-    SparkConfigAnnotations:
-      "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
-    BatchEnsemblingJobResources:
-      DriverCPURequest: "1"
-      DriverMemoryRequest: "1Gi"
-      ExecutorReplica: 2
-      ExecutorCPURequest: "1"
-      ExecutorMemoryRequest: "1Gi"
 KubernetesLabelConfigs:
   Environment: dev
 SparkAppConfig:

--- a/api/config-dev.yaml
+++ b/api/config-dev.yaml
@@ -6,6 +6,7 @@ DbConfig:
 DeployConfig:
   EnvironmentType: dev 
 EnsemblingJobConfig:
+  Enabled: false
   DefaultEnvironment: dev
   RecordsToProcessInOneIteration: 10
   MaxRetryCount: 3

--- a/api/config-dev.yaml
+++ b/api/config-dev.yaml
@@ -16,16 +16,15 @@ BatchEnsemblingConfig:
     RecordsToProcessInOneIteration: 10
     MaxRetryCount: 3
   ImageBuildingConfig:
-    ImageConfig:
-      Registry: ghcr.io
-      BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
-      BuildNamespace: default
+    BuildNamespace: default
+    BuildTimeoutDuration: 20m
+    DestinationRegistry: ghcr.io
+    BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
+    KanikoConfig:
       BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main
       DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
-      BuildTimeoutDuration: 20m
-    KanikoConfig:
       Image: gcr.io/kaniko-project/executor
-      ImageVersion: v1.5.2
+      ImageVersion: v1.6.0
       ResourceRequestsLimits:
         Requests:
           CPU: "1"

--- a/api/config-dev.yaml
+++ b/api/config-dev.yaml
@@ -1,41 +1,43 @@
-BatchRunnerConfig:
-  TimeInterval: 10s
+BatchEnsemblerConfig:
+  Enabled: true
+  JobConfig:
+    DefaultEnvironment: dev
+    DefaultConfigurations:
+      SparkConfigAnnotations:
+        "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
+      BatchEnsemblingJobResources:
+        DriverCPURequest: "1"
+        DriverMemoryRequest: "1Gi"
+        ExecutorReplica: 2
+        ExecutorCPURequest: "1"
+        ExecutorMemoryRequest: "1Gi"
+  RunnerConfig:
+    TimeInterval: 10s
+    RecordsToProcessInOneIteration: 10
+    MaxRetryCount: 3
+  ImageBuildingConfig:
+    ImageConfig:
+      Registry: ghcr.io
+      BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
+      BuildNamespace: default
+      BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main
+      DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
+      BuildTimeoutDuration: 20m
+    KanikoConfig:
+      Image: gcr.io/kaniko-project/executor
+      ImageVersion: v1.5.2
+      ResourceRequestsLimits:
+        Requests:
+          CPU: "1"
+          Memory: 1Gi
+        Limits:
+          CPU: "1"
+          Memory: 1Gi
 DbConfig:
   User: turing
   Password: turing
 DeployConfig:
   EnvironmentType: dev 
-EnsemblingJobConfig:
-  Enabled: false
-  DefaultEnvironment: dev
-  RecordsToProcessInOneIteration: 10
-  MaxRetryCount: 3
-  ImageBuilderConfig:
-    Registry: ghcr.io
-    BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
-    BuildNamespace: default
-    BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main
-    DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
-    BuildTimeoutDuration: 20m
-  KanikoConfig:
-    Image: gcr.io/kaniko-project/executor
-    ImageVersion: v1.5.2
-    ResourceRequestsLimits:
-      Requests:
-        CPU: "1"
-        Memory: 1Gi
-      Limits:
-        CPU: "1"
-        Memory: 1Gi
-  DefaultConfigurations:
-    SparkConfigAnnotations:
-      "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
-    BatchEnsemblingJobResources:
-      DriverCPURequest: "1"
-      DriverMemoryRequest: "1Gi"
-      ExecutorReplica: 2
-      ExecutorCPURequest: "1"
-      ExecutorMemoryRequest: "1Gi"
 KubernetesLabelConfigs:
   Environment: dev
 SparkAppConfig:

--- a/api/config-dev.yaml
+++ b/api/config-dev.yaml
@@ -1,4 +1,4 @@
-BatchEnsemblerConfig:
+BatchEnsemblingConfig:
   Enabled: true
   JobConfig:
     DefaultEnvironment: dev

--- a/api/turing/api/appcontext.go
+++ b/api/turing/api/appcontext.go
@@ -86,13 +86,17 @@ func NewAppContext(
 		return nil, errors.Wrapf(err, "Failed initializing cluster controllers")
 	}
 
-	// Initialise Ensembling Job Service
-	ensemblingJobService := service.NewEnsemblingJobService(db, cfg.EnsemblingJobConfig.DefaultEnvironment)
-
 	// Initialise Labeller
 	labeller.InitKubernetesLabeller(
 		cfg.KubernetesLabelConfigs.LabelPrefix,
 		cfg.KubernetesLabelConfigs.Environment,
+	)
+
+	// Initialise Ensembling Job Service
+	ensemblingJobService := service.NewEnsemblingJobService(
+		db,
+		cfg.EnsemblingJobConfig.DefaultEnvironment,
+		cfg.EnsemblingJobConfig.DefaultConfigurations,
 	)
 
 	// Initialise Batch components
@@ -101,7 +105,7 @@ func NewAppContext(
 
 	if cfg.EnsemblingJobConfig.Enabled {
 		batchClusterController := clusterControllers[cfg.EnsemblingJobConfig.DefaultEnvironment]
-		ensemblingImageBuilder, err := imagebuilder.NewEnsemberJobImageBuilder(
+		ensemblingImageBuilder, err := imagebuilder.NewEnsemblerJobImageBuilder(
 			batchClusterController,
 			cfg.EnsemblingJobConfig.ImageBuilderConfig,
 			cfg.EnsemblingJobConfig.KanikoConfig,

--- a/api/turing/api/appcontext.go
+++ b/api/turing/api/appcontext.go
@@ -95,20 +95,20 @@ func NewAppContext(
 	// Initialise Ensembling Job Service
 	ensemblingJobService := service.NewEnsemblingJobService(
 		db,
-		cfg.BatchEnsemblerConfig.JobConfig.DefaultEnvironment,
-		cfg.BatchEnsemblerConfig.JobConfig.DefaultConfigurations,
+		cfg.BatchEnsemblingConfig.JobConfig.DefaultEnvironment,
+		cfg.BatchEnsemblingConfig.JobConfig.DefaultConfigurations,
 	)
 
 	// Initialise Batch components
 	// Since there is only the default environment, we will not create multiple batch runners.
 	var batchJobRunners []batchrunner.BatchJobRunner
 
-	if cfg.BatchEnsemblerConfig.Enabled {
-		batchClusterController := clusterControllers[cfg.BatchEnsemblerConfig.JobConfig.DefaultEnvironment]
+	if cfg.BatchEnsemblingConfig.Enabled {
+		batchClusterController := clusterControllers[cfg.BatchEnsemblingConfig.JobConfig.DefaultEnvironment]
 		ensemblingImageBuilder, err := imagebuilder.NewEnsemblerJobImageBuilder(
 			batchClusterController,
-			cfg.BatchEnsemblerConfig.ImageBuildingConfig.ImageConfig,
-			cfg.BatchEnsemblerConfig.ImageBuildingConfig.KanikoConfig,
+			cfg.BatchEnsemblingConfig.ImageBuildingConfig.ImageConfig,
+			cfg.BatchEnsemblingConfig.ImageBuildingConfig.KanikoConfig,
 		)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed initializing ensembling image builder")
@@ -125,10 +125,10 @@ func NewAppContext(
 			ensemblingJobService,
 			mlpSvc,
 			ensemblingImageBuilder,
-			cfg.BatchEnsemblerConfig.RunnerConfig.RecordsToProcessInOneIteration,
-			cfg.BatchEnsemblerConfig.RunnerConfig.MaxRetryCount,
-			cfg.BatchEnsemblerConfig.ImageBuildingConfig.ImageConfig.BuildTimeoutDuration,
-			cfg.BatchEnsemblerConfig.RunnerConfig.TimeInterval,
+			cfg.BatchEnsemblingConfig.RunnerConfig.RecordsToProcessInOneIteration,
+			cfg.BatchEnsemblingConfig.RunnerConfig.MaxRetryCount,
+			cfg.BatchEnsemblingConfig.ImageBuildingConfig.ImageConfig.BuildTimeoutDuration,
+			cfg.BatchEnsemblingConfig.RunnerConfig.TimeInterval,
 		)
 		batchJobRunners = append(batchJobRunners, batchEnsemblingJobRunner)
 	}

--- a/api/turing/api/appcontext.go
+++ b/api/turing/api/appcontext.go
@@ -107,8 +107,7 @@ func NewAppContext(
 		batchClusterController := clusterControllers[cfg.BatchEnsemblingConfig.JobConfig.DefaultEnvironment]
 		ensemblingImageBuilder, err := imagebuilder.NewEnsemblerJobImageBuilder(
 			batchClusterController,
-			cfg.BatchEnsemblingConfig.ImageBuildingConfig.ImageConfig,
-			cfg.BatchEnsemblingConfig.ImageBuildingConfig.KanikoConfig,
+			cfg.BatchEnsemblingConfig.ImageBuildingConfig,
 		)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed initializing ensembling image builder")
@@ -127,7 +126,7 @@ func NewAppContext(
 			ensemblingImageBuilder,
 			cfg.BatchEnsemblingConfig.RunnerConfig.RecordsToProcessInOneIteration,
 			cfg.BatchEnsemblingConfig.RunnerConfig.MaxRetryCount,
-			cfg.BatchEnsemblingConfig.ImageBuildingConfig.ImageConfig.BuildTimeoutDuration,
+			cfg.BatchEnsemblingConfig.ImageBuildingConfig.BuildTimeoutDuration,
 			cfg.BatchEnsemblingConfig.RunnerConfig.TimeInterval,
 		)
 		batchJobRunners = append(batchJobRunners, batchEnsemblingJobRunner)

--- a/api/turing/api/appcontext.go
+++ b/api/turing/api/appcontext.go
@@ -95,20 +95,20 @@ func NewAppContext(
 	// Initialise Ensembling Job Service
 	ensemblingJobService := service.NewEnsemblingJobService(
 		db,
-		cfg.EnsemblingJobConfig.DefaultEnvironment,
-		cfg.EnsemblingJobConfig.DefaultConfigurations,
+		cfg.BatchEnsemblerConfig.JobConfig.DefaultEnvironment,
+		cfg.BatchEnsemblerConfig.JobConfig.DefaultConfigurations,
 	)
 
 	// Initialise Batch components
 	// Since there is only the default environment, we will not create multiple batch runners.
 	var batchJobRunners []batchrunner.BatchJobRunner
 
-	if cfg.EnsemblingJobConfig.Enabled {
-		batchClusterController := clusterControllers[cfg.EnsemblingJobConfig.DefaultEnvironment]
+	if cfg.BatchEnsemblerConfig.Enabled {
+		batchClusterController := clusterControllers[cfg.BatchEnsemblerConfig.JobConfig.DefaultEnvironment]
 		ensemblingImageBuilder, err := imagebuilder.NewEnsemblerJobImageBuilder(
 			batchClusterController,
-			cfg.EnsemblingJobConfig.ImageBuilderConfig,
-			cfg.EnsemblingJobConfig.KanikoConfig,
+			cfg.BatchEnsemblerConfig.ImageBuildingConfig.ImageConfig,
+			cfg.BatchEnsemblerConfig.ImageBuildingConfig.KanikoConfig,
 		)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed initializing ensembling image builder")
@@ -125,9 +125,10 @@ func NewAppContext(
 			ensemblingJobService,
 			mlpSvc,
 			ensemblingImageBuilder,
-			cfg.EnsemblingJobConfig.RecordsToProcessInOneIteration,
-			cfg.EnsemblingJobConfig.MaxRetryCount,
-			cfg.EnsemblingJobConfig.ImageBuilderConfig.BuildTimeoutDuration,
+			cfg.BatchEnsemblerConfig.RunnerConfig.RecordsToProcessInOneIteration,
+			cfg.BatchEnsemblerConfig.RunnerConfig.MaxRetryCount,
+			cfg.BatchEnsemblerConfig.ImageBuildingConfig.ImageConfig.BuildTimeoutDuration,
+			cfg.BatchEnsemblerConfig.RunnerConfig.TimeInterval,
 		)
 		batchJobRunners = append(batchJobRunners, batchEnsemblingJobRunner)
 	}

--- a/api/turing/api/appcontext_test.go
+++ b/api/turing/api/appcontext_test.go
@@ -69,6 +69,7 @@ func TestNewAppContext(t *testing.T) {
 			MaxMemory:       config.Quantity(resource.MustParse("100Mi")),
 		},
 		EnsemblingJobConfig: &config.EnsemblingJobConfig{
+			Enabled:                        true,
 			DefaultEnvironment:             "dev",
 			RecordsToProcessInOneIteration: 10,
 			MaxRetryCount:                  3,

--- a/api/turing/api/appcontext_test.go
+++ b/api/turing/api/appcontext_test.go
@@ -47,7 +47,7 @@ func TestNewAppContext(t *testing.T) {
 
 	testCfg := &config.Config{
 		Port: 8080,
-		BatchEnsemblerConfig: &config.BatchEnsemblerConfig{
+		BatchEnsemblingConfig: &config.BatchEnsemblingConfig{
 			Enabled: true,
 			JobConfig: config.JobConfig{
 				DefaultEnvironment: "dev",
@@ -272,15 +272,15 @@ func TestNewAppContext(t *testing.T) {
 
 	ensemblingImageBuilder, err := imagebuilder.NewEnsemblerJobImageBuilder(
 		nil,
-		testCfg.BatchEnsemblerConfig.ImageBuildingConfig.ImageConfig,
-		testCfg.BatchEnsemblerConfig.ImageBuildingConfig.KanikoConfig,
+		testCfg.BatchEnsemblingConfig.ImageBuildingConfig.ImageConfig,
+		testCfg.BatchEnsemblingConfig.ImageBuildingConfig.KanikoConfig,
 	)
 	assert.Nil(t, err)
 
 	ensemblingJobService := service.NewEnsemblingJobService(
 		nil,
-		testCfg.BatchEnsemblerConfig.JobConfig.DefaultEnvironment,
-		testCfg.BatchEnsemblerConfig.JobConfig.DefaultConfigurations,
+		testCfg.BatchEnsemblingConfig.JobConfig.DefaultEnvironment,
+		testCfg.BatchEnsemblingConfig.JobConfig.DefaultConfigurations,
 	)
 	batchEnsemblingController := batchensembling.NewBatchEnsemblingController(
 		nil,
@@ -292,10 +292,10 @@ func TestNewAppContext(t *testing.T) {
 		ensemblingJobService,
 		mlpSvc,
 		ensemblingImageBuilder,
-		testCfg.BatchEnsemblerConfig.RunnerConfig.RecordsToProcessInOneIteration,
-		testCfg.BatchEnsemblerConfig.RunnerConfig.MaxRetryCount,
-		testCfg.BatchEnsemblerConfig.ImageBuildingConfig.ImageConfig.BuildTimeoutDuration,
-		testCfg.BatchEnsemblerConfig.RunnerConfig.TimeInterval,
+		testCfg.BatchEnsemblingConfig.RunnerConfig.RecordsToProcessInOneIteration,
+		testCfg.BatchEnsemblingConfig.RunnerConfig.MaxRetryCount,
+		testCfg.BatchEnsemblingConfig.ImageBuildingConfig.ImageConfig.BuildTimeoutDuration,
+		testCfg.BatchEnsemblingConfig.RunnerConfig.TimeInterval,
 	)
 
 	assert.Equal(t, &AppContext{

--- a/api/turing/api/appcontext_test.go
+++ b/api/turing/api/appcontext_test.go
@@ -70,17 +70,15 @@ func TestNewAppContext(t *testing.T) {
 				MaxRetryCount:                  3,
 			},
 			ImageBuildingConfig: config.ImageBuildingConfig{
-				ImageConfig: config.ImageConfig{
-					Registry:             "ghcr.io",
-					BaseImageRef:         "ghcr.io/gojek/turing/batch-ensembler:0.0.0-build.1-98b071d",
-					BuildNamespace:       "default",
-					BuildContextURI:      "git://github.com/gojek/turing.git#refs/heads/master",
-					DockerfileFilePath:   "engines/batch-ensembler/app.Dockerfile",
-					BuildTimeoutDuration: 10 * time.Minute,
-				},
+				DestinationRegistry:  "ghcr.io",
+				BaseImageRef:         "ghcr.io/gojek/turing/batch-ensembler:0.0.0-build.1-98b071d",
+				BuildNamespace:       "default",
+				BuildTimeoutDuration: 10 * time.Minute,
 				KanikoConfig: config.KanikoConfig{
-					Image:        "gcr.io/kaniko-project/executor",
-					ImageVersion: "v1.5.2",
+					BuildContextURI:    "git://github.com/gojek/turing.git#refs/heads/master",
+					DockerfileFilePath: "engines/batch-ensembler/app.Dockerfile",
+					Image:              "gcr.io/kaniko-project/executor",
+					ImageVersion:       "v1.5.2",
 					ResourceRequestsLimits: config.ResourceRequestsLimits{
 						Requests: config.Resource{
 							CPU:    "500m",
@@ -272,8 +270,7 @@ func TestNewAppContext(t *testing.T) {
 
 	ensemblingImageBuilder, err := imagebuilder.NewEnsemblerJobImageBuilder(
 		nil,
-		testCfg.BatchEnsemblingConfig.ImageBuildingConfig.ImageConfig,
-		testCfg.BatchEnsemblingConfig.ImageBuildingConfig.KanikoConfig,
+		testCfg.BatchEnsemblingConfig.ImageBuildingConfig,
 	)
 	assert.Nil(t, err)
 
@@ -294,7 +291,7 @@ func TestNewAppContext(t *testing.T) {
 		ensemblingImageBuilder,
 		testCfg.BatchEnsemblingConfig.RunnerConfig.RecordsToProcessInOneIteration,
 		testCfg.BatchEnsemblingConfig.RunnerConfig.MaxRetryCount,
-		testCfg.BatchEnsemblingConfig.ImageBuildingConfig.ImageConfig.BuildTimeoutDuration,
+		testCfg.BatchEnsemblingConfig.ImageBuildingConfig.BuildTimeoutDuration,
 		testCfg.BatchEnsemblingConfig.RunnerConfig.TimeInterval,
 	)
 

--- a/api/turing/api/appcontext_test.go
+++ b/api/turing/api/appcontext_test.go
@@ -35,6 +35,7 @@ func (c *MockVaultClient) GetClusterSecret(clusterName string) (*vault.ClusterSe
 
 func TestNewAppContext(t *testing.T) {
 	// Create test config
+	tolerationName := "batch-job"
 	timeout, _ := time.ParseDuration("10s")
 	delTimeout, _ := time.ParseDuration("1s")
 
@@ -115,7 +116,7 @@ func TestNewAppContext(t *testing.T) {
 			CorePerCPURequest:              1.5,
 			CPURequestToCPULimit:           1.25,
 			SparkVersion:                   "2.4.5",
-			TolerationName:                 "batch-job",
+			TolerationName:                 &tolerationName,
 			SubmissionFailureRetries:       3,
 			SubmissionFailureRetryInterval: 10,
 			FailureRetries:                 3,

--- a/api/turing/batch/ensembling/controller_test.go
+++ b/api/turing/batch/ensembling/controller_test.go
@@ -31,6 +31,7 @@ var (
 	standardLabels map[string]string = map[string]string{
 		"model": "T800",
 	}
+	tolerationName                          = "batch-job"
 	sparkInfraConfig *config.SparkAppConfig = &config.SparkAppConfig{
 		NodeSelector: map[string]string{
 			"node-workload-type": "batch",
@@ -38,7 +39,7 @@ var (
 		CorePerCPURequest:              1.5,
 		CPURequestToCPULimit:           1.25,
 		SparkVersion:                   "2.4.5",
-		TolerationName:                 "batch-job",
+		TolerationName:                 &tolerationName,
 		SubmissionFailureRetries:       3,
 		SubmissionFailureRetryInterval: 10,
 		FailureRetries:                 3,

--- a/api/turing/batch/ensembling/runner.go
+++ b/api/turing/batch/ensembling/runner.go
@@ -22,6 +22,7 @@ type ensemblingJobRunner struct {
 	recordsToProcessInOneIteration int
 	maxRetryCount                  int
 	imageBuildTimeoutDuration      time.Duration
+	timeInterval                   time.Duration
 }
 
 // NewBatchEnsemblingJobRunner creates a new batch ensembling job runner
@@ -34,6 +35,7 @@ func NewBatchEnsemblingJobRunner(
 	recordsToProcessInOneIteration int,
 	maxRetryCount int,
 	imageBuildTimeoutDuration time.Duration,
+	timeInterval time.Duration,
 ) batchrunner.BatchJobRunner {
 	return &ensemblingJobRunner{
 		ensemblingController:           ensemblingController,
@@ -43,7 +45,12 @@ func NewBatchEnsemblingJobRunner(
 		recordsToProcessInOneIteration: recordsToProcessInOneIteration,
 		maxRetryCount:                  maxRetryCount,
 		imageBuildTimeoutDuration:      imageBuildTimeoutDuration,
+		timeInterval:                   timeInterval,
 	}
+}
+
+func (r *ensemblingJobRunner) GetInterval() time.Duration {
+	return r.timeInterval
 }
 
 func (r *ensemblingJobRunner) Run() {

--- a/api/turing/batch/ensembling/runner_test.go
+++ b/api/turing/batch/ensembling/runner_test.go
@@ -248,6 +248,7 @@ func TestRun(t *testing.T) {
 				10,
 				3,
 				10*time.Minute,
+				10*time.Second,
 			)
 			r.Run()
 		})

--- a/api/turing/batch/runner/base.go
+++ b/api/turing/batch/runner/base.go
@@ -7,14 +7,17 @@ import (
 // BatchJobRunner is an interface that exposes the batch processes.
 type BatchJobRunner interface {
 	Run()
+	GetInterval() time.Duration
 }
 
 // RunBatchRunners will run all runners asynchronously.
-func RunBatchRunners(interval time.Duration, runners []BatchJobRunner) {
-	for {
-		for _, runner := range runners {
-			go runner.Run()
-		}
-		time.Sleep(interval)
+func RunBatchRunners(runners []BatchJobRunner) {
+	for _, runner := range runners {
+		go func(runner BatchJobRunner) {
+			for {
+				runner.Run()
+				time.Sleep(runner.GetInterval())
+			}
+		}(runner)
 	}
 }

--- a/api/turing/cluster/spark.go
+++ b/api/turing/cluster/spark.go
@@ -86,7 +86,6 @@ type CreateSparkRequest struct {
 	ExecutorReplica       int32
 	ServiceAccountName    string
 	SparkInfraConfig      *config.SparkAppConfig
-	TaintKey              *string
 }
 
 func createSparkRequest(request *CreateSparkRequest) (*apisparkv1beta2.SparkApplication, error) {
@@ -166,10 +165,10 @@ func createSparkExecutor(request *CreateSparkRequest) (*apisparkv1beta2.Executor
 			Labels: request.JobLabels,
 		},
 	}
-	if request.TaintKey != nil {
+	if request.SparkInfraConfig.TolerationName != nil {
 		s.SparkPodSpec.Tolerations = []apicorev1.Toleration{
 			{
-				Key:      *request.TaintKey,
+				Key:      *request.SparkInfraConfig.TolerationName,
 				Operator: apicorev1.TolerationOpEqual,
 				Value:    "true",
 				Effect:   apicorev1.TaintEffectNoSchedule,
@@ -224,10 +223,10 @@ func createSparkDriver(request *CreateSparkRequest) (*apisparkv1beta2.DriverSpec
 		},
 		ServiceAccount: &request.ServiceAccountName,
 	}
-	if request.TaintKey != nil {
+	if request.SparkInfraConfig.TolerationName != nil {
 		s.SparkPodSpec.Tolerations = []apicorev1.Toleration{
 			{
-				Key:      *request.TaintKey,
+				Key:      *request.SparkInfraConfig.TolerationName,
 				Operator: apicorev1.TolerationOpEqual,
 				Value:    "true",
 				Effect:   apicorev1.TaintEffectNoSchedule,

--- a/api/turing/cluster/spark_test.go
+++ b/api/turing/cluster/spark_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var (
+	tolerationName                          = "batch-job"
 	sparkInfraConfig *config.SparkAppConfig = &config.SparkAppConfig{
 		NodeSelector: map[string]string{
 			"node-workload-type": "batch",
@@ -20,7 +21,7 @@ var (
 		CorePerCPURequest:              1.0,
 		CPURequestToCPULimit:           1.0,
 		SparkVersion:                   "2.4.5",
-		TolerationName:                 "batch-job",
+		TolerationName:                 &tolerationName,
 		SubmissionFailureRetries:       3,
 		SubmissionFailureRetryInterval: 10,
 		FailureRetries:                 3,
@@ -132,7 +133,6 @@ var (
 	serviceAccountName       = "service-account"
 	jobLabels                = make(map[string]string)
 	memoryResult, _          = toMegabyte(memoryValue)
-	taintKey                 = "batch-job"
 )
 
 func TestCreateSparkRequest(t *testing.T) {
@@ -150,7 +150,6 @@ func TestCreateSparkRequest(t *testing.T) {
 		ExecutorReplica:       executorReplica,
 		ServiceAccountName:    serviceAccountName,
 		SparkInfraConfig:      sparkInfraConfig,
-		TaintKey:              &taintKey,
 	}
 	expected := &apisparkv1beta2.SparkApplication{
 		ObjectMeta: apimetav1.ObjectMeta{

--- a/api/turing/cmd/main.go
+++ b/api/turing/cmd/main.go
@@ -109,10 +109,7 @@ func main() {
 	}
 
 	// Run batch runners
-	go batchrunner.RunBatchRunners(
-		cfg.BatchRunnerConfig.TimeInterval,
-		appCtx.BatchRunners,
-	)
+	go batchrunner.RunBatchRunners(appCtx.BatchRunners)
 
 	// Register handlers
 	health := healthcheck.NewHandler()

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	Port                   int `validate:"required"`
 	AllowedOrigins         []string
 	AuthConfig             *AuthorizationConfig
-	BatchEnsemblerConfig   *BatchEnsemblerConfig   `validate:"required"`
+	BatchEnsemblingConfig  *BatchEnsemblingConfig  `validate:"required"`
 	DbConfig               *DatabaseConfig         `validate:"required"`
 	DeployConfig           *DeploymentConfig       `validate:"required"`
 	SparkAppConfig         *SparkAppConfig         `validate:"required"`
@@ -93,8 +93,8 @@ func (c *Config) Validate() error {
 	return validate.Struct(c)
 }
 
-// BatchEnsemblerConfig captures the config related to the running of batch runners
-type BatchEnsemblerConfig struct {
+// BatchEnsemblingConfig captures the config related to the running of batch runners
+type BatchEnsemblingConfig struct {
 	Enabled             bool                `validate:"required"`
 	JobConfig           JobConfig           `validate:"required"`
 	RunnerConfig        RunnerConfig        `validate:"required"`

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -125,6 +125,8 @@ type KubernetesLabelConfigs struct {
 
 // EnsemblingJobConfig captures the config related to the ensembling batch jobs.
 type EnsemblingJobConfig struct {
+	// Enabled is a switch to enable/disable batch ensembling.
+	Enabled bool
 	// RecordsToProcessInOneIteration dictates the number of batch ensembling jobs to be queried at once.
 	RecordsToProcessInOneIteration int `validate:"required"`
 	// MaxRetryCount is the number of retries the batch ensembler runner should try before giving up.

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -193,14 +193,13 @@ type SparkAppConfig struct {
 	CorePerCPURequest              float64 `validate:"required"`
 	CPURequestToCPULimit           float64 `validate:"required"`
 	SparkVersion                   string  `validate:"required"`
-	TolerationName                 string  `validate:"required"`
-	SubmissionFailureRetries       int32   `validate:"required"`
-	SubmissionFailureRetryInterval int64   `validate:"required"`
-	FailureRetries                 int32   `validate:"required"`
-	FailureRetryInterval           int64   `validate:"required"`
-	PythonVersion                  string  `validate:"required"`
-	TTLSecond                      int64   `validate:"required"`
-	TaintKey                       *string
+	TolerationName                 *string
+	SubmissionFailureRetries       int32  `validate:"required"`
+	SubmissionFailureRetryInterval int64  `validate:"required"`
+	FailureRetries                 int32  `validate:"required"`
+	FailureRetryInterval           int64  `validate:"required"`
+	PythonVersion                  string `validate:"required"`
+	TTLSecond                      int64  `validate:"required"`
 }
 
 // TuringUIConfig captures config related to serving Turing UI files

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -130,28 +130,16 @@ type RunnerConfig struct {
 
 // ImageBuildingConfig contains the information regarding the image builder and the image buildee.
 type ImageBuildingConfig struct {
-	// ImageConfig contains the configuration related to the image buildee.
-	ImageConfig ImageConfig `validate:"required"`
-	// KanikoConfig contains the configuration related to the kaniko executor image builder.
-	KanikoConfig KanikoConfig `validate:"required"`
-}
-
-// ImageConfig provides the configuration used for the OCI image building.
-// The details here contain the details pertaining to the ensembler image and not the kaniko image.
-type ImageConfig struct {
-	// Registry is the registry of the newly built ensembler image.
-	Registry string `validate:"required"`
-	// BaseImageRef is the image name of the base ensembler image based on engines/batch-ensembler/Dockerfile.
-	BaseImageRef string `validate:"required"`
 	// BuildNamespace contains the Kubernetes namespace it should be built in.
 	BuildNamespace string `validate:"required"`
-	// BuildContextURI contains the image build context, which should be engines/batch-ensembler/
-	// The forms supported are listed here https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts
-	BuildContextURI string `validate:"required"`
-	// DockerfileFilePath contains where the Dockerfile is
-	DockerfileFilePath string `validate:"required"`
 	// BuildTimeoutDuration is the Kubernetes Job timeout duration.
 	BuildTimeoutDuration time.Duration `validate:"required"`
+	// DestinationRegistry is the registry of the newly built ensembler image.
+	DestinationRegistry string `validate:"required"`
+	// BaseImageRef is the image name of the base ensembler image based on engines/batch-ensembler/Dockerfile.
+	BaseImageRef string `validate:"required"`
+	// KanikoConfig contains the configuration related to the kaniko executor image builder.
+	KanikoConfig KanikoConfig `validate:"required"`
 }
 
 // Resource contains the Kubernetes resource request and limits
@@ -168,8 +156,16 @@ type ResourceRequestsLimits struct {
 
 // KanikoConfig provides the configuration used for the Kaniko image.
 type KanikoConfig struct {
-	Image                  string                 `validate:"required"`
-	ImageVersion           string                 `validate:"required"`
+	// BuildContextURI contains the image build context, which should be engines/batch-ensembler/
+	// The forms supported are listed here https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts
+	BuildContextURI string `validate:"required"`
+	// DockerfileFilePath contains where the Dockerfile is
+	DockerfileFilePath string `validate:"required"`
+	// Image is the Kaniko image
+	Image string `validate:"required"`
+	// ImageVersion is the version tag of the Kaniko image
+	ImageVersion string `validate:"required"`
+	// ResourceRequestsLimits is the resources required by Kaniko executor.
 	ResourceRequestsLimits ResourceRequestsLimits `validate:"required"`
 }
 

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -512,8 +512,52 @@ func TestConfigValidate(t *testing.T) {
 	tolerationName := "batch-job"
 	validConfig := Config{
 		Port: 5000,
-		BatchRunnerConfig: &BatchRunnerConfig{
-			TimeInterval: 3 * time.Minute,
+		BatchEnsemblerConfig: &BatchEnsemblerConfig{
+			Enabled: true,
+			JobConfig: JobConfig{
+				DefaultEnvironment: "dev",
+				DefaultConfigurations: DefaultEnsemblingJobConfigurations{
+					BatchEnsemblingJobResources: openapi.EnsemblingResources{
+						DriverCpuRequest:      &driverCPURequest,
+						DriverMemoryRequest:   &driverMemoryRequest,
+						ExecutorReplica:       &executorReplica,
+						ExecutorCpuRequest:    &executorCPURequest,
+						ExecutorMemoryRequest: &executorMemoryRequest,
+					},
+					SparkConfigAnnotations: map[string]string{
+						"spark/spark.sql.execution.arrow.pyspark.enabled": "true",
+					},
+				},
+			},
+			RunnerConfig: RunnerConfig{
+				TimeInterval:                   3 * time.Minute,
+				RecordsToProcessInOneIteration: 10,
+				MaxRetryCount:                  3,
+			},
+			ImageBuildingConfig: ImageBuildingConfig{
+				ImageConfig: ImageConfig{
+					Registry:             "ghcr.io",
+					BaseImageRef:         "ghcr.io/gojek/turing/batch-ensembler:0.0.0-build.1-98b071d",
+					BuildNamespace:       "default",
+					BuildContextURI:      "git://github.com/gojek/turing.git#refs/heads/master",
+					DockerfileFilePath:   "engines/batch-ensembler/app.Dockerfile",
+					BuildTimeoutDuration: 10 * time.Minute,
+				},
+				KanikoConfig: KanikoConfig{
+					Image:        "gcr.io/kaniko-project/executor",
+					ImageVersion: "v1.5.2",
+					ResourceRequestsLimits: ResourceRequestsLimits{
+						Requests: Resource{
+							CPU:    "500m",
+							Memory: "1Gi",
+						},
+						Limits: Resource{
+							CPU:    "500m",
+							Memory: "1Gi",
+						},
+					},
+				},
+			},
 		},
 		DbConfig: &DatabaseConfig{
 			Host:     "localhost",
@@ -528,46 +572,6 @@ func TestConfigValidate(t *testing.T) {
 			DeletionTimeout: 1 * time.Minute,
 			MaxCPU:          Quantity(resource.MustParse("2")),
 			MaxMemory:       Quantity(resource.MustParse("8Gi")),
-		},
-		EnsemblingJobConfig: &EnsemblingJobConfig{
-			Enabled:                        true,
-			DefaultEnvironment:             "dev",
-			RecordsToProcessInOneIteration: 10,
-			MaxRetryCount:                  3,
-			ImageBuilderConfig: ImageBuilderConfig{
-				Registry:             "ghcr.io",
-				BaseImageRef:         "ghcr.io/gojek/turing/batch-ensembler:0.0.0-build.1-98b071d",
-				BuildNamespace:       "default",
-				BuildContextURI:      "git://github.com/gojek/turing.git#refs/heads/master",
-				DockerfileFilePath:   "engines/batch-ensembler/app.Dockerfile",
-				BuildTimeoutDuration: 10 * time.Minute,
-			},
-			KanikoConfig: KanikoConfig{
-				Image:        "gcr.io/kaniko-project/executor",
-				ImageVersion: "v1.5.2",
-				ResourceRequestsLimits: ResourceRequestsLimits{
-					Requests: Resource{
-						CPU:    "500m",
-						Memory: "1Gi",
-					},
-					Limits: Resource{
-						CPU:    "500m",
-						Memory: "1Gi",
-					},
-				},
-			},
-			DefaultConfigurations: DefaultEnsemblingJobConfigurations{
-				BatchEnsemblingJobResources: openapi.EnsemblingResources{
-					DriverCpuRequest:      &driverCPURequest,
-					DriverMemoryRequest:   &driverMemoryRequest,
-					ExecutorReplica:       &executorReplica,
-					ExecutorCpuRequest:    &executorCPURequest,
-					ExecutorMemoryRequest: &executorMemoryRequest,
-				},
-				SparkConfigAnnotations: map[string]string{
-					"spark/spark.sql.execution.arrow.pyspark.enabled": "true",
-				},
-			},
 		},
 		SparkAppConfig: &SparkAppConfig{
 			NodeSelector: map[string]string{
@@ -674,7 +678,7 @@ func TestConfigValidate(t *testing.T) {
 		},
 		"missing ensembling job default environment": {
 			validConfigUpdate: func(validConfig Config) Config {
-				validConfig.EnsemblingJobConfig.DefaultEnvironment = ""
+				validConfig.BatchEnsemblerConfig.JobConfig.DefaultEnvironment = ""
 				return validConfig
 			},
 			wantErr: true,
@@ -688,7 +692,7 @@ func TestConfigValidate(t *testing.T) {
 		},
 		"missing batch runner config": {
 			validConfigUpdate: func(validConfig Config) Config {
-				validConfig.BatchRunnerConfig = nil
+				validConfig.BatchEnsemblerConfig = nil
 				return validConfig
 			},
 			wantErr: true,

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -509,7 +509,7 @@ func TestConfigValidate(t *testing.T) {
 	var executorReplica int32 = 2
 	executorCPURequest := "1"
 	executorMemoryRequest := "1Gi"
-
+	tolerationName := "batch-job"
 	validConfig := Config{
 		Port: 5000,
 		BatchRunnerConfig: &BatchRunnerConfig{
@@ -576,7 +576,7 @@ func TestConfigValidate(t *testing.T) {
 			CorePerCPURequest:              1.5,
 			CPURequestToCPULimit:           1.25,
 			SparkVersion:                   "2.4.5",
-			TolerationName:                 "batch-job",
+			TolerationName:                 &tolerationName,
 			SubmissionFailureRetries:       3,
 			SubmissionFailureRetryInterval: 10,
 			FailureRetries:                 3,

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -535,17 +535,15 @@ func TestConfigValidate(t *testing.T) {
 				MaxRetryCount:                  3,
 			},
 			ImageBuildingConfig: ImageBuildingConfig{
-				ImageConfig: ImageConfig{
-					Registry:             "ghcr.io",
-					BaseImageRef:         "ghcr.io/gojek/turing/batch-ensembler:0.0.0-build.1-98b071d",
-					BuildNamespace:       "default",
-					BuildContextURI:      "git://github.com/gojek/turing.git#refs/heads/master",
-					DockerfileFilePath:   "engines/batch-ensembler/app.Dockerfile",
-					BuildTimeoutDuration: 10 * time.Minute,
-				},
+				DestinationRegistry:  "ghcr.io",
+				BaseImageRef:         "ghcr.io/gojek/turing/batch-ensembler:0.0.0-build.1-98b071d",
+				BuildNamespace:       "default",
+				BuildTimeoutDuration: 10 * time.Minute,
 				KanikoConfig: KanikoConfig{
-					Image:        "gcr.io/kaniko-project/executor",
-					ImageVersion: "v1.5.2",
+					BuildContextURI:    "git://github.com/gojek/turing.git#refs/heads/master",
+					DockerfileFilePath: "engines/batch-ensembler/app.Dockerfile",
+					Image:              "gcr.io/kaniko-project/executor",
+					ImageVersion:       "v1.5.2",
 					ResourceRequestsLimits: ResourceRequestsLimits{
 						Requests: Resource{
 							CPU:    "500m",

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -530,6 +530,7 @@ func TestConfigValidate(t *testing.T) {
 			MaxMemory:       Quantity(resource.MustParse("8Gi")),
 		},
 		EnsemblingJobConfig: &EnsemblingJobConfig{
+			Enabled:                        true,
 			DefaultEnvironment:             "dev",
 			RecordsToProcessInOneIteration: 10,
 			MaxRetryCount:                  3,

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -512,7 +512,7 @@ func TestConfigValidate(t *testing.T) {
 	tolerationName := "batch-job"
 	validConfig := Config{
 		Port: 5000,
-		BatchEnsemblerConfig: &BatchEnsemblerConfig{
+		BatchEnsemblingConfig: &BatchEnsemblingConfig{
 			Enabled: true,
 			JobConfig: JobConfig{
 				DefaultEnvironment: "dev",
@@ -678,7 +678,7 @@ func TestConfigValidate(t *testing.T) {
 		},
 		"missing ensembling job default environment": {
 			validConfigUpdate: func(validConfig Config) Config {
-				validConfig.BatchEnsemblerConfig.JobConfig.DefaultEnvironment = ""
+				validConfig.BatchEnsemblingConfig.JobConfig.DefaultEnvironment = ""
 				return validConfig
 			},
 			wantErr: true,
@@ -692,7 +692,7 @@ func TestConfigValidate(t *testing.T) {
 		},
 		"missing batch runner config": {
 			validConfigUpdate: func(validConfig Config) Config {
-				validConfig.BatchEnsemblerConfig = nil
+				validConfig.BatchEnsemblingConfig = nil
 				return validConfig
 			},
 			wantErr: true,

--- a/api/turing/config/example.yaml
+++ b/api/turing/config/example.yaml
@@ -48,6 +48,7 @@ NewRelic:
 
 # Ensembling job config
 EnsemblingJobConfig:
+  Enabled: true
   DefaultEnvironment: dev
   RecordsToProcessInOneIteration: 10
   MaxRetryCount: 3

--- a/api/turing/config/example.yaml
+++ b/api/turing/config/example.yaml
@@ -11,10 +11,43 @@ AuthConfig:
   # ORY Keto auth server URL: https://github.com/ory/keto
   URL: http://example.com/auth
 
-# Batch runner configurations
+# Batch ensembler job configurations
 BatchRunnerConfig:
-  # How long to wait before running the runners again.
-  TimeInterval: 10s
+  Enabled: true
+  JobConfig:
+    DefaultEnvironment: dev
+    DefaultConfigurations:
+      SparkConfigAnnotations:
+        "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
+      BatchEnsemblingJobResources:
+        DriverCPURequest: "1"
+        DriverMemoryRequest: "1Gi"
+        ExecutorReplica: 2
+        ExecutorCPURequest: "1"
+        ExecutorMemoryRequest: "1Gi"
+  RunnerConfig:
+    # How long to wait before running the runners again.
+    TimeInterval: 10s
+    RecordsToProcessInOneIteration: 10
+    MaxRetryCount: 3
+  ImageBuildingConfig:
+    ImageConfig:
+      Registry: ghcr.io
+      BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
+      BuildNamespace: default
+      BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main
+      DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
+      BuildTimeoutDuration: 20m
+    KanikoConfig:
+      Image: gcr.io/kaniko-project/executor
+      ImageVersion: v1.5.2
+      ResourceRequestsLimits:
+        Requests:
+          CPU: "1"
+          Memory: 1Gi
+        Limits:
+          CPU: "1"
+          Memory: 1Gi
 
 # Postgresql connection and credentials
 DbConfig:
@@ -45,39 +78,6 @@ NewRelic:
     - 404
     - 405
     - 412
-
-# Ensembling job config
-EnsemblingJobConfig:
-  Enabled: true
-  DefaultEnvironment: dev
-  RecordsToProcessInOneIteration: 10
-  MaxRetryCount: 3
-  ImageBuilderConfig:
-    Registry: ghcr.io
-    BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
-    BuildNamespace: default
-    BuildContextURI: git://github.com/gojek/turing.git#refs/heads/master
-    DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
-    BuildTimeoutDuration: 10m
-  KanikoConfig:
-    Image: gcr.io/kaniko-project/executor
-    ImageVersion: v1.5.2
-    ResourceRequestsLimits:
-      Requests:
-        CPU: "1"
-        Memory: 1Gi
-      Limits:
-        CPU: "1"
-        Memory: 1Gi
-  DefaultConfigurations:
-    SparkConfigAnnotations:
-      "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
-    BatchEnsemblingJobResources:
-      DriverCPURequest: "1"
-      DriverMemoryRequest: "1Gi"
-      ExecutorReplica: 2
-      ExecutorCPURequest: "1"
-      ExecutorMemoryRequest: "1Gi"
 
 KubernetesLabelConfigs:
   # KubernetesLabelPrefix is the prefix used for tagging kubernetes components.

--- a/api/turing/config/example.yaml
+++ b/api/turing/config/example.yaml
@@ -12,7 +12,7 @@ AuthConfig:
   URL: http://example.com/auth
 
 # Batch ensembler job configurations
-BatchRunnerConfig:
+BatchEnsemblingConfig:
   Enabled: true
   JobConfig:
     DefaultEnvironment: dev

--- a/api/turing/config/example.yaml
+++ b/api/turing/config/example.yaml
@@ -102,6 +102,7 @@ SparkAppConfig:
   CorePerCPURequest: 1.5
   CPURequestToCPULimit: 1.25
   SparkVersion: "2.4.5"
+  TolerationName: batch-job
   SubmissionFailureRetries: 3
   SubmissionFailureRetryInterval: 10
   FailureRetries: 3

--- a/api/turing/config/example.yaml
+++ b/api/turing/config/example.yaml
@@ -31,16 +31,15 @@ BatchEnsemblingConfig:
     RecordsToProcessInOneIteration: 10
     MaxRetryCount: 3
   ImageBuildingConfig:
-    ImageConfig:
-      Registry: ghcr.io
-      BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
-      BuildNamespace: default
+    BuildNamespace: default
+    BuildTimeoutDuration: 20m
+    DestinationRegistry: ghcr.io
+    BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
+    KanikoConfig:
       BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main
       DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
-      BuildTimeoutDuration: 20m
-    KanikoConfig:
       Image: gcr.io/kaniko-project/executor
-      ImageVersion: v1.5.2
+      ImageVersion: v1.6.0
       ResourceRequestsLimits:
         Requests:
           CPU: "1"

--- a/api/turing/imagebuilder/ensembler.go
+++ b/api/turing/imagebuilder/ensembler.go
@@ -11,14 +11,12 @@ import (
 // NewEnsemblerJobImageBuilder create ImageBuilder for building docker image of prediction job (batch)
 func NewEnsemblerJobImageBuilder(
 	clusterController cluster.Controller,
-	imageConfig config.ImageConfig,
-	kanikoConfig config.KanikoConfig,
+	imageBuildingConfig config.ImageBuildingConfig,
 ) (ImageBuilder, error) {
 	return newImageBuilder(
 		clusterController,
-		imageConfig,
-		kanikoConfig,
-		&ensemblerJobNameGenerator{registry: imageConfig.Registry},
+		imageBuildingConfig,
+		&ensemblerJobNameGenerator{registry: imageBuildingConfig.DestinationRegistry},
 	)
 }
 

--- a/api/turing/imagebuilder/ensembler.go
+++ b/api/turing/imagebuilder/ensembler.go
@@ -11,7 +11,7 @@ import (
 // NewEnsemblerJobImageBuilder create ImageBuilder for building docker image of prediction job (batch)
 func NewEnsemblerJobImageBuilder(
 	clusterController cluster.Controller,
-	imageConfig config.ImageBuilderConfig,
+	imageConfig config.ImageConfig,
 	kanikoConfig config.KanikoConfig,
 ) (ImageBuilder, error) {
 	return newImageBuilder(

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -88,7 +88,7 @@ type nameGenerator interface {
 
 type imageBuilder struct {
 	clusterController cluster.Controller
-	imageConfig       config.ImageBuilderConfig
+	imageConfig       config.ImageConfig
 	kanikoConfig      config.KanikoConfig
 	nameGenerator     nameGenerator
 }
@@ -96,7 +96,7 @@ type imageBuilder struct {
 // NewImageBuilder creates a new ImageBuilder
 func newImageBuilder(
 	clusterController cluster.Controller,
-	imageConfig config.ImageBuilderConfig,
+	imageConfig config.ImageConfig,
 	kanikoConfig config.KanikoConfig,
 	nameGenerator nameGenerator,
 ) (ImageBuilder, error) {

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -87,29 +87,26 @@ type nameGenerator interface {
 }
 
 type imageBuilder struct {
-	clusterController cluster.Controller
-	imageConfig       config.ImageConfig
-	kanikoConfig      config.KanikoConfig
-	nameGenerator     nameGenerator
+	clusterController   cluster.Controller
+	imageBuildingConfig config.ImageBuildingConfig
+	nameGenerator       nameGenerator
 }
 
 // NewImageBuilder creates a new ImageBuilder
 func newImageBuilder(
 	clusterController cluster.Controller,
-	imageConfig config.ImageConfig,
-	kanikoConfig config.KanikoConfig,
+	imageBuildingConfig config.ImageBuildingConfig,
 	nameGenerator nameGenerator,
 ) (ImageBuilder, error) {
-	err := checkParseResources(kanikoConfig.ResourceRequestsLimits)
+	err := checkParseResources(imageBuildingConfig.KanikoConfig.ResourceRequestsLimits)
 	if err != nil {
 		return nil, ErrUnableToParseKanikoResource
 	}
 
 	return &imageBuilder{
-		clusterController: clusterController,
-		imageConfig:       imageConfig,
-		kanikoConfig:      kanikoConfig,
-		nameGenerator:     nameGenerator,
+		clusterController:   clusterController,
+		imageBuildingConfig: imageBuildingConfig,
+		nameGenerator:       nameGenerator,
 	}, nil
 }
 
@@ -134,7 +131,7 @@ func (ib *imageBuilder) BuildImage(request BuildImageRequest) (string, error) {
 		request.VersionID,
 	)
 	job, err := ib.clusterController.GetJob(
-		ib.imageConfig.BuildNamespace,
+		ib.imageBuildingConfig.BuildNamespace,
 		kanikoJobName,
 	)
 
@@ -153,7 +150,7 @@ func (ib *imageBuilder) BuildImage(request BuildImageRequest) (string, error) {
 		// Only recreate when job has failed too many times, else no action required and just wait for it to finish
 		if job.Status.Failed != 0 {
 			// job already created before so we have to delete it first if it failed
-			err = ib.clusterController.DeleteJob(ib.imageConfig.BuildNamespace, job.Name)
+			err = ib.clusterController.DeleteJob(ib.imageBuildingConfig.BuildNamespace, job.Name)
 			if err != nil {
 				log.Errorf("error deleting job: %v", err)
 				return "", ErrDeleteFailedJob
@@ -176,7 +173,7 @@ func (ib *imageBuilder) BuildImage(request BuildImageRequest) (string, error) {
 }
 
 func (ib *imageBuilder) waitForJobToFinish(job *apibatchv1.Job) error {
-	timeout := time.After(ib.imageConfig.BuildTimeoutDuration)
+	timeout := time.After(ib.imageBuildingConfig.BuildTimeoutDuration)
 	ticker := time.NewTicker(time.Second * tickDurationInSeconds)
 
 	for {
@@ -184,7 +181,7 @@ func (ib *imageBuilder) waitForJobToFinish(job *apibatchv1.Job) error {
 		case <-timeout:
 			return ErrTimeoutBuildingImage
 		case <-ticker.C:
-			j, err := ib.clusterController.GetJob(ib.imageConfig.BuildNamespace, job.Name)
+			j, err := ib.clusterController.GetJob(ib.imageBuildingConfig.BuildNamespace, job.Name)
 			if err != nil {
 				log.Errorf("unable to get job status for job %s: %v", job.Name, err)
 				return ErrUnableToBuildImage
@@ -211,10 +208,10 @@ func (ib *imageBuilder) createKanikoJob(
 	folderName := fmt.Sprintf("%s/%s", splitURI[len(splitURI)-1], service.EnsemblerFolder)
 
 	kanikoArgs := []string{
-		fmt.Sprintf("--dockerfile=%s", ib.imageConfig.DockerfileFilePath),
-		fmt.Sprintf("--context=%s", ib.imageConfig.BuildContextURI),
+		fmt.Sprintf("--dockerfile=%s", ib.imageBuildingConfig.KanikoConfig.DockerfileFilePath),
+		fmt.Sprintf("--context=%s", ib.imageBuildingConfig.KanikoConfig.BuildContextURI),
 		fmt.Sprintf("--build-arg=MODEL_URL=%s", artifactURI),
-		fmt.Sprintf("--build-arg=BASE_IMAGE=%s", ib.imageConfig.BaseImageRef),
+		fmt.Sprintf("--build-arg=BASE_IMAGE=%s", ib.imageBuildingConfig.BaseImageRef),
 		fmt.Sprintf("--build-arg=FOLDER_NAME=%s", folderName),
 		fmt.Sprintf("--destination=%s", imageRef),
 		"--cache=true",
@@ -223,7 +220,7 @@ func (ib *imageBuilder) createKanikoJob(
 
 	job := cluster.Job{
 		Name:                    kanikoJobName,
-		Namespace:               ib.imageConfig.BuildNamespace,
+		Namespace:               ib.imageBuildingConfig.BuildNamespace,
 		Labels:                  buildLabels,
 		Completions:             &jobCompletions,
 		BackOffLimit:            &jobBackOffLimit,
@@ -231,9 +228,13 @@ func (ib *imageBuilder) createKanikoJob(
 		RestartPolicy:           apicorev1.RestartPolicyNever,
 		Containers: []cluster.Container{
 			{
-				Name:  imageBuilderContainerName,
-				Image: fmt.Sprintf("%s:%s", ib.kanikoConfig.Image, ib.kanikoConfig.ImageVersion),
-				Args:  kanikoArgs,
+				Name: imageBuilderContainerName,
+				Image: fmt.Sprintf(
+					"%s:%s",
+					ib.imageBuildingConfig.KanikoConfig.Image,
+					ib.imageBuildingConfig.KanikoConfig.ImageVersion,
+				),
+				Args: kanikoArgs,
 				VolumeMounts: []cluster.VolumeMount{
 					{
 						Name:      kanikoSecretName,
@@ -248,12 +249,20 @@ func (ib *imageBuilder) createKanikoJob(
 				},
 				Resources: cluster.RequestLimitResources{
 					Request: cluster.Resource{
-						CPU:    resource.MustParse(ib.kanikoConfig.ResourceRequestsLimits.Requests.CPU),
-						Memory: resource.MustParse(ib.kanikoConfig.ResourceRequestsLimits.Requests.Memory),
+						CPU: resource.MustParse(
+							ib.imageBuildingConfig.KanikoConfig.ResourceRequestsLimits.Requests.CPU,
+						),
+						Memory: resource.MustParse(
+							ib.imageBuildingConfig.KanikoConfig.ResourceRequestsLimits.Requests.Memory,
+						),
 					},
 					Limit: cluster.Resource{
-						CPU:    resource.MustParse(ib.kanikoConfig.ResourceRequestsLimits.Limits.CPU),
-						Memory: resource.MustParse(ib.kanikoConfig.ResourceRequestsLimits.Limits.Memory),
+						CPU: resource.MustParse(
+							ib.imageBuildingConfig.KanikoConfig.ResourceRequestsLimits.Limits.CPU,
+						),
+						Memory: resource.MustParse(
+							ib.imageBuildingConfig.KanikoConfig.ResourceRequestsLimits.Limits.Memory,
+						),
 					},
 				},
 			},
@@ -267,7 +276,7 @@ func (ib *imageBuilder) createKanikoJob(
 	}
 
 	return ib.clusterController.CreateJob(
-		ib.imageConfig.BuildNamespace,
+		ib.imageBuildingConfig.BuildNamespace,
 		job,
 	)
 }
@@ -275,7 +284,7 @@ func (ib *imageBuilder) createKanikoJob(
 func (ib *imageBuilder) checkIfImageExists(imageName string, imageTag string) (bool, error) {
 	keychain := authn.DefaultKeychain
 
-	if strings.Contains(ib.imageConfig.Registry, "gcr.io") {
+	if strings.Contains(ib.imageBuildingConfig.DestinationRegistry, "gcr.io") {
 		keychain = google.Keychain
 	}
 
@@ -340,7 +349,7 @@ func (ib *imageBuilder) GetImageBuildingJobStatus(
 		versionID,
 	)
 	job, err := ib.clusterController.GetJob(
-		ib.imageConfig.BuildNamespace,
+		ib.imageBuildingConfig.BuildNamespace,
 		kanikoJobName,
 	)
 	if err != nil {
@@ -373,7 +382,7 @@ func (ib *imageBuilder) DeleteImageBuildingJob(
 		versionID,
 	)
 	job, err := ib.clusterController.GetJob(
-		ib.imageConfig.BuildNamespace,
+		ib.imageBuildingConfig.BuildNamespace,
 		kanikoJobName,
 	)
 	if err != nil {
@@ -381,6 +390,6 @@ func (ib *imageBuilder) DeleteImageBuildingJob(
 		return nil
 	}
 	// Delete job
-	err = ib.clusterController.DeleteJob(ib.imageConfig.BuildNamespace, job.Name)
+	err = ib.clusterController.DeleteJob(ib.imageBuildingConfig.BuildNamespace, job.Name)
 	return err
 }

--- a/api/turing/imagebuilder/imagebuilder_test.go
+++ b/api/turing/imagebuilder/imagebuilder_test.go
@@ -43,7 +43,7 @@ func TestBuildEnsemblerImage(t *testing.T) {
 		versionID         models.ID
 		inputDependencies []string
 		namespace         string
-		imageConfig       config.ImageBuilderConfig
+		imageConfig       config.ImageConfig
 		kanikoConfig      config.KanikoConfig
 		buildLabels       map[string]string
 		clusterController func() cluster.Controller
@@ -101,7 +101,7 @@ func TestBuildEnsemblerImage(t *testing.T) {
 			buildLabels: map[string]string{
 				"gojek.io/team": "dsp",
 			},
-			imageConfig: config.ImageBuilderConfig{
+			imageConfig: config.ImageConfig{
 				Registry:             dockerRegistry,
 				BaseImageRef:         baseImageRef,
 				BuildNamespace:       buildNamespace,
@@ -178,7 +178,7 @@ func TestBuildEnsemblerImage(t *testing.T) {
 
 				return ctlr
 			},
-			imageConfig: config.ImageBuilderConfig{
+			imageConfig: config.ImageConfig{
 				Registry:             dockerRegistry,
 				BaseImageRef:         baseImageRef,
 				BuildNamespace:       buildNamespace,
@@ -264,7 +264,7 @@ func TestBuildEnsemblerImage(t *testing.T) {
 			buildLabels: map[string]string{
 				"gojek.io/team": "dsp",
 			},
-			imageConfig: config.ImageBuilderConfig{
+			imageConfig: config.ImageConfig{
 				Registry:             dockerRegistry,
 				BaseImageRef:         baseImageRef,
 				BuildNamespace:       buildNamespace,
@@ -397,13 +397,13 @@ func TestParseResources(t *testing.T) {
 func TestGetImageBuildingJobStatus(t *testing.T) {
 	tests := map[string]struct {
 		clusterController func() cluster.Controller
-		imageConfig       config.ImageBuilderConfig
+		imageConfig       config.ImageConfig
 		kanikoConfig      config.KanikoConfig
 		hasErr            bool
 		expected          JobStatus
 	}{
 		"success | active": {
-			imageConfig: config.ImageBuilderConfig{
+			imageConfig: config.ImageConfig{
 				Registry:             dockerRegistry,
 				BaseImageRef:         baseImageRef,
 				BuildNamespace:       buildNamespace,
@@ -441,7 +441,7 @@ func TestGetImageBuildingJobStatus(t *testing.T) {
 			expected: JobStatusActive,
 		},
 		"success | succeeded": {
-			imageConfig: config.ImageBuilderConfig{
+			imageConfig: config.ImageConfig{
 				Registry:             dockerRegistry,
 				BaseImageRef:         baseImageRef,
 				BuildNamespace:       buildNamespace,
@@ -479,7 +479,7 @@ func TestGetImageBuildingJobStatus(t *testing.T) {
 			expected: JobStatusSucceeded,
 		},
 		"success | Failed": {
-			imageConfig: config.ImageBuilderConfig{
+			imageConfig: config.ImageConfig{
 				Registry:             dockerRegistry,
 				BaseImageRef:         baseImageRef,
 				BuildNamespace:       buildNamespace,
@@ -517,7 +517,7 @@ func TestGetImageBuildingJobStatus(t *testing.T) {
 			expected: JobStatusFailed,
 		},
 		"success | Unknown": {
-			imageConfig: config.ImageBuilderConfig{
+			imageConfig: config.ImageConfig{
 				Registry:             dockerRegistry,
 				BaseImageRef:         baseImageRef,
 				BuildNamespace:       buildNamespace,
@@ -551,7 +551,7 @@ func TestGetImageBuildingJobStatus(t *testing.T) {
 			expected: JobStatusUnknown,
 		},
 		"failure | Unknown": {
-			imageConfig: config.ImageBuilderConfig{
+			imageConfig: config.ImageConfig{
 				Registry:             dockerRegistry,
 				BaseImageRef:         baseImageRef,
 				BuildNamespace:       buildNamespace,
@@ -604,12 +604,12 @@ func TestGetImageBuildingJobStatus(t *testing.T) {
 func TestDeleteImageBuildingJob(t *testing.T) {
 	tests := map[string]struct {
 		clusterController func() cluster.Controller
-		imageConfig       config.ImageBuilderConfig
+		imageConfig       config.ImageConfig
 		kanikoConfig      config.KanikoConfig
 		hasErr            bool
 	}{
 		"success | no error": {
-			imageConfig: config.ImageBuilderConfig{
+			imageConfig: config.ImageConfig{
 				Registry:             dockerRegistry,
 				BaseImageRef:         baseImageRef,
 				BuildNamespace:       buildNamespace,

--- a/test/e2e/turing.helm-values.yaml
+++ b/test/e2e/turing.helm-values.yaml
@@ -29,16 +29,15 @@ turing:
         RecordsToProcessInOneIteration: 10
         MaxRetryCount: 3
       ImageBuildingConfig:
-        ImageConfig:
-          Registry: ghcr.io
-          BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
-          BuildNamespace: default
+        BuildNamespace: default
+        BuildTimeoutDuration: 20m
+        DestinationRegistry: ghcr.io
+        BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
+        KanikoConfig:
           BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main
           DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
-          BuildTimeoutDuration: 20m
-        KanikoConfig:
           Image: gcr.io/kaniko-project/executor
-          ImageVersion: v1.5.2
+          ImageVersion: v1.6.0
           ResourceRequestsLimits:
             Requests:
               CPU: "1"

--- a/test/e2e/turing.helm-values.yaml
+++ b/test/e2e/turing.helm-values.yaml
@@ -11,7 +11,7 @@ turing:
       cpu: 100m
       memory: 128Mi
   config: 
-    BatchEnsemblerConfig:
+    BatchEnsemblingConfig:
       Enabled: true
       JobConfig:
         DefaultEnvironment: id-dev

--- a/test/e2e/turing.helm-values.yaml
+++ b/test/e2e/turing.helm-values.yaml
@@ -11,44 +11,47 @@ turing:
       cpu: 100m
       memory: 128Mi
   config: 
-    BatchRunnerConfig:
-      TimeInterval: 10s
+    BatchEnsemblerConfig:
+      Enabled: true
+      JobConfig:
+        DefaultEnvironment: id-dev
+        DefaultConfigurations:
+          SparkConfigAnnotations:
+            "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
+          BatchEnsemblingJobResources:
+            DriverCPURequest: "1"
+            DriverMemoryRequest: "1Gi"
+            ExecutorReplica: 2
+            ExecutorCPURequest: "1"
+            ExecutorMemoryRequest: "1Gi"
+      RunnerConfig:
+        TimeInterval: 10s
+        RecordsToProcessInOneIteration: 10
+        MaxRetryCount: 3
+      ImageBuildingConfig:
+        ImageConfig:
+          Registry: ghcr.io
+          BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:latest
+          BuildNamespace: default
+          BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main
+          DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
+          BuildTimeoutDuration: 20m
+        KanikoConfig:
+          Image: gcr.io/kaniko-project/executor
+          ImageVersion: v1.5.2
+          ResourceRequestsLimits:
+            Requests:
+              CPU: "1"
+              Memory: 1Gi
+            Limits:
+              CPU: "1"
+              Memory: 1Gi
     DbConfig:
       Host: turing-postgresql
       User: turing 
       Password: secret
     DeployConfig:
       EnvironmentType: id-dev
-    EnsemblingJobConfig:
-      DefaultEnvironment: id-dev
-      RecordsToProcessInOneIteration: 10
-      MaxRetryCount: 3
-      ImageBuilderConfig:
-        Registry: ghcr.io
-        BaseImageRef: ghcr.io/gojek/turing/batch-ensembler:0.0.0-build.1-98b071d
-        BuildNamespace: default
-        BuildContextURI: git://github.com/gojek/turing.git#refs/heads/main
-        DockerfileFilePath: engines/batch-ensembler/app.Dockerfile
-        BuildTimeoutDuration: 20m
-      KanikoConfig:
-        Image: gcr.io/kaniko-project/executor
-        ImageVersion: v1.5.2
-        ResourceRequestsLimits:
-          Requests:
-            CPU: "1"
-            Memory: 1Gi
-          Limits:
-            CPU: "1"
-            Memory: 1Gi
-      DefaultConfigurations:
-        SparkConfigAnnotations:
-          "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
-        BatchEnsemblingJobResources:
-          DriverCPURequest: "1"
-          DriverMemoryRequest: "1Gi"
-          ExecutorReplica: 2
-          ExecutorCPURequest: "1"
-          ExecutorMemoryRequest: "1Gi"
     KubernetesLabelConfigs:
       Environment: dev
     SparkAppConfig:


### PR DESCRIPTION
Added a toggle to turn off the batch ensembling feature.

By design, the API binary will panic if the wrong configurations are given. If the user requires the batch ensembling feature, he should be confident that it should work when it is deployed. As opposed to only finding out the problem when the feature is being used.

Small bug I found in the configuration regarding Kubernetes Tolerations: fixed by using the correct key and remove TaintKey as it is redundant.