### PR TITLE
Turing SDK: terminate ensembling job

### DIFF
--- a/api/openapi/jobs.yaml
+++ b/api/openapi/jobs.yaml
@@ -94,8 +94,8 @@ paths:
           description: "Invalid ensembling job"
     delete:
       tags: *tags
-      operationId: "DeleteEnsemblingJob"
-      summary: Delete an ongoing Ensembling Job.
+      operationId: "TerminateEnsemblingJob"
+      summary: Terminate an ongoing Ensembling Job.
       parameters:
         - in: path
           name: project_id
@@ -386,6 +386,7 @@ components:
       type: "string"
       enum:
         - pending
+        - building
         - running
         - terminating
         - terminated

--- a/api/turing/api/ensembling_job_api.go
+++ b/api/turing/api/ensembling_job_api.go
@@ -110,7 +110,7 @@ func (c EnsemblingJobController) ListEnsemblingJobs(
 }
 
 type deleteEnsemblingJobResponse struct {
-	ID models.ID `schema:"id"`
+	ID models.ID `json:"id"`
 }
 
 // DeleteEnsemblingJob deletes and ensembling job and cancels any ongoing process.

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -1,8 +1,9 @@
+fire
 google-auth>=1.30.0,<2.0dev
 google-cloud-storage>=1.37.0
 mlflow==1.14.1
 numpy==1.17.3
 pandas==1.2.2
 python-dateutil
+requests==2.25.1
 urllib3 >= 1.25.3
-fire

--- a/sdk/samples/batch_job/batch_job.py
+++ b/sdk/samples/batch_job/batch_job.py
@@ -1,3 +1,4 @@
+import time
 import turing
 import turing.batch
 import turing.batch.config
@@ -7,11 +8,11 @@ SERVICE_ACCOUNT_NAME = "service-account@gcp-project.iam.gserviceaccount.com"
 
 
 def main(turing_api: str, project: str):
-    # Initialize Turing client
+    # Initialize Turing client:
     turing.set_url(turing_api)
     turing.set_project(project)
 
-    # Save pyfunc ensembler in Turing's backend
+    # Save pyfunc ensembler in Turing's backend:
     ensembler = turing.PyFuncEnsembler.create(
         name="my-ensembler",
         ensembler_instance=MyEnsembler(),
@@ -24,15 +25,19 @@ def main(turing_api: str, project: str):
     )
     print("Ensembler created:\n", ensembler)
 
+    # Or fetch existing ensembler by its ID:
+    # ensembler_id = < ENSEMBLER_ID >
+    # ensembler = turing.PyFuncEnsembler.get_by_id(ensembler_id)
+
     # Define configuration of the batch ensembling job
 
-    # Configure datasource, that contains input features
+    # Configure datasource, that contains input features:
     source = turing.batch.config.source.BigQueryDataset(
         table="project.dataset.features",
         features=["feature_1", "feature_2", "features_3"]
     ).join_on(columns=["feature_1"])
 
-    # Configure dataset(s), that contain predictions of individual models
+    # Configure dataset(s), that contain predictions of individual models:
     predictions = {
         'model_odd':
             turing.batch.config.source.BigQueryDataset(
@@ -54,20 +59,20 @@ def main(turing_api: str, project: str):
             ).join_on(columns=["feature_1"]).select(columns=["prediction_score"])
     }
 
-    # Configure ensembling result
+    # Configure ensembling result:
     result_config = turing.batch.config.ResultConfig(
         type=turing.batch.config.ResultType.INTEGER,
         column_name="prediction_result"
     )
 
-    # Configure destination, where ensembling results will be stored
+    # Configure destination, where ensembling results will be stored:
     sink = turing.batch.config.sink.BigQuerySink(
         table="project.dataset.ensembling_results",
         staging_bucket="staging_bucket"
     ).save_mode(turing.batch.config.sink.SaveMode.OVERWRITE) \
         .select(columns=["feature_1", "feature_2", "prediction_result"])
 
-    # (Optional) Configure resources allocation for the job execution
+    # (Optional) Configure resources allocation for the job execution:
     resource_request = turing.batch.config.ResourceRequest(
         driver_cpu_request="1",
         driver_memory_request="1G",
@@ -76,7 +81,7 @@ def main(turing_api: str, project: str):
         executor_memory_request="800M"
     )
 
-    # Submit the job for execution
+    # Submit the job for execution:
     job = ensembler.submit_job(
         turing.batch.config.EnsemblingJobConfig(
             source=source,
@@ -88,6 +93,26 @@ def main(turing_api: str, project: str):
         )
     )
     print(job)
+
+    # You can also retrieve the instance of existing job by its ID:
+    # job_id = < JOB_ID >
+    # job = turing.batch.EnsemblingJob.get_by_id(job_id=job_id)
+    #
+    # # Or list all ensembling jobs within the project
+    # jobs = turing.batch.EnsemblingJob.list(status=[
+    #     turing.batch.EnsemblingJobStatus.PENDING,
+    #     turing.batch.EnsemblingJobStatus.RUNNING,
+    # ])
+
+    # Refresh the status of the job
+    for i in range(3):
+        time.sleep(5)
+        job.refresh()
+        print(f"Refresh #{i+1}: {job}")
+
+    # It's also possible to terminate a running job:
+    job.terminate()
+    print(f"Job's termination in process: {job}")
 
 
 if __name__ == '__main__':

--- a/sdk/tests/__init__.py
+++ b/sdk/tests/__init__.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from dateutil.tz import tzutc
 from turing import generated as client
 import turing.ensembler
 
@@ -8,6 +9,12 @@ def json_serializer(o):
         return o.isoformat()
     if isinstance(o, (client.model_utils.ModelNormal, client.model_utils.ModelComposed)):
         return o.to_dict()
+
+
+def utc_date(date_str: str):
+    return datetime.strptime(
+        date_str, "%Y-%m-%dT%H:%M:%S.%fZ"
+    ).replace(tzinfo=tzutc())
 
 
 class MyTestEnsembler(turing.ensembler.PyFunc):

--- a/sdk/tests/batch/job_test.py
+++ b/sdk/tests/batch/job_test.py
@@ -68,22 +68,13 @@ def _responses():
         )
     ]
 )
-def test_list_jobs(turing_api, project, use_google_oauth, api_response, expected):
-    responses.add(
-        method="GET",
-        url=f"/v1/projects?name={project.name}",
-        body=json.dumps([project], default=tests.json_serializer),
-        match_querystring=True,
-        status=200,
-        content_type="application/json"
-    )
-
+def test_list_jobs(turing_api, active_project, api_response, expected, use_google_oauth):
     turing.set_url(turing_api, use_google_oauth)
-    turing.set_project(project.name)
+    turing.set_project(active_project.name)
 
     responses.add(
         method="GET",
-        url=f"/v1/projects/{project.id}/jobs?"
+        url=f"/v1/projects/{active_project.id}/jobs?"
             f"status={turing.batch.EnsemblingJobStatus.PENDING.value}&"
             f"status={turing.batch.EnsemblingJobStatus.RUNNING.value}",
         body=api_response,
@@ -132,22 +123,19 @@ def test_list_jobs(turing_api, project, use_google_oauth, api_response, expected
         )
     ]
 )
-def test_submit_job(turing_api, project, use_google_oauth, ensembling_job_config, api_response, expected):
-    responses.add(
-        method="GET",
-        url=f"/v1/projects?name={project.name}",
-        body=json.dumps([project], default=tests.json_serializer),
-        match_querystring=True,
-        status=200,
-        content_type="application/json"
-    )
-
+def test_submit_job(
+        turing_api,
+        active_project,
+        ensembling_job_config,
+        api_response,
+        expected,
+        use_google_oauth):
     turing.set_url(turing_api, use_google_oauth)
-    turing.set_project(project.name)
+    turing.set_project(active_project.name)
 
     responses.add(
         method="POST",
-        url=f"/v1/projects/{project.id}/jobs",
+        url=f"/v1/projects/{active_project.id}/jobs",
         body=api_response,
         status=201,
         content_type="application/json"
@@ -166,3 +154,7 @@ def test_submit_job(turing_api, project, use_google_oauth, ensembling_job_config
     assert actual.error == expected.error
     assert actual.created_at == expected.created_at
     assert actual.updated_at == expected.updated_at
+
+
+def test_fetch_job():
+    pass

--- a/sdk/tests/batch/job_test.py
+++ b/sdk/tests/batch/job_test.py
@@ -19,7 +19,7 @@ with open(os.path.join(data_dir, "get_job_0000.json")) as f:
     get_job_0000 = f.read()
 
 
-@pytest.fixture(scope="module", name="responses")
+@pytest.fixture(scope="function", name="responses")
 def _responses():
     return responses
 

--- a/sdk/tests/batch/job_test.py
+++ b/sdk/tests/batch/job_test.py
@@ -19,7 +19,7 @@ with open(os.path.join(data_dir, "get_job_0000.json")) as f:
     get_job_0000 = f.read()
 
 
-@pytest.fixture(scope="function", name="responses")
+@pytest.fixture(scope="module", name="responses")
 def _responses():
     return responses
 
@@ -181,18 +181,18 @@ def test_fetch_job(
 
     assert job == expected
 
-    # responses.reset()
-    # responses.add(
-    #     method="GET",
-    #     url=f"/v1/projects/{active_project.id}/jobs/{expected.id}",
-    #     body=api_response_refresh,
-    #     status=200,
-    #     content_type="application/json"
-    # )
-    #
-    # job.refresh()
-    #
-    # assert job == updated
+    responses.reset()
+    responses.add(
+        method="GET",
+        url=f"/v1/projects/{active_project.id}/jobs/{expected.id}",
+        body=api_response_refresh,
+        status=200,
+        content_type="application/json"
+    )
+
+    job.refresh()
+
+    assert job == updated
 
 
 @responses.activate

--- a/sdk/tests/batch/job_test.py
+++ b/sdk/tests/batch/job_test.py
@@ -181,18 +181,18 @@ def test_fetch_job(
 
     assert job == expected
 
-    responses.reset()
-    responses.add(
-        method="GET",
-        url=f"/v1/projects/{active_project.id}/jobs/{expected.id}",
-        body=api_response_refresh,
-        status=200,
-        content_type="application/json"
-    )
-
-    job.refresh()
-
-    assert job == updated
+    # responses.reset()
+    # responses.add(
+    #     method="GET",
+    #     url=f"/v1/projects/{active_project.id}/jobs/{expected.id}",
+    #     body=api_response_refresh,
+    #     status=200,
+    #     content_type="application/json"
+    # )
+    #
+    # job.refresh()
+    #
+    # assert job == updated
 
 
 @responses.activate

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -1,6 +1,8 @@
+import json
 from datetime import datetime, timedelta
 import pytest
 import random
+import tests
 from turing import generated as client
 from turing import ensembler
 import turing.batch.config
@@ -28,6 +30,19 @@ def project():
         created_at=datetime.now(),
         updated_at=datetime.now()
     )
+
+
+@pytest.fixture
+def active_project(responses, project):
+    responses.add(
+        method="GET",
+        url=f"/v1/projects?name={project.name}",
+        body=json.dumps([project], default=tests.json_serializer),
+        match_querystring=True,
+        status=200,
+        content_type="application/json"
+    )
+    return project
 
 
 @pytest.fixture

--- a/sdk/tests/ensembler_test.py
+++ b/sdk/tests/ensembler_test.py
@@ -12,7 +12,7 @@ from turing import generated as client
 responses = Responses('requests.packages.urllib3')
 
 
-@pytest.fixture(scope="module", name="responses")
+@pytest.fixture(scope="function", name="responses")
 def _responses():
     return responses
 

--- a/sdk/tests/ensembler_test.py
+++ b/sdk/tests/ensembler_test.py
@@ -61,11 +61,7 @@ def test_list_ensemblers(turing_api, active_project, generic_ensemblers, use_goo
     assert all([isinstance(p, turing.PyFuncEnsembler) for p in actual])
 
     for actual, expected in zip(actual, generic_ensemblers):
-        assert actual.id == expected.id
-        assert actual.name == expected.name
-        assert actual.project_id == active_project.id
-        assert actual.created_at == expected.created_at
-        assert actual.updated_at == expected.updated_at
+        assert actual.to_dict() == expected.to_dict()
 
 
 @responses.activate
@@ -98,14 +94,7 @@ def test_create_ensembler(
         }
     )
 
-    assert actual.id == pyfunc_ensembler.id
-    assert actual.name == pyfunc_ensembler.name
-    assert actual.project_id == pyfunc_ensembler.project_id
-    assert actual.mlflow_experiment_id == pyfunc_ensembler.mlflow_experiment_id
-    assert actual.mlflow_run_id == pyfunc_ensembler.mlflow_run_id
-    assert actual.artifact_uri == pyfunc_ensembler.artifact_uri
-    assert actual.created_at == pyfunc_ensembler.created_at
-    assert actual.updated_at == pyfunc_ensembler.updated_at
+    assert actual.to_dict() == pyfunc_ensembler.to_dict()
 
 
 @responses.activate
@@ -157,11 +146,4 @@ def test_update_ensembler(
         },
         code_dir=[os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "samples/quickstart")]
     )
-    assert actual.id == pyfunc_ensembler.id
-    assert actual.name == pyfunc_ensembler.name
-    assert actual.project_id == pyfunc_ensembler.project_id
-    assert actual.mlflow_experiment_id == pyfunc_ensembler.mlflow_experiment_id
-    assert actual.mlflow_run_id == pyfunc_ensembler.mlflow_run_id
-    assert actual.artifact_uri == pyfunc_ensembler.artifact_uri
-    assert actual.created_at == pyfunc_ensembler.created_at
-    assert actual.updated_at == pyfunc_ensembler.updated_at
+    assert actual.to_dict() == pyfunc_ensembler.to_dict()

--- a/sdk/tests/ensembler_test.py
+++ b/sdk/tests/ensembler_test.py
@@ -12,7 +12,7 @@ from turing import generated as client
 responses = Responses('requests.packages.urllib3')
 
 
-@pytest.fixture(scope="function", name="responses")
+@pytest.fixture(scope="module", name="responses")
 def _responses():
     return responses
 

--- a/sdk/tests/fixtures/mlflow.py
+++ b/sdk/tests/fixtures/mlflow.py
@@ -60,7 +60,7 @@ def mock_mlflow(responses, experiment_name, experiment_id, run_id, artifact_uri)
 
     responses.add(
         method="POST",
-        url=f"/api/2.0/mlflow/runs/log-model",
+        url="/api/2.0/mlflow/runs/log-model",
         body="{}",
         status=200,
         content_type="application/json",

--- a/sdk/tests/testdata/api_responses/get_job_0000.json
+++ b/sdk/tests/testdata/api_responses/get_job_0000.json
@@ -1,0 +1,88 @@
+{
+  "id": 1,
+  "created_at": "2021-07-06T12:28:32.850365Z",
+  "updated_at": "2021-07-07T00:00:00.252642Z",
+  "name": "pyfunc-ensembler: 2021-07-06T00:00:00+03:00",
+  "ensembler_id": 2,
+  "project_id": 1,
+  "environment_name": "dev",
+  "infra_config": {
+    "artifact_uri": "gs://bucket-name/mlflow/343/f5fb1c8bdb3845648c02001c54a609d7/artifacts",
+    "ensembler_name": "pyfunc-ensembler",
+    "service_account_name": "service-account",
+    "resources": {
+      "driver_cpu_request": "1",
+      "driver_memory_request": "2Gi",
+      "executor_replica": 5,
+      "executor_cpu_request": "0.8",
+      "executor_memory_request": "1Gi"
+    }
+  },
+  "job_config": {
+    "version": "v1",
+    "kind": "BatchEnsemblingJob",
+    "spec": {
+      "source": {
+        "dataset": {
+          "type": "BQ",
+          "bq_config": {
+            "table": "project.dataset.ensembling_results",
+            "features":
+            [
+              "feature_1",
+              "feature_2"
+            ]
+          }
+        },
+        "join_on":
+        [
+          "feature_1"
+        ]
+      },
+      "predictions": {
+        "model_a": {
+          "dataset": {
+            "type": "BQ",
+            "bq_config": {
+              "table": "project.dataset.ensembling_results",
+              "features":
+              [
+                "feature_1",
+                "feature_2"
+              ]
+            }
+          },
+          "join_on":
+          [
+            "feature_1"
+          ],
+          "columns":
+          [
+            "feature_2"
+          ]
+        }
+      },
+      "ensembler": {
+        "uri": "/home/spark/artifacts",
+        "result": {
+          "column_name": "prediction_result",
+          "type": "DOUBLE"
+        }
+      },
+      "sink": {
+        "type": "BQ",
+        "columns":
+        [
+          "prediction_score"
+        ],
+        "save_mode": "ERRORIFEXISTS",
+        "bq_config": {
+          "table": "project.dataset.ensembling_results",
+          "staging_bucket": "staging_bucket"
+        }
+      }
+    }
+  },
+  "status": "failed_building",
+  "error": "timeout has occurred"
+}

--- a/sdk/turing/__init__.py
+++ b/sdk/turing/__init__.py
@@ -1,10 +1,33 @@
-import turing.session
-from turing.project import Project
 from turing.ensembler import Ensembler, EnsemblerType, PyFuncEnsembler
-
+from turing.project import Project
+from turing.session import TuringSession
 from turing.version import VERSION as __version__
 
-set_url = turing.session.set_url
-set_project = turing.session.set_project
+active_session: TuringSession = TuringSession(
+    host="http://localhost:8080",
+    use_google_oauth=False
+)
 
-__all__ = ["set_url", "set_project"]
+
+def set_url(url: str, use_google_oauth: bool = True):
+    """
+    Set Turing API URL
+
+    :param url: Turing API URL
+    :param use_google_oauth: whether use google auth or not
+    """
+
+    global active_session
+    active_session = TuringSession(host=url, use_google_oauth=use_google_oauth)
+
+
+def set_project(project_name: str):
+    """
+    Set active project
+
+    :param project_name: project name
+    """
+    active_session.set_project(project_name)
+
+
+__all__ = ["set_url", "set_project", "active_session"]

--- a/sdk/turing/_base_types.py
+++ b/sdk/turing/_base_types.py
@@ -23,6 +23,11 @@ class DataObject:
 
         return dict(attribs)
 
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return self.to_dict() == other.to_dict()
+        return False
+
     def __str__(self):
         return '%s(%s)' % (
             type(self).__name__,

--- a/sdk/turing/_base_types.py
+++ b/sdk/turing/_base_types.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from turing.generated.model_utils import ModelNormal
+from turing.generated.model_utils import OpenApiModel
 
 
 class DataObject:
@@ -60,7 +60,7 @@ class ApiObject(DataObject):
         return self._updated_at
 
     @classmethod
-    def from_open_api(cls, open_api: ModelNormal):
+    def from_open_api(cls, open_api: OpenApiModel):
         """
         Factory method, for constructing ApiObject (and its sub-classes) instances
         from a relevant instance of openapi-generator generated model instance

--- a/sdk/turing/batch/job.py
+++ b/sdk/turing/batch/job.py
@@ -32,6 +32,7 @@ class EnsemblingJobStatus(Enum):
     """
 
     PENDING = "pending"
+    BUILDING = "building"
     RUNNING = "running"
     TERMINATING = "terminating"
     TERMINATED = "terminated"
@@ -85,6 +86,36 @@ class EnsemblingJob(ApiObject):
     @property
     def error(self) -> str:
         return self._error
+
+    def refresh(self):
+        """
+        Fetches latest updates of this ensembling job
+        """
+        from turing.session import active_session
+        self.__dict__.update(
+            EnsemblingJob.from_open_api(
+                active_session.get_ensembling_job(job_id=self.id)
+            ).__dict__
+        )
+
+    def terminate(self):
+        """
+        Terminates this ensembling job
+        """
+        from turing.session import active_session
+        active_session.terminate_ensembling_job(job_id=self.id)
+
+        self.refresh()
+
+    @classmethod
+    def get_by_id(cls, job_id: int) -> 'EnsemblingJob':
+        """
+        Fetch ensembling job by its ID
+        """
+        from turing.session import active_session
+        return EnsemblingJob.from_open_api(
+            active_session.get_ensembling_job(job_id=job_id)
+        )
 
     @classmethod
     def submit(

--- a/sdk/turing/batch/job.py
+++ b/sdk/turing/batch/job.py
@@ -91,10 +91,9 @@ class EnsemblingJob(ApiObject):
         """
         Fetches latest updates of this ensembling job
         """
-        from turing.session import active_session
         self.__dict__.update(
             EnsemblingJob.from_open_api(
-                active_session.get_ensembling_job(job_id=self.id)
+                turing.active_session.get_ensembling_job(job_id=self.id)
             ).__dict__
         )
 
@@ -102,9 +101,7 @@ class EnsemblingJob(ApiObject):
         """
         Terminates this ensembling job
         """
-        from turing.session import active_session
-        active_session.terminate_ensembling_job(job_id=self.id)
-
+        turing.active_session.terminate_ensembling_job(job_id=self.id)
         self.refresh()
 
     @classmethod
@@ -112,10 +109,8 @@ class EnsemblingJob(ApiObject):
         """
         Fetch ensembling job by its ID
         """
-        from turing.session import active_session
         return EnsemblingJob.from_open_api(
-            active_session.get_ensembling_job(job_id=job_id)
-        )
+            turing.active_session.get_ensembling_job(job_id=job_id))
 
     @classmethod
     def submit(
@@ -129,8 +124,6 @@ class EnsemblingJob(ApiObject):
         :param config: configuration of ensembling job
         :return: instance of ensembling job
         """
-        from turing.session import active_session
-
         job_config = turing.generated.models.EnsemblerConfig(
             version=EnsemblingJob._VERSION,
             kind=turing.generated.models.EnsemblerConfigKind(EnsemblingJob._KIND),
@@ -144,8 +137,7 @@ class EnsemblingJob(ApiObject):
         )
 
         return EnsemblingJob.from_open_api(
-            active_session.submit_ensembling_job(job=job)
-        )
+            turing.active_session.submit_ensembling_job(job=job))
 
     @classmethod
     def list(
@@ -162,14 +154,11 @@ class EnsemblingJob(ApiObject):
 
         :return: list of ensembling jobs
         """
-
-        from turing.session import active_session
-
         mapped_statuses = None
         if status:
             mapped_statuses = [turing.generated.models.EnsemblerJobStatus(s.value) for s in status]
 
-        response = active_session.list_ensembling_jobs(
+        response = turing.active_session.list_ensembling_jobs(
             status=mapped_statuses,
             page=page,
             page_size=page_size

--- a/sdk/turing/ensembler.py
+++ b/sdk/turing/ensembler.py
@@ -253,6 +253,19 @@ class PyFuncEnsembler(Ensembler):
         return EnsemblingJob.submit(self.id, job_config)
 
     @classmethod
+    def get_by_id(cls, ensembler_id: int) -> 'PyFuncEnsembler':
+        """
+        Get the instance of a pyfunc ensembler with given ID
+
+        :param ensembler_id:
+        :return: instance of pyfunc ensembler
+        """
+        from turing.session import active_session
+
+        return PyFuncEnsembler.from_open_api(
+            active_session.get_ensembler(ensembler_id))
+
+    @classmethod
     def list(
             cls,
             page: Optional[int] = None,

--- a/sdk/turing/ensembler.py
+++ b/sdk/turing/ensembler.py
@@ -1,12 +1,11 @@
 import abc
 from enum import Enum
 from typing import Optional, Union, List, Any, Dict
-import mlflow.pyfunc
+import mlflow
 import numpy
 import pandas
 import turing.generated.models
 from turing._base_types import ApiObject, ApiObjectSpec
-
 from turing.batch import EnsemblingJob
 from turing.batch.config import EnsemblingJobConfig
 
@@ -125,9 +124,7 @@ class Ensembler(ApiObject):
         :return: list of ensemblers
         """
 
-        from turing.session import active_session
-
-        response = active_session.list_ensemblers(
+        response = turing.active_session.list_ensemblers(
             ensembler_type=ensembler_type,
             page=page,
             page_size=page_size
@@ -184,10 +181,9 @@ class PyFuncEnsembler(Ensembler):
         return f"{project_name}/ensemblers/{ensembler_name}"
 
     def _save(self):
-        from turing.session import active_session
         self.__dict__.update(
             PyFuncEnsembler.from_open_api(
-                active_session.update_ensembler(self.to_open_api())
+                turing.active_session.update_ensembler(self.to_open_api())
             ).__dict__
         )
 
@@ -212,15 +208,11 @@ class PyFuncEnsembler(Ensembler):
             with the model. This will be passed to turing.ensembler.PyFunc.initialize().
             Example: {"config" : "config/staging.yaml"}
         """
-
-        import mlflow
-        from turing.session import active_session
-
         if name:
             self.name = name
 
         if ensembler_instance:
-            project_name = active_session.active_project.name
+            project_name = turing.active_session.active_project.name
             mlflow.set_experiment(experiment_name=self._experiment_name(project_name, self.name))
 
             mlflow.start_run()
@@ -260,10 +252,8 @@ class PyFuncEnsembler(Ensembler):
         :param ensembler_id:
         :return: instance of pyfunc ensembler
         """
-        from turing.session import active_session
-
         return PyFuncEnsembler.from_open_api(
-            active_session.get_ensembler(ensembler_id))
+            turing.active_session.get_ensembler(ensembler_id))
 
     @classmethod
     def list(
@@ -279,9 +269,7 @@ class PyFuncEnsembler(Ensembler):
 
         :return: list of pyfunc ensemblers
         """
-        from turing.session import active_session
-
-        response = active_session.list_ensemblers(
+        response = turing.active_session.list_ensemblers(
             ensembler_type=EnsemblerType.PYFUNC,
             page=page,
             page_size=page_size
@@ -313,10 +301,7 @@ class PyFuncEnsembler(Ensembler):
 
         :return: saved instance of PyFuncEnsembler
         """
-        import mlflow
-        from turing.session import active_session
-
-        project_name = active_session.active_project.name
+        project_name = turing.active_session.active_project.name
         mlflow.set_experiment(experiment_name=cls._experiment_name(project_name, name))
 
         mlflow.start_run()
@@ -339,4 +324,4 @@ class PyFuncEnsembler(Ensembler):
         mlflow.end_run()
 
         return PyFuncEnsembler.from_open_api(
-            active_session.create_ensembler(ensembler.to_open_api()))
+            turing.active_session.create_ensembler(ensembler.to_open_api()))

--- a/sdk/turing/generated/api/ensembling_job_api.py
+++ b/sdk/turing/generated/api/ensembling_job_api.py
@@ -166,132 +166,6 @@ class EnsemblingJobApi(object):
             callable=__create_ensembling_job
         )
 
-        def __delete_ensembling_job(
-            self,
-            project_id,
-            job_id,
-            **kwargs
-        ):
-            """Delete an ongoing Ensembling Job.  # noqa: E501
-
-            This method makes a synchronous HTTP request by default. To make an
-            asynchronous HTTP request, please pass async_req=True
-
-            >>> thread = api.delete_ensembling_job(project_id, job_id, async_req=True)
-            >>> result = thread.get()
-
-            Args:
-                project_id (int):
-                job_id (int):
-
-            Keyword Args:
-                _return_http_data_only (bool): response data without head status
-                    code and headers. Default is True.
-                _preload_content (bool): if False, the urllib3.HTTPResponse object
-                    will be returned without reading/decoding response data.
-                    Default is True.
-                _request_timeout (float/tuple): timeout setting for this request. If one
-                    number provided, it will be total request timeout. It can also
-                    be a pair (tuple) of (connection, read) timeouts.
-                    Default is None.
-                _check_input_type (bool): specifies if type checking
-                    should be done one the data sent to the server.
-                    Default is True.
-                _check_return_type (bool): specifies if type checking
-                    should be done one the data received from the server.
-                    Default is True.
-                _host_index (int/None): specifies the index of the server
-                    that we want to use.
-                    Default is read from the configuration.
-                async_req (bool): execute request asynchronously
-
-            Returns:
-                IdObject
-                    If the method is called asynchronously, returns the request
-                    thread.
-            """
-            kwargs['async_req'] = kwargs.get(
-                'async_req', False
-            )
-            kwargs['_return_http_data_only'] = kwargs.get(
-                '_return_http_data_only', True
-            )
-            kwargs['_preload_content'] = kwargs.get(
-                '_preload_content', True
-            )
-            kwargs['_request_timeout'] = kwargs.get(
-                '_request_timeout', None
-            )
-            kwargs['_check_input_type'] = kwargs.get(
-                '_check_input_type', True
-            )
-            kwargs['_check_return_type'] = kwargs.get(
-                '_check_return_type', True
-            )
-            kwargs['_host_index'] = kwargs.get('_host_index')
-            kwargs['project_id'] = \
-                project_id
-            kwargs['job_id'] = \
-                job_id
-            return self.call_with_http_info(**kwargs)
-
-        self.delete_ensembling_job = _Endpoint(
-            settings={
-                'response_type': (IdObject,),
-                'auth': [],
-                'endpoint_path': '/projects/{project_id}/jobs/{job_id}',
-                'operation_id': 'delete_ensembling_job',
-                'http_method': 'DELETE',
-                'servers': None,
-            },
-            params_map={
-                'all': [
-                    'project_id',
-                    'job_id',
-                ],
-                'required': [
-                    'project_id',
-                    'job_id',
-                ],
-                'nullable': [
-                ],
-                'enum': [
-                ],
-                'validation': [
-                ]
-            },
-            root_map={
-                'validations': {
-                },
-                'allowed_values': {
-                },
-                'openapi_types': {
-                    'project_id':
-                        (int,),
-                    'job_id':
-                        (int,),
-                },
-                'attribute_map': {
-                    'project_id': 'project_id',
-                    'job_id': 'job_id',
-                },
-                'location_map': {
-                    'project_id': 'path',
-                    'job_id': 'path',
-                },
-                'collection_format_map': {
-                }
-            },
-            headers_map={
-                'accept': [
-                    'application/json'
-                ],
-                'content_type': [],
-            },
-            api_client=api_client,
-            callable=__delete_ensembling_job
-        )
-
         def __get_ensembling_job(
             self,
             project_id,
@@ -551,4 +425,130 @@ class EnsemblingJobApi(object):
             },
             api_client=api_client,
             callable=__list_ensembling_jobs
+        )
+
+        def __terminate_ensembling_job(
+            self,
+            project_id,
+            job_id,
+            **kwargs
+        ):
+            """Terminate an ongoing Ensembling Job.  # noqa: E501
+
+            This method makes a synchronous HTTP request by default. To make an
+            asynchronous HTTP request, please pass async_req=True
+
+            >>> thread = api.terminate_ensembling_job(project_id, job_id, async_req=True)
+            >>> result = thread.get()
+
+            Args:
+                project_id (int):
+                job_id (int):
+
+            Keyword Args:
+                _return_http_data_only (bool): response data without head status
+                    code and headers. Default is True.
+                _preload_content (bool): if False, the urllib3.HTTPResponse object
+                    will be returned without reading/decoding response data.
+                    Default is True.
+                _request_timeout (float/tuple): timeout setting for this request. If one
+                    number provided, it will be total request timeout. It can also
+                    be a pair (tuple) of (connection, read) timeouts.
+                    Default is None.
+                _check_input_type (bool): specifies if type checking
+                    should be done one the data sent to the server.
+                    Default is True.
+                _check_return_type (bool): specifies if type checking
+                    should be done one the data received from the server.
+                    Default is True.
+                _host_index (int/None): specifies the index of the server
+                    that we want to use.
+                    Default is read from the configuration.
+                async_req (bool): execute request asynchronously
+
+            Returns:
+                IdObject
+                    If the method is called asynchronously, returns the request
+                    thread.
+            """
+            kwargs['async_req'] = kwargs.get(
+                'async_req', False
+            )
+            kwargs['_return_http_data_only'] = kwargs.get(
+                '_return_http_data_only', True
+            )
+            kwargs['_preload_content'] = kwargs.get(
+                '_preload_content', True
+            )
+            kwargs['_request_timeout'] = kwargs.get(
+                '_request_timeout', None
+            )
+            kwargs['_check_input_type'] = kwargs.get(
+                '_check_input_type', True
+            )
+            kwargs['_check_return_type'] = kwargs.get(
+                '_check_return_type', True
+            )
+            kwargs['_host_index'] = kwargs.get('_host_index')
+            kwargs['project_id'] = \
+                project_id
+            kwargs['job_id'] = \
+                job_id
+            return self.call_with_http_info(**kwargs)
+
+        self.terminate_ensembling_job = _Endpoint(
+            settings={
+                'response_type': (IdObject,),
+                'auth': [],
+                'endpoint_path': '/projects/{project_id}/jobs/{job_id}',
+                'operation_id': 'terminate_ensembling_job',
+                'http_method': 'DELETE',
+                'servers': None,
+            },
+            params_map={
+                'all': [
+                    'project_id',
+                    'job_id',
+                ],
+                'required': [
+                    'project_id',
+                    'job_id',
+                ],
+                'nullable': [
+                ],
+                'enum': [
+                ],
+                'validation': [
+                ]
+            },
+            root_map={
+                'validations': {
+                },
+                'allowed_values': {
+                },
+                'openapi_types': {
+                    'project_id':
+                        (int,),
+                    'job_id':
+                        (int,),
+                },
+                'attribute_map': {
+                    'project_id': 'project_id',
+                    'job_id': 'job_id',
+                },
+                'location_map': {
+                    'project_id': 'path',
+                    'job_id': 'path',
+                },
+                'collection_format_map': {
+                }
+            },
+            headers_map={
+                'accept': [
+                    'application/json'
+                ],
+                'content_type': [],
+            },
+            api_client=api_client,
+            callable=__terminate_ensembling_job
         )

--- a/sdk/turing/generated/model/ensembler_job_status.py
+++ b/sdk/turing/generated/model/ensembler_job_status.py
@@ -50,6 +50,7 @@ class EnsemblerJobStatus(ModelSimple):
     allowed_values = {
         ('value',): {
             'PENDING': "pending",
+            'BUILDING': "building",
             'RUNNING': "running",
             'TERMINATING': "terminating",
             'TERMINATED': "terminated",
@@ -106,10 +107,10 @@ class EnsemblerJobStatus(ModelSimple):
         Note that value can be passed either in args or in kwargs, but not in both.
 
         Args:
-            args[0] (str):, must be one of ["pending", "running", "terminating", "terminated", "completed", "failed", "failed_submission", "failed_building", ]  # noqa: E501
+            args[0] (str):, must be one of ["pending", "building", "running", "terminating", "terminated", "completed", "failed", "failed_submission", "failed_building", ]  # noqa: E501
 
         Keyword Args:
-            value (str):, must be one of ["pending", "running", "terminating", "terminated", "completed", "failed", "failed_submission", "failed_building", ]  # noqa: E501
+            value (str):, must be one of ["pending", "building", "running", "terminating", "terminated", "completed", "failed", "failed_submission", "failed_building", ]  # noqa: E501
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.

--- a/sdk/turing/project.py
+++ b/sdk/turing/project.py
@@ -31,7 +31,5 @@ class Project(ApiObject):
 
     @classmethod
     def list(cls, name: Optional[str] = None) -> List['Project']:
-        from turing.session import active_session
-
-        response = active_session.list_projects(name=name)
+        response = turing.active_session.list_projects(name=name)
         return [Project.from_open_api(item) for item in response]

--- a/sdk/turing/session.py
+++ b/sdk/turing/session.py
@@ -11,7 +11,8 @@ from turing.generated.models import \
     EnsemblingJob, \
     EnsemblerJobStatus, \
     EnsemblersPaginatedResults, \
-    EnsemblingJobPaginatedResults
+    EnsemblingJobPaginatedResults, \
+    IdObject
 
 
 def require_active_project(f):
@@ -132,6 +133,16 @@ class TuringSession:
             ensembler=ensembler)
 
     @require_active_project
+    def get_ensembler(self, ensembler_id: int) -> Ensembler:
+        """
+        Fetch ensembler details by its ID
+        """
+        return EnsemblerApi(self._api_client).get_ensembler_details(
+            project_id=self.active_project.id,
+            ensembler_id=ensembler_id,
+        )
+
+    @require_active_project
     def update_ensembler(self, ensembler: Ensembler) -> Ensembler:
         """
         Update existing ensembler
@@ -161,6 +172,23 @@ class TuringSession:
         return EnsemblingJobApi(self._api_client).list_ensembling_jobs(
             project_id=self.active_project.id,
             **kwargs
+        )
+
+    @require_active_project
+    def get_ensembling_job(self, job_id: int) -> EnsemblingJob:
+        """
+        Fetch ensembling job by its ID
+        """
+        return EnsemblingJobApi(self._api_client).get_ensembling_job(
+            project_id=self.active_project.id,
+            job_id=job_id
+        )
+
+    @require_active_project
+    def terminate_ensembling_job(self, job_id: int) -> IdObject:
+        return EnsemblingJobApi(self._api_client).terminate_ensembling_job(
+            project_id=self.active_project.id,
+            job_id=job_id
         )
 
     @require_active_project

--- a/sdk/turing/session.py
+++ b/sdk/turing/session.py
@@ -1,7 +1,6 @@
 import os
 import mlflow
 from typing import List, Optional
-
 from turing.ensembler import EnsemblerType
 from turing.generated import ApiClient, Configuration
 from turing.generated.apis import EnsemblerApi, EnsemblingJobApi, ProjectApi
@@ -197,30 +196,3 @@ class TuringSession:
             project_id=self.active_project.id,
             ensembling_job=job
         )
-
-
-active_session: TuringSession = TuringSession(
-    host="http://localhost:8080",
-    use_google_oauth=False
-)
-
-
-def set_url(url: str, use_google_oauth: bool = True):
-    """
-    Set Turing API URL
-
-    :param url: Turing API URL
-    :param use_google_oauth: whether use google auth or not
-    """
-
-    global active_session
-    active_session = TuringSession(host=url, use_google_oauth=use_google_oauth)
-
-
-def set_project(project_name: str):
-    """
-    Set active project
-
-    :param project_name: project name
-    """
-    active_session.set_project(project_name)


### PR DESCRIPTION
### Context:
This PR builds up on the [previous PR](https://github.com/gojek/turing/pull/72) and adds the way to terminate a running job from the SDK

### Changes:
- Added `.terminate()` and `.refresh()` methods into `EnsemblingJob`class
- Added minor fixes into turing-api and openapi spec
- Extended [batch_job.py](https://github.com/gojek/turing/compare/main...romanwozniak:sdk_terminate_ensembling_job?expand=1#diff-24411c64b2ce258f7ecccd88cb035d695dbc0e652fba7025ddc156d26117a620) example with a demonstration on how to terminate the job
- Unit tests