### PR TITLE
Add validation and default ensembling job values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ EnsemblingJobConfig:
       Limits:
         CPU: "1"
         Memory: 1Gi
+  DefaultConfigurations:
+    SparkConfigAnnotations:
+      "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
+    BatchEnsemblingJobResources:
+      DriverCPURequest: "1"
+      DriverMemoryRequest: "1Gi"
+      ExecutorReplica: 2
+      ExecutorCPURequest: "1"
+      ExecutorMemoryRequest: "1Gi"
 KubernetesLabelConfigs:
   Environment: dev
 SparkAppConfig:

--- a/api/config-dev.yaml
+++ b/api/config-dev.yaml
@@ -26,6 +26,15 @@ EnsemblingJobConfig:
       Limits:
         CPU: "1"
         Memory: 1Gi
+  DefaultConfigurations:
+    SparkConfigAnnotations:
+      "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
+    BatchEnsemblingJobResources:
+      DriverCPURequest: "1"
+      DriverMemoryRequest: "1Gi"
+      ExecutorReplica: 2
+      ExecutorCPURequest: "1"
+      ExecutorMemoryRequest: "1Gi"
 KubernetesLabelConfigs:
   Environment: dev
 SparkAppConfig:

--- a/api/turing/api/appcontext.go
+++ b/api/turing/api/appcontext.go
@@ -103,7 +103,11 @@ func NewAppContext(
 		cfg.KubernetesLabelConfigs.Environment,
 	)
 
-	ensemblingJobService := service.NewEnsemblingJobService(db, cfg.EnsemblingJobConfig.DefaultEnvironment)
+	ensemblingJobService := service.NewEnsemblingJobService(
+		db,
+		cfg.EnsemblingJobConfig.DefaultEnvironment,
+		cfg.EnsemblingJobConfig.DefaultConfigurations,
+	)
 	batchEnsemblingController := batchensembling.NewBatchEnsemblingController(
 		batchClusterController,
 		mlpSvc,

--- a/api/turing/api/appcontext_test.go
+++ b/api/turing/api/appcontext_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gojek/turing/api/turing/imagebuilder"
 	"github.com/gojek/turing/api/turing/middleware"
 	"github.com/gojek/turing/api/turing/middleware/mocks"
+	"github.com/gojek/turing/api/turing/models"
 	"github.com/gojek/turing/api/turing/service"
 	svcmocks "github.com/gojek/turing/api/turing/service/mocks"
 	"github.com/jinzhu/gorm"
@@ -84,6 +85,18 @@ func TestNewAppContext(t *testing.T) {
 						CPU:    "500m",
 						Memory: "1Gi",
 					},
+				},
+			},
+			DefaultConfigurations: config.DefaultEnsemblingJobConfigurations{
+				BatchEnsemblingJobResources: models.BatchEnsemblingJobResources{
+					DriverCPURequest:      "1",
+					DriverMemoryRequest:   "1Gi",
+					ExecutorReplica:       2,
+					ExecutorCPURequest:    "1",
+					ExecutorMemoryRequest: "1Gi",
+				},
+				SparkConfigAnnotations: map[string]string{
+					"spark/spark.sql.execution.arrow.pyspark.enabled": "true",
 				},
 			},
 		},
@@ -251,7 +264,11 @@ func TestNewAppContext(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	ensemblingJobService := service.NewEnsemblingJobService(nil, testCfg.EnsemblingJobConfig.DefaultEnvironment)
+	ensemblingJobService := service.NewEnsemblingJobService(
+		nil,
+		testCfg.EnsemblingJobConfig.DefaultEnvironment,
+		testCfg.EnsemblingJobConfig.DefaultConfigurations,
+	)
 	batchEnsemblingController := batchensembling.NewBatchEnsemblingController(
 		nil,
 		mlpSvc,

--- a/api/turing/api/appcontext_test.go
+++ b/api/turing/api/appcontext_test.go
@@ -13,10 +13,10 @@ import (
 	batchrunner "github.com/gojek/turing/api/turing/batch/runner"
 	"github.com/gojek/turing/api/turing/cluster"
 	"github.com/gojek/turing/api/turing/config"
+	openapi "github.com/gojek/turing/api/turing/generated"
 	"github.com/gojek/turing/api/turing/imagebuilder"
 	"github.com/gojek/turing/api/turing/middleware"
 	"github.com/gojek/turing/api/turing/middleware/mocks"
-	"github.com/gojek/turing/api/turing/models"
 	"github.com/gojek/turing/api/turing/service"
 	svcmocks "github.com/gojek/turing/api/turing/service/mocks"
 	"github.com/jinzhu/gorm"
@@ -37,6 +37,13 @@ func TestNewAppContext(t *testing.T) {
 	// Create test config
 	timeout, _ := time.ParseDuration("10s")
 	delTimeout, _ := time.ParseDuration("1s")
+
+	driverCPURequest := "1"
+	driverMemoryRequest := "1Gi"
+	var executorReplica int32 = 2
+	executorCPURequest := "1"
+	executorMemoryRequest := "1Gi"
+
 	testCfg := &config.Config{
 		Port: 8080,
 		AuthConfig: &config.AuthorizationConfig{
@@ -88,12 +95,12 @@ func TestNewAppContext(t *testing.T) {
 				},
 			},
 			DefaultConfigurations: config.DefaultEnsemblingJobConfigurations{
-				BatchEnsemblingJobResources: models.BatchEnsemblingJobResources{
-					DriverCPURequest:      "1",
-					DriverMemoryRequest:   "1Gi",
-					ExecutorReplica:       2,
-					ExecutorCPURequest:    "1",
-					ExecutorMemoryRequest: "1Gi",
+				BatchEnsemblingJobResources: openapi.EnsemblingResources{
+					DriverCpuRequest:      &driverCPURequest,
+					DriverMemoryRequest:   &driverMemoryRequest,
+					ExecutorReplica:       &executorReplica,
+					ExecutorCpuRequest:    &executorCPURequest,
+					ExecutorMemoryRequest: &executorMemoryRequest,
 				},
 				SparkConfigAnnotations: map[string]string{
 					"spark/spark.sql.execution.arrow.pyspark.enabled": "true",

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -136,7 +136,7 @@ type EnsemblingJobConfig struct {
 	// ImageBuilderConfig contains the configuration related to the built ensembler image itself.
 	ImageBuilderConfig ImageBuilderConfig `validate:"required"`
 	// DefaultConfigurations contains the default configurations applied to the ensembling job.
-	// The user is free to override/append to the configuration
+	// The user (the person who calls the API) is free to override/append the default values.
 	DefaultConfigurations DefaultEnsemblingJobConfigurations `validate:"required"`
 }
 

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -8,8 +8,9 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
-	"github.com/gojek/mlp/api/pkg/instrumentation/newrelic"
-	"github.com/gojek/mlp/api/pkg/instrumentation/sentry"
+	"github.com/gojek/mlp/pkg/instrumentation/newrelic"
+	"github.com/gojek/mlp/pkg/instrumentation/sentry"
+	"github.com/gojek/turing/api/turing/models"
 	"github.com/mitchellh/mapstructure"
 
 	// Using a maintained fork of https://github.com/spf13/viper mainly so that viper.AllSettings()
@@ -134,6 +135,17 @@ type EnsemblingJobConfig struct {
 	KanikoConfig KanikoConfig `validate:"required"`
 	// ImageBuilderConfig contains the configuration related to the built ensembler image itself.
 	ImageBuilderConfig ImageBuilderConfig `validate:"required"`
+	// DefaultConfigurations contains the default configurations applied to the ensembling job.
+	// The user is free to override/append to the configuration
+	DefaultConfigurations DefaultEnsemblingJobConfigurations `validate:"required"`
+}
+
+// DefaultEnsemblingJobConfigurations contains the default configurations applied to the ensembling job.
+type DefaultEnsemblingJobConfigurations struct {
+	// BatchEnsemblingJobResources contains the resources delared to run the ensembling job.
+	BatchEnsemblingJobResources models.BatchEnsemblingJobResources
+	// SparkConfigAnnotations contains the Spark configurations
+	SparkConfigAnnotations map[string]string
 }
 
 // ImageBuilderConfig provides the configuration used for the OCI image building.
@@ -306,7 +318,7 @@ type MLPConfig struct {
 //
 // Refer to example.yaml for an example of config file.
 func Load(filepaths ...string) (*Config, error) {
-	v := viper.New()
+	v := viper.NewWithOptions(viper.KeyDelimiter("::"))
 
 	// Load default config values
 	setDefaultValues(v)
@@ -323,7 +335,7 @@ func Load(filepaths ...string) (*Config, error) {
 	// Load config values from environment variables.
 	// Nested keys in the config is represented by variable name separated by '_'.
 	// For example, DbConfig.Host can be set from environment variable DBCONFIG_HOST.
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvKeyReplacer(strings.NewReplacer("::", "_"))
 	v.AutomaticEnv()
 
 	config := &Config{}
@@ -358,54 +370,54 @@ func setDefaultValues(v *viper.Viper) {
 
 	v.SetDefault("AllowedOrigins", "*")
 
-	v.SetDefault("AuthConfig.Enabled", "false")
-	v.SetDefault("AuthConfig.URL", "")
+	v.SetDefault("AuthConfig::Enabled", "false")
+	v.SetDefault("AuthConfig::URL", "")
 
-	v.SetDefault("DbConfig.Host", "localhost")
-	v.SetDefault("DbConfig.Port", "5432")
-	v.SetDefault("DbConfig.User", "")
-	v.SetDefault("DbConfig.Password", "")
-	v.SetDefault("DbConfig.Database", "turing")
+	v.SetDefault("DbConfig::Host", "localhost")
+	v.SetDefault("DbConfig::Port", "5432")
+	v.SetDefault("DbConfig::User", "")
+	v.SetDefault("DbConfig::Password", "")
+	v.SetDefault("DbConfig::Database", "turing")
 
-	v.SetDefault("DeployConfig.EnvironmentType", "")
-	v.SetDefault("DeployConfig.GcpProject", "")
-	v.SetDefault("DeployConfig.Timeout", "3m")
-	v.SetDefault("DeployConfig.DeletionTimeout", "1m")
-	v.SetDefault("DeployConfig.MaxCPU", "4")
-	v.SetDefault("DeployConfig.MaxMemory", "8Gi")
+	v.SetDefault("DeployConfig::EnvironmentType", "")
+	v.SetDefault("DeployConfig::GcpProject", "")
+	v.SetDefault("DeployConfig::Timeout", "3m")
+	v.SetDefault("DeployConfig::DeletionTimeout", "1m")
+	v.SetDefault("DeployConfig::MaxCPU", "4")
+	v.SetDefault("DeployConfig::MaxMemory", "8Gi")
 
-	v.SetDefault("RouterDefaults.Image", "")
-	v.SetDefault("RouterDefaults.FiberDebugLogEnabled", "false")
-	v.SetDefault("RouterDefaults.CustomMetricsEnabled", "false")
-	v.SetDefault("RouterDefaults.JaegerEnabled", "false")
-	v.SetDefault("RouterDefaults.JaegerCollectorEndpoint", "")
-	v.SetDefault("RouterDefaults.LogLevel", "INFO")
-	v.SetDefault("RouterDefaults.FluentdConfig.Image", "")
-	v.SetDefault("RouterDefaults.FluentdConfig.Tag", "turing-result.log")
-	v.SetDefault("RouterDefaults.FluentdConfig.FlushIntervalSeconds", "90")
-	v.SetDefault("RouterDefaults.Experiment", map[string]interface{}{})
+	v.SetDefault("RouterDefaults::Image", "")
+	v.SetDefault("RouterDefaults::FiberDebugLogEnabled", "false")
+	v.SetDefault("RouterDefaults::CustomMetricsEnabled", "false")
+	v.SetDefault("RouterDefaults::JaegerEnabled", "false")
+	v.SetDefault("RouterDefaults::JaegerCollectorEndpoint", "")
+	v.SetDefault("RouterDefaults::LogLevel", "INFO")
+	v.SetDefault("RouterDefaults::FluentdConfig::Image", "")
+	v.SetDefault("RouterDefaults::FluentdConfig::Tag", "turing-result.log")
+	v.SetDefault("RouterDefaults::FluentdConfig::FlushIntervalSeconds", "90")
+	v.SetDefault("RouterDefaults::Experiment", map[string]interface{}{})
 
-	v.SetDefault("Sentry.Enabled", "false")
-	v.SetDefault("Sentry.DSN", "")
+	v.SetDefault("Sentry::Enabled", "false")
+	v.SetDefault("Sentry::DSN", "")
 
-	v.SetDefault("VaultConfig.Address", "http://localhost:8200")
-	v.SetDefault("VaultConfig.Token", "")
+	v.SetDefault("VaultConfig::Address", "http://localhost:8200")
+	v.SetDefault("VaultConfig::Token", "")
 
 	v.SetDefault("TuringEncryptionKey", "")
 
-	v.SetDefault("AlertConfig.Enabled", "false")
-	v.SetDefault("AlertConfig.GitLab.BaseURL", "https://gitlab.com")
-	v.SetDefault("AlertConfig.GitLab.Token", "")
-	v.SetDefault("AlertConfig.GitLab.ProjectID", "")
-	v.SetDefault("AlertConfig.GitLab.Branch", "master")
-	v.SetDefault("AlertConfig.GitLab.PathPrefix", "turing")
+	v.SetDefault("AlertConfig::Enabled", "false")
+	v.SetDefault("AlertConfig::GitLab::BaseURL", "https://gitlab.com")
+	v.SetDefault("AlertConfig::GitLab::Token", "")
+	v.SetDefault("AlertConfig::GitLab::ProjectID", "")
+	v.SetDefault("AlertConfig::GitLab::Branch", "master")
+	v.SetDefault("AlertConfig::GitLab::PathPrefix", "turing")
 
-	v.SetDefault("MLPConfig.MerlinURL", "")
-	v.SetDefault("MLPConfig.MLPURL", "")
-	v.SetDefault("MLPConfig.MLPEncryptionKey", "")
+	v.SetDefault("MLPConfig::MerlinURL", "")
+	v.SetDefault("MLPConfig::MLPURL", "")
+	v.SetDefault("MLPConfig::MLPEncryptionKey", "")
 
-	v.SetDefault("TuringUIConfig.AppDirectory", "")
-	v.SetDefault("TuringUIConfig.Homepage", "/turing")
+	v.SetDefault("TuringUIConfig::AppDirectory", "")
+	v.SetDefault("TuringUIConfig::Homepage", "/turing")
 
 	v.SetDefault("SwaggerFile", "api/openapi.yaml")
 	v.SetDefault("Experiment", map[string]interface{}{})

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/gojek/mlp/api/pkg/instrumentation/newrelic"
 	"github.com/gojek/mlp/api/pkg/instrumentation/sentry"
-	"github.com/gojek/turing/api/turing/models"
+	openapi "github.com/gojek/turing/api/turing/generated"
 	"github.com/mitchellh/mapstructure"
 
 	// Using a maintained fork of https://github.com/spf13/viper mainly so that viper.AllSettings()
@@ -143,7 +143,7 @@ type EnsemblingJobConfig struct {
 // DefaultEnsemblingJobConfigurations contains the default configurations applied to the ensembling job.
 type DefaultEnsemblingJobConfigurations struct {
 	// BatchEnsemblingJobResources contains the resources delared to run the ensembling job.
-	BatchEnsemblingJobResources models.BatchEnsemblingJobResources
+	BatchEnsemblingJobResources openapi.EnsemblingResources
 	// SparkConfigAnnotations contains the Spark configurations
 	SparkConfigAnnotations map[string]string
 }

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
-	"github.com/gojek/mlp/pkg/instrumentation/newrelic"
-	"github.com/gojek/mlp/pkg/instrumentation/sentry"
+	"github.com/gojek/mlp/api/pkg/instrumentation/newrelic"
+	"github.com/gojek/mlp/api/pkg/instrumentation/sentry"
 	"github.com/gojek/turing/api/turing/models"
 	"github.com/mitchellh/mapstructure"
 

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gojek/mlp/api/pkg/instrumentation/newrelic"
 	"github.com/gojek/mlp/api/pkg/instrumentation/sentry"
 	tu "github.com/gojek/turing/api/turing/internal/testutils"
+	"github.com/gojek/turing/api/turing/models"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -546,6 +547,18 @@ func TestConfigValidate(t *testing.T) {
 						CPU:    "500m",
 						Memory: "1Gi",
 					},
+				},
+			},
+			DefaultConfigurations: DefaultEnsemblingJobConfigurations{
+				BatchEnsemblingJobResources: models.BatchEnsemblingJobResources{
+					DriverCPURequest:      "1",
+					DriverMemoryRequest:   "1Gi",
+					ExecutorReplica:       2,
+					ExecutorCPURequest:    "1",
+					ExecutorMemoryRequest: "1Gi",
+				},
+				SparkConfigAnnotations: map[string]string{
+					"spark/spark.sql.execution.arrow.pyspark.enabled": "true",
 				},
 			},
 		},

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/gojek/mlp/api/pkg/instrumentation/newrelic"
 	"github.com/gojek/mlp/api/pkg/instrumentation/sentry"
+	openapi "github.com/gojek/turing/api/turing/generated"
 	tu "github.com/gojek/turing/api/turing/internal/testutils"
-	"github.com/gojek/turing/api/turing/models"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -504,6 +504,12 @@ func TestStringToQuantityHookFunc(t *testing.T) {
 }
 
 func TestConfigValidate(t *testing.T) {
+	driverCPURequest := "1"
+	driverMemoryRequest := "1Gi"
+	var executorReplica int32 = 2
+	executorCPURequest := "1"
+	executorMemoryRequest := "1Gi"
+
 	validConfig := Config{
 		Port: 5000,
 		BatchRunnerConfig: &BatchRunnerConfig{
@@ -550,12 +556,12 @@ func TestConfigValidate(t *testing.T) {
 				},
 			},
 			DefaultConfigurations: DefaultEnsemblingJobConfigurations{
-				BatchEnsemblingJobResources: models.BatchEnsemblingJobResources{
-					DriverCPURequest:      "1",
-					DriverMemoryRequest:   "1Gi",
-					ExecutorReplica:       2,
-					ExecutorCPURequest:    "1",
-					ExecutorMemoryRequest: "1Gi",
+				BatchEnsemblingJobResources: openapi.EnsemblingResources{
+					DriverCpuRequest:      &driverCPURequest,
+					DriverMemoryRequest:   &driverMemoryRequest,
+					ExecutorReplica:       &executorReplica,
+					ExecutorCpuRequest:    &executorCPURequest,
+					ExecutorMemoryRequest: &executorMemoryRequest,
 				},
 				SparkConfigAnnotations: map[string]string{
 					"spark/spark.sql.execution.arrow.pyspark.enabled": "true",

--- a/api/turing/config/example.yaml
+++ b/api/turing/config/example.yaml
@@ -68,6 +68,15 @@ EnsemblingJobConfig:
       Limits:
         CPU: "1"
         Memory: 1Gi
+  DefaultConfigurations:
+    SparkConfigAnnotations:
+      "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
+    BatchEnsemblingJobResources:
+      DriverCPURequest: "1"
+      DriverMemoryRequest: "1Gi"
+      ExecutorReplica: 2
+      ExecutorCPURequest: "1"
+      ExecutorMemoryRequest: "1Gi"
 
 KubernetesLabelConfigs:
   # KubernetesLabelPrefix is the prefix used for tagging kubernetes components.

--- a/api/turing/models/ensembling_job.go
+++ b/api/turing/models/ensembling_job.go
@@ -44,7 +44,7 @@ type InfraConfig struct {
 	ArtifactURI        string                       `json:"artifact_uri"`
 	EnsemblerName      string                       `json:"ensembler_name"`
 	ServiceAccountName string                       `json:"service_account_name" validate:"required"`
-	Resources          *openapi.EnsemblingResources `json:"resources" validate:"required"`
+	Resources          *openapi.EnsemblingResources `json:"resources"`
 }
 
 // Value returns json value, implement driver.Valuer interface

--- a/api/turing/models/ensembling_job.go
+++ b/api/turing/models/ensembling_job.go
@@ -11,12 +11,12 @@ import (
 // EnsemblingJob holds the information required for an ensembling job to be done asynchronously
 type EnsemblingJob struct {
 	Model
-	Name            string       `json:"name"`
-	EnsemblerID     ID           `json:"ensembler_id"`
+	Name            string       `json:"name" validate:"required"`
+	EnsemblerID     ID           `json:"ensembler_id" validate:"required"`
 	ProjectID       ID           `json:"project_id"`
 	EnvironmentName string       `json:"environment_name"`
-	InfraConfig     *InfraConfig `json:"infra_config"`
-	JobConfig       *JobConfig   `json:"job_config"`
+	InfraConfig     *InfraConfig `json:"infra_config" validate:"required"`
+	JobConfig       *JobConfig   `json:"job_config" validate:"required"`
 	RetryCount      int          `json:"-" gorm:"default:0"`
 	Status          Status       `json:"status" gorm:"default:pending"`
 	Error           string       `json:"error"`
@@ -43,8 +43,8 @@ func (c *JobConfig) Scan(value interface{}) error {
 type InfraConfig struct {
 	ArtifactURI        string                       `json:"artifact_uri"`
 	EnsemblerName      string                       `json:"ensembler_name"`
-	ServiceAccountName string                       `json:"service_account_name"`
-	Resources          *openapi.EnsemblingResources `json:"resources"`
+	ServiceAccountName string                       `json:"service_account_name" validate:"required"`
+	Resources          *openapi.EnsemblingResources `json:"resources" validate:"required"`
 }
 
 // Value returns json value, implement driver.Valuer interface

--- a/api/turing/service/ensembling_job_service.go
+++ b/api/turing/service/ensembling_job_service.go
@@ -164,7 +164,7 @@ func (s *ensemblingJobService) CreateEnsemblingJob(
 	job.InfraConfig.ArtifactURI = ensembler.ArtifactURI
 	job.InfraConfig.EnsemblerName = ensembler.Name
 
-	job.JobConfig.JobConfig.Metadata.Name = generateDefaultJobName(ensembler.Name)
+	job.JobConfig.Metadata.Name = generateDefaultJobName(ensembler.Name)
 	s.mergeDefaultConfigurations(job)
 
 	// Save ensembling job
@@ -184,8 +184,8 @@ func (s *ensemblingJobService) MarkEnsemblingJobForTermination(job *models.Ensem
 func (s *ensemblingJobService) mergeDefaultConfigurations(job *models.EnsemblingJob) {
 	// Only apply default if key does not exist, we should respect the users annotation override.
 	for key, value := range s.defaultConfig.SparkConfigAnnotations {
-		if _, ok := job.JobConfig.JobConfig.Metadata.Annotations[key]; !ok {
-			job.JobConfig.JobConfig.Metadata.Annotations[key] = value
+		if _, ok := job.JobConfig.Metadata.Annotations[key]; !ok {
+			job.JobConfig.Metadata.Annotations[key] = value
 		}
 	}
 
@@ -195,23 +195,23 @@ func (s *ensemblingJobService) mergeDefaultConfigurations(job *models.Ensembling
 		return
 	}
 
-	if job.InfraConfig.Resources.DriverCPURequest == "" {
-		job.InfraConfig.Resources.DriverCPURequest = s.defaultConfig.BatchEnsemblingJobResources.DriverCPURequest
+	if job.InfraConfig.Resources.DriverCpuRequest == nil {
+		job.InfraConfig.Resources.DriverCpuRequest = s.defaultConfig.BatchEnsemblingJobResources.DriverCpuRequest
 	}
 
-	if job.InfraConfig.Resources.DriverMemoryRequest == "" {
+	if job.InfraConfig.Resources.DriverMemoryRequest == nil {
 		job.InfraConfig.Resources.DriverMemoryRequest = s.defaultConfig.BatchEnsemblingJobResources.DriverMemoryRequest
 	}
 
-	if job.InfraConfig.Resources.ExecutorReplica == 0 {
+	if job.InfraConfig.Resources.ExecutorReplica == nil {
 		job.InfraConfig.Resources.ExecutorReplica = s.defaultConfig.BatchEnsemblingJobResources.ExecutorReplica
 	}
 
-	if job.InfraConfig.Resources.ExecutorCPURequest == "" {
-		job.InfraConfig.Resources.ExecutorCPURequest = s.defaultConfig.BatchEnsemblingJobResources.ExecutorCPURequest
+	if job.InfraConfig.Resources.ExecutorCpuRequest == nil {
+		job.InfraConfig.Resources.ExecutorCpuRequest = s.defaultConfig.BatchEnsemblingJobResources.ExecutorCpuRequest
 	}
 
-	if job.InfraConfig.Resources.ExecutorMemoryRequest == "" {
+	if job.InfraConfig.Resources.ExecutorMemoryRequest == nil {
 		job.InfraConfig.Resources.ExecutorMemoryRequest = s.defaultConfig.BatchEnsemblingJobResources.ExecutorMemoryRequest
 	}
 }

--- a/test/e2e/turing.helm-values.yaml
+++ b/test/e2e/turing.helm-values.yaml
@@ -40,6 +40,15 @@ turing:
           Limits:
             CPU: "1"
             Memory: 1Gi
+      DefaultConfigurations:
+        SparkConfigAnnotations:
+          "spark/spark.sql.execution.arrow.pyspark.enabled": "true"
+        BatchEnsemblingJobResources:
+          DriverCPURequest: "1"
+          DriverMemoryRequest: "1Gi"
+          ExecutorReplica: 2
+          ExecutorCPURequest: "1"
+          ExecutorMemoryRequest: "1Gi"
     KubernetesLabelConfigs:
       Environment: dev
     SparkAppConfig:


### PR DESCRIPTION
This PR adds the following:

1. Default Spark config annotations that is configurable in the Turing API config file.
2. Add in validation for the Create ensembling job POST body.
3. Nasty side effects include the rewiring of viper configuration delimiter from `.` to `::` due to a problem in unmarshalling strings.

For example:
```go
type Foo struct {
  Bar map[string]string
}
```

with a configuration of

```yaml
Foo:
  Bar:
    "hello.one.two": "some string"
```

Will yield this structure instead:
```foo
Foo = interface{}{
  "Bar": interface{}{
    "hello": interface{}{
      "one": inteface{}{
        "two": "some string",
      },
    },
  },
}
```

To solve this, we change the delimiter to something uncommon, say a cons operator `::`.