### PR TITLE
UI: Add view to show ensemblers

### DIFF
--- a/api/api/specs/jobs.yaml
+++ b/api/api/specs/jobs.yaml
@@ -29,6 +29,14 @@ paths:
             type: integer
             default: 10
         - in: query
+          name: ensembler_id
+          schema:
+            $ref: "#/components/schemas/Id"
+        - in: query
+          name: search
+          schema:
+            type: string
+        - in: query
           name: status
           schema:
             type: array

--- a/api/turing/service/ensembling_job_service.go
+++ b/api/turing/service/ensembling_job_service.go
@@ -23,7 +23,9 @@ type EnsemblingJobFindByIDOptions struct {
 type EnsemblingJobListOptions struct {
 	PaginationOptions
 	ProjectID          *models.ID      `schema:"project_id" validate:"required"`
+	EnsemblerID        *models.ID      `schema:"ensembler_id"`
 	Statuses           []models.Status `schema:"status"`
+	Search             *string         `schema:"search"`
 	RetryCountLessThan *int            `schema:"-"`
 	UpdatedAtBefore    *time.Time      `schema:"-"`
 }
@@ -98,6 +100,14 @@ func (s *ensemblingJobService) List(options EnsemblingJobListOptions) (*Paginate
 	query := s.db
 	if options.ProjectID != nil {
 		query = query.Where("project_id = ?", options.ProjectID)
+	}
+
+	if options.EnsemblerID != nil {
+		query = query.Where("ensembler_id = ?", options.EnsemblerID)
+	}
+
+	if options.Search != nil && len(*options.Search) > 0 {
+		query = query.Where("name like ?", fmt.Sprintf("%%%s%%", *options.Search))
 	}
 
 	if options.Statuses != nil {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1390,9 +1390,9 @@
       }
     },
     "@gojek/mlp-ui": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@gojek/mlp-ui/-/mlp-ui-1.4.8.tgz",
-      "integrity": "sha512-TsmIUlMOJTZOeOOQD77guYCp/xFIb2Xuemj8bBYPjrwbDtHDBCz8nG494zdoP7ZWIdMFgDEPFGLFHqhQnyd82g==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@gojek/mlp-ui/-/mlp-ui-1.4.9.tgz",
+      "integrity": "sha512-aDXOL/apwKTtUchmjux+f6+XufSjl9CNb+9EXJ7PvbFZ0eZKCh7dGKrvNleqRY/cbDAhhZnzeoc5huoR0x83BA==",
       "requires": {
         "classnames": "^2.2.6",
         "lodash": "^4.17.20",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1407,6 +1407,19 @@
         "react-sticky": "^6.0.3",
         "resize-observer-polyfill": "^1.5.1",
         "yup": "^0.29.1"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "6.14.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+          "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "filter-obj": "^1.1.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        }
       }
     },
     "@hapi/address": {
@@ -14470,6 +14483,19 @@
       "integrity": "sha512-40x6taKMwsDn4TrWx4YvnVxv5mO1O9KUrbK/jx8N0oDYf38ZFUK/OHNSAwTvu7Aj+cQcjBuf5aDh5R328YrrXg==",
       "requires": {
         "query-string": "^6.3.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "6.14.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+          "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "filter-obj": "^1.1.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        }
       }
     },
     "property-expr": {
@@ -14570,9 +14596,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "mitt": "^2.1.0",
     "moment": "^2.27.0",
     "object-assign-deep": "^0.4.0",
+    "query-string": "^7.0.1",
     "react": "16.13.1",
     "react-diff-viewer": "^3.1.1",
     "react-dom": "16.13.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@elastic/datemath": "5.0.3",
     "@elastic/eui": "32.3.0",
-    "@gojek/mlp-ui": "1.4.8",
+    "@gojek/mlp-ui": "1.4.9",
     "@reach/router": "1.3.3",
     "@sentry/browser": "5.15.5",
     "js-yaml": "^4.0.0",

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -17,6 +17,7 @@ import { RouterDetailsView } from "./router/details/RouterDetailsView";
 import { RouterVersionDetailsView } from "./router/versions/details/RouterVersionDetailsView";
 import { PrivateLayout } from "./PrivateLayout";
 import { ListEnsemblingJobsView } from "./job/list/ListEnsemblingJobsView";
+import { ListEnsemblersView } from "./ensembler/list/ListEnsemblersView";
 
 const App = () => (
   <ErrorBoundary>
@@ -46,6 +47,12 @@ const App = () => (
           <PrivateRoute
             path={`${appConfig.homepage}/projects/:projectId/jobs`}
             render={PrivateLayout(ListEnsemblingJobsView)}
+          />
+
+          {/* ENSEMBLERS */}
+          <PrivateRoute
+            path={`${appConfig.homepage}/projects/:projectId/ensemblers`}
+            render={PrivateLayout(ListEnsemblersView)}
           />
 
           {/* CREATE ROUTER */}

--- a/ui/src/ensembler/list/ListEnsemblersTable.js
+++ b/ui/src/ensembler/list/ListEnsemblersTable.js
@@ -1,0 +1,158 @@
+import React, { Fragment, useState } from "react";
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiCallOut,
+  EuiHealth,
+  EuiSearchBar,
+  EuiSpacer,
+  EuiText,
+  EuiToolTip
+} from "@elastic/eui";
+import { appConfig } from "../../config";
+import { EnsemblerType } from "../../services/ensembler/EnsemblerType";
+import moment from "moment";
+
+const { defaultTextSize, defaultIconSize, dateFormat } = appConfig.tables;
+
+export const ListEnsemblersTable = ({
+  items,
+  totalItemCount,
+  isLoaded,
+  error,
+  defaultPageSize,
+  onQueryChange,
+  onPaginationChange,
+  onRowClick
+}) => {
+  const [searchQuery, setSearchQuery] = useState(EuiSearchBar.Query.MATCH_ALL);
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(defaultPageSize);
+
+  const onSearchChange = ({ queryText }) => {
+    const query = EuiSearchBar.Query.parse(queryText);
+    setSearchQuery(query);
+    onQueryChange(query);
+  };
+
+  const onTableChange = ({ page = {} }) => {
+    setPageIndex(page.index);
+    setPageSize(page.size);
+
+    onPaginationChange(page);
+  };
+
+  const columns = [
+    {
+      field: "id",
+      name: "Id",
+      width: "72px",
+      render: (id, item) => (
+        <EuiText size={defaultTextSize}>
+          {id}
+          {moment().diff(item.created_at, "hours") <= 1 && (
+            <Fragment>
+              &nbsp;
+              <EuiBadge color="secondary">New</EuiBadge>
+            </Fragment>
+          )}
+        </EuiText>
+      )
+    },
+    {
+      field: "name",
+      name: "Name",
+      width: "30%",
+      render: name => (
+        <span className="eui-textTruncate" title={name}>
+          {name}
+        </span>
+      )
+    },
+    {
+      field: "created_at",
+      name: "Created",
+      sortable: true,
+      width: "20%",
+      render: date => (
+        <EuiToolTip
+          position="top"
+          content={moment(date, dateFormat).toLocaleString()}>
+          <EuiText size={defaultTextSize}>
+            {moment(date, dateFormat).fromNow()}
+          </EuiText>
+        </EuiToolTip>
+      )
+    },
+    {
+      field: "updated_at",
+      name: "Updated",
+      width: "20%",
+      render: date => (
+        <EuiToolTip
+          position="top"
+          content={moment(date, dateFormat).toLocaleString()}>
+          <EuiText size={defaultTextSize}>
+            {moment(date, dateFormat).fromNow()}
+          </EuiText>
+        </EuiToolTip>
+      )
+    }
+  ];
+
+  const pagination = {
+    pageIndex,
+    pageSize,
+    totalItemCount
+  };
+
+  const search = {
+    query: searchQuery,
+    onChange: onSearchChange,
+    box: {
+      incremental: true
+    },
+    filters: [
+      {
+        type: "field_value_selection",
+        field: "type",
+        name: "Ensembler Type",
+        multiSelect: false,
+        options: EnsemblerType.values.map(status => ({
+          value: status.toString(),
+          view: <EuiHealth color={status.color}>{status.toString()}</EuiHealth>
+        }))
+      }
+    ]
+  };
+
+  const cellProps = item =>
+    onRowClick
+      ? {
+          style: { cursor: "pointer" },
+          onClick: () => onRowClick(item)
+        }
+      : undefined;
+
+  return error ? (
+    <EuiCallOut
+      title="Sorry, there was an error"
+      color="danger"
+      iconType="alert">
+      <p>{error.message}</p>
+    </EuiCallOut>
+  ) : (
+    <Fragment>
+      <EuiSearchBar {...search} />
+      <EuiSpacer size="l" />
+      <EuiBasicTable
+        items={items}
+        loading={!isLoaded}
+        columns={columns}
+        cellProps={cellProps}
+        pagination={pagination}
+        onChange={onTableChange}
+      />
+    </Fragment>
+  );
+};

--- a/ui/src/ensembler/list/ListEnsemblersTable.js
+++ b/ui/src/ensembler/list/ListEnsemblersTable.js
@@ -20,14 +20,12 @@ export const ListEnsemblersTable = ({
   totalItemCount,
   isLoaded,
   error,
-  defaultPageSize,
+  page,
   onQueryChange,
   onPaginationChange,
   onRowClick
 }) => {
   const [searchQuery, setSearchQuery] = useState(EuiSearchBar.Query.MATCH_ALL);
-  const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState(defaultPageSize);
 
   const onSearchChange = ({ queryText }) => {
     const query = EuiSearchBar.Query.parse(queryText);
@@ -35,12 +33,7 @@ export const ListEnsemblersTable = ({
     onQueryChange(query);
   };
 
-  const onTableChange = ({ page = {} }) => {
-    setPageIndex(page.index);
-    setPageSize(page.size);
-
-    onPaginationChange(page);
-  };
+  const onTableChange = ({ page = {} }) => onPaginationChange(page);
 
   const columns = [
     {
@@ -68,6 +61,11 @@ export const ListEnsemblersTable = ({
           {name}
         </span>
       )
+    },
+    {
+      field: "type",
+      name: "Type",
+      width: "15%"
     },
     {
       field: "created_at",
@@ -101,8 +99,8 @@ export const ListEnsemblersTable = ({
   ];
 
   const pagination = {
-    pageIndex,
-    pageSize,
+    pageIndex: page.index,
+    pageSize: page.size,
     totalItemCount
   };
 

--- a/ui/src/ensembler/list/ListEnsemblersView.js
+++ b/ui/src/ensembler/list/ListEnsemblersView.js
@@ -14,8 +14,8 @@ import { appConfig } from "../../config";
 
 const { defaultPageSize } = appConfig.pagination;
 
-export const ListEnsemblersView = ({ projectId, ...props }) => {
-  const [pagination, setPagination] = useState({ page_size: defaultPageSize });
+export const ListEnsemblersView = ({ projectId }) => {
+  const [page, setPage] = useState({ index: 0, size: defaultPageSize });
   const [filter, setFilter] = useState({});
   const [results, setResults] = useState({ items: [], totalItemCount: 0 });
 
@@ -32,19 +32,15 @@ export const ListEnsemblersView = ({ projectId, ...props }) => {
     });
   };
 
-  const onPaginationChange = page => {
-    setPagination({
-      page: page.index + 1,
-      page_size: page.size
-    });
-  };
-
   const [{ data, isLoaded, error }] = useTuringApi(
     `/projects/${projectId}/ensemblers`,
     {
       query: {
         ...filter,
-        ...pagination
+        ...{
+          page: page.index + 1,
+          page_size: page.size
+        }
       }
     },
     { results: [], paging: { total: 0 } }
@@ -79,9 +75,9 @@ export const ListEnsemblersView = ({ projectId, ...props }) => {
             {...results}
             isLoaded={isLoaded}
             error={error}
-            defaultPageSize={defaultPageSize}
+            page={page}
             onQueryChange={onQueryChange}
-            onPaginationChange={onPaginationChange}
+            onPaginationChange={setPage}
             onRowClick={onRowClick}
           />
         </EuiPageContent>

--- a/ui/src/ensembler/list/ListEnsemblersView.js
+++ b/ui/src/ensembler/list/ListEnsemblersView.js
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from "react";
+import { useTuringApi } from "../../hooks/useTuringApi";
+import { replaceBreadcrumbs } from "@gojek/mlp-ui";
+import {
+  EuiPage,
+  EuiPageBody,
+  EuiPageContent,
+  EuiPageHeader,
+  EuiPageHeaderSection
+} from "@elastic/eui";
+import { PageTitle } from "../../components/page/PageTitle";
+import { ListEnsemblersTable } from "./ListEnsemblersTable";
+import { appConfig } from "../../config";
+
+const { defaultPageSize } = appConfig.pagination;
+
+export const ListEnsemblersView = ({ projectId, ...props }) => {
+  const [pagination, setPagination] = useState({ page_size: defaultPageSize });
+  const [filter, setFilter] = useState({});
+  const [results, setResults] = useState({ items: [], totalItemCount: 0 });
+
+  const onQueryChange = query => {
+    setFilter(filter => {
+      const typeClause = query.getSimpleFieldClause("type");
+
+      if (!!typeClause) {
+        filter["type"] = typeClause.value;
+      } else {
+        delete filter["type"];
+      }
+      return { ...filter };
+    });
+  };
+
+  const onPaginationChange = page => {
+    setPagination({
+      page: page.index + 1,
+      page_size: page.size
+    });
+  };
+
+  const [{ data, isLoaded, error }] = useTuringApi(
+    `/projects/${projectId}/ensemblers`,
+    {
+      query: {
+        ...filter,
+        ...pagination
+      }
+    },
+    { results: [], paging: { total: 0 } }
+  );
+
+  useEffect(() => {
+    if (isLoaded && !error) {
+      setResults({
+        items: data.results,
+        totalItemCount: data.paging.total
+      });
+    }
+  }, [data, isLoaded, error]);
+
+  useEffect(() => {
+    replaceBreadcrumbs([{ text: "Ensemblers" }]);
+  }, []);
+
+  const onRowClick = item => {};
+  // props.navigate(`./${item.id}/details`);
+
+  return (
+    <EuiPage>
+      <EuiPageBody>
+        <EuiPageHeader>
+          <EuiPageHeaderSection>
+            <PageTitle title="Ensemblers" />
+          </EuiPageHeaderSection>
+        </EuiPageHeader>
+        <EuiPageContent>
+          <ListEnsemblersTable
+            {...results}
+            isLoaded={isLoaded}
+            error={error}
+            defaultPageSize={defaultPageSize}
+            onQueryChange={onQueryChange}
+            onPaginationChange={onPaginationChange}
+            onRowClick={onRowClick}
+          />
+        </EuiPageContent>
+      </EuiPageBody>
+    </EuiPage>
+  );
+};

--- a/ui/src/job/list/ListEnsemblingJobsTable.js
+++ b/ui/src/job/list/ListEnsemblingJobsTable.js
@@ -24,15 +24,13 @@ export const ListEnsemblingJobsTable = ({
   totalItemCount,
   isLoaded,
   error,
-  defaultPageSize,
+  page,
   onQueryChange,
   onPaginationChange,
   onRowClick
 }) => {
   const ensemblers = useContext(EnsemblersContext);
   const [searchQuery, setSearchQuery] = useState(EuiSearchBar.Query.MATCH_ALL);
-  const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState(defaultPageSize);
 
   const onSearchChange = ({ queryText }) => {
     const query = EuiSearchBar.Query.parse(queryText);
@@ -40,12 +38,7 @@ export const ListEnsemblingJobsTable = ({
     onQueryChange(query);
   };
 
-  const onTableChange = ({ page = {} }) => {
-    setPageIndex(page.index);
-    setPageSize(page.size);
-
-    onPaginationChange(page);
-  };
+  const onTableChange = ({ page = {} }) => onPaginationChange(page);
 
   const columns = [
     {
@@ -128,8 +121,8 @@ export const ListEnsemblingJobsTable = ({
   ];
 
   const pagination = {
-    pageIndex,
-    pageSize,
+    pageIndex: page.index,
+    pageSize: page.size,
     totalItemCount
   };
 

--- a/ui/src/job/list/ListEnsemblingJobsView.js
+++ b/ui/src/job/list/ListEnsemblingJobsView.js
@@ -17,7 +17,7 @@ import { appConfig } from "../../config";
 const { defaultPageSize } = appConfig.pagination;
 
 export const ListEnsemblingJobsView = ({ projectId }) => {
-  const [pagination, setPagination] = useState({ page_size: defaultPageSize });
+  const [page, setPage] = useState({ index: 0, size: defaultPageSize });
   const [filter, setFilter] = useState({});
   const [results, setResults] = useState({ items: [], totalItemCount: 0 });
 
@@ -34,19 +34,15 @@ export const ListEnsemblingJobsView = ({ projectId }) => {
     });
   };
 
-  const onPaginationChange = page => {
-    setPagination({
-      page: page.index + 1,
-      page_size: page.size
-    });
-  };
-
   const [{ data, isLoaded, error }] = useTuringApi(
     `/projects/${projectId}/jobs`,
     {
       query: {
         ...filter,
-        ...pagination
+        ...{
+          page: page.index + 1,
+          page_size: page.size
+        }
       }
     },
     { results: [], paging: { total: 0 } }
@@ -87,9 +83,9 @@ export const ListEnsemblingJobsView = ({ projectId }) => {
               {...results}
               isLoaded={isLoaded}
               error={error}
-              defaultPageSize={defaultPageSize}
+              page={page}
               onQueryChange={onQueryChange}
-              onPaginationChange={onPaginationChange}
+              onPaginationChange={setPage}
               onRowClick={onRowClick}
             />
           </EnsemblersContextContextProvider>

--- a/ui/src/providers/ensemblers/context.js
+++ b/ui/src/providers/ensemblers/context.js
@@ -21,9 +21,9 @@ export const EnsemblersContextContextProvider = ({
       query: !!ensemblerType
         ? {
             type: ensemblerType,
-            pageSize: Number.MAX_SAFE_INTEGER
+            page_size: Number.MAX_SAFE_INTEGER
           }
-        : { pageSize: Number.MAX_SAFE_INTEGER }
+        : { page_size: Number.MAX_SAFE_INTEGER }
     },
     { results: [] }
   );

--- a/ui/src/services/ensembler/EnsemblerType.js
+++ b/ui/src/services/ensembler/EnsemblerType.js
@@ -1,0 +1,9 @@
+import { EnumValue, Enum } from "../enum/Enum";
+
+export const EnsemblerType = Enum({
+  PYFUNC: EnumValue("pyfunc", {
+    label: "Pyfunc",
+    color: "#BD271E",
+    iconType: "cross"
+  })
+});

--- a/ui/src/services/ensembler/EnsemblerType.js
+++ b/ui/src/services/ensembler/EnsemblerType.js
@@ -2,8 +2,6 @@ import { EnumValue, Enum } from "../enum/Enum";
 
 export const EnsemblerType = Enum({
   PYFUNC: EnumValue("pyfunc", {
-    label: "Pyfunc",
-    color: "#BD271E",
-    iconType: "cross"
+    label: "Pyfunc"
   })
 });

--- a/ui/src/services/enum/Enum.js
+++ b/ui/src/services/enum/Enum.js
@@ -1,0 +1,16 @@
+export const EnumValue = (name, props) =>
+  Object.freeze({
+    ...props,
+    toJSON: () => name,
+    toString: () => name
+  });
+
+export const Enum = values => {
+  const allValues = Object.values(values);
+
+  return Object.freeze({
+    ...values,
+    values: allValues,
+    fromValue: name => allValues.find(s => name === s.toString())
+  });
+};

--- a/ui/src/services/enum_value/EnumValue.js
+++ b/ui/src/services/enum_value/EnumValue.js
@@ -1,6 +1,0 @@
-export const EnumValue = (name, props) =>
-  Object.freeze({
-    ...props,
-    toJSON: () => name,
-    toString: () => name
-  });

--- a/ui/src/services/job_status/JobStatus.js
+++ b/ui/src/services/job_status/JobStatus.js
@@ -1,6 +1,6 @@
-import { EnumValue } from "../enum_value/EnumValue";
+import { Enum, EnumValue } from "../enum/Enum";
 
-const values = {
+export const JobStatus = Enum({
   PENDING: EnumValue("pending", {
     label: "Pending",
     color: "#F5A700",
@@ -45,12 +45,4 @@ const values = {
     color: "#BD271E",
     iconType: "cross"
   })
-};
-
-const allValues = Object.values(values);
-
-export const JobStatus = Object.freeze({
-  ...values,
-  values: allValues,
-  fromValue: name => allValues.find(s => name === s.toString())
 });

--- a/ui/src/services/status/Status.js
+++ b/ui/src/services/status/Status.js
@@ -1,6 +1,6 @@
-import { EnumValue } from "../enum_value/EnumValue";
+import { EnumValue, Enum } from "../enum/Enum";
 
-const values = {
+export const Status = Enum({
   DEPLOYED: EnumValue("deployed", {
     label: "Deployed",
     color: "#017D73",
@@ -20,12 +20,4 @@ const values = {
     label: "Not Deployed",
     color: "#6A717D"
   })
-};
-
-const allValues = Object.values(values);
-
-export const Status = Object.freeze({
-  ...values,
-  values: allValues,
-  fromValue: name => allValues.find(s => name === s.toString())
 });


### PR DESCRIPTION
### Context
This PR makes it possible to view a list of ensemblers in Turing UI. Plus:
* Makes it possible to view ensembling jobs of a specific ensembler
* Updates jobs api to support `ensembler_id` and `search` query parameters
* Bumps version of `@mlp/ui` library to use the newer version of `NavDrawer`

### Screenshots:
<img width="1440" alt="Screenshot 2021-08-03 at 23 57 48" src="https://user-images.githubusercontent.com/1886194/128085186-344f4630-5e1b-4b76-8099-8c18b0d30d2f.png">
<img width="1440" alt="Screenshot 2021-08-03 at 23 57 36" src="https://user-images.githubusercontent.com/1886194/128085197-4628215a-8a2f-466e-b2af-533ec4271877.png">
