### PR TITLE
Fix Swagger UI in Helm chart.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -60,6 +60,7 @@ jobs:
           - "install_merlin" install_merlin \
           - "build_turing_router_docker_image" build_turing_router_docker_image \
           - "build_turing_apiserver_docker_image" build_turing_apiserver_docker_image \
+          - "build_turing_swagger_docker_image" build_turing_swagger_docker_image \
           --and-then \
           - "install_turing" install_turing
 

--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -29,4 +29,4 @@ jobs:
         run: echo ${{ secrets.GHCR_TOKEN }} | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Publish image
-        run: docker push ${{ env.DOCKER_REGISTRY }}/turing/batch-ensembler:$(make version)
+        run: docker push ${{ env.DOCKER_REGISTRY }}/turing/turing-swagger:$(make version)

--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -1,0 +1,32 @@
+name: swagger
+
+on:
+  push:
+    paths:
+    - ".github/workflows/swagger.yaml"
+    - "api/api/**"
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  publish-docker:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./api/api
+    env:
+      DOCKER_REGISTRY: ghcr.io/gojek
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build image
+        run: make build-image
+
+      - name: Setup GitHub Container Registry
+        run: echo ${{ secrets.GHCR_TOKEN }} | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Publish image
+        run: docker push ${{ env.DOCKER_REGISTRY }}/turing/batch-ensembler:$(make version)

--- a/api/api/Dockerfile
+++ b/api/api/Dockerfile
@@ -1,0 +1,4 @@
+FROM swaggerapi/swagger-ui:v3.47.1
+
+RUN mkdir -p /app/api
+COPY . /app/api

--- a/api/api/Dockerfile
+++ b/api/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM swaggerapi/swagger-ui:v3.47.1
+FROM swaggerapi/swagger-ui:v3.52.0
 
 RUN mkdir -p /app/api
 COPY . /app/api

--- a/api/api/Makefile
+++ b/api/api/Makefile
@@ -1,0 +1,7 @@
+SHELL := /bin/bash
+VERSION_NUMBER=$(if $(VERSION),$(VERSION),$(shell ../../scripts/vertagen/vertagen.sh -f docker))
+
+.PHONY: build-image
+build-image:
+	@docker build . \
+		--tag $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY)/,)turing/turing-swagger:${VERSION_NUMBER}

--- a/api/api/Makefile
+++ b/api/api/Makefile
@@ -5,3 +5,7 @@ VERSION_NUMBER=$(if $(VERSION),$(VERSION),$(shell ../../scripts/vertagen/vertage
 build-image:
 	@docker build . \
 		--tag $(if $(DOCKER_REGISTRY),$(DOCKER_REGISTRY)/,)turing/turing-swagger:${VERSION_NUMBER}
+
+.PHONY: version
+version:
+	@echo $(VERSION_NUMBER)

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
         echo "Done!"
 
   swagger-ui:
-    image: swaggerapi/swagger-ui:v3.47.1
+    image: swaggerapi/swagger-ui:v3.52.0
     ports:
       - 8081:5555
     volumes:

--- a/api/turing/cmd/main.go
+++ b/api/turing/cmd/main.go
@@ -122,10 +122,6 @@ func main() {
 	mux.Handle("/v1/internal/", http.StripPrefix("/v1/internal", health))
 	mux.Handle("/v1/", http.StripPrefix("/v1", api.NewRouter(appCtx)))
 
-	if len(cfg.SwaggerFile) > 0 {
-		// Serve Swagger Spec
-		mux.Handle("/openapi.yaml", web.FileHandler(cfg.SwaggerFile, false))
-	}
 	// Serve UI
 	if cfg.TuringUIConfig.AppDirectory != "" {
 		log.Infof(

--- a/engines/router/compose/docs.yaml
+++ b/engines/router/compose/docs.yaml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   swagger-ui:
-    image: swaggerapi/swagger-ui:v3.47.1
+    image: swaggerapi/swagger-ui:v3.52.0
     ports:
       - 5555:8080
     volumes:

--- a/infra/chart/Chart.yaml
+++ b/infra/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.1.3
+version: 0.1.4

--- a/infra/chart/templates/deployment.yaml
+++ b/infra/chart/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       - name: swagger-ui
-        image: "swaggerapi/swagger-ui:{{ .Values.swaggerUi.image.tag }}"
+        image: {{ .Values.swaggerUi.image.registry }}{{ .Values.swaggerUi.image.repository }}:{{ .Values.swaggerUi.image.tag }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: {{ .Values.swaggerUi.service.internalPort }}
@@ -119,12 +119,6 @@ spec:
         command: ['sh', '-c']
         args:
         - |
-          mkdir /app
-          echo "Fetching swagger configuration from http://127.0.0.1:{{ .Values.turing.service.internalPort }}/openapi.yaml..."
-          until $$(wget -O $${SWAGGER_JSON} --tries 1 --timeout 1 http://127.0.0.1:{{ .Values.turing.service.internalPort }}/openapi.yaml); do
-            printf '.'
-            sleep 10
-          done
           echo "Update Swagger config..."
           sed -r -i 's%^((\s*)-(\s*)url\s*:).*$$%\1 "'$${API_SERVER}'"%' $${SWAGGER_JSON}
           echo "Running Swagger UI..."

--- a/infra/chart/values.yaml
+++ b/infra/chart/values.yaml
@@ -105,11 +105,11 @@ swaggerUi:
   image:
     # -- Docker registry for Turing Swagger UI image. User is required to override
     # the registry for now as there is no publicly available Turing Swagger UI image
-    registry: docker.io/
+    registry: ghcr.io/turing
     # -- Docker image repository for Turing Swagger UI
     repository: turing-swagger
     # -- Docker image tag for Turing Swagger UI
-    tag: v3.47.1
+    tag: latest
   # -- URL of API server
   apiServer: "http://127.0.0.1/v1"
   service:

--- a/infra/chart/values.yaml
+++ b/infra/chart/values.yaml
@@ -102,8 +102,13 @@ dbMigrations:
     tag: v4.7.1
 
 swaggerUi:
-  # -- Docker tag for Swagger UI https://hub.docker.com/r/swaggerapi/swagger-ui
   image:
+    # -- Docker registry for Turing Swagger UI image. User is required to override
+    # the registry for now as there is no publicly available Turing Swagger UI image
+    registry: docker.io/
+    # -- Docker image repository for Turing Swagger UI
+    repository: turing-swagger
+    # -- Docker image tag for Turing Swagger UI
     tag: v3.47.1
   # -- URL of API server
   apiServer: "http://127.0.0.1/v1"

--- a/test/e2e/setup-infra.sh
+++ b/test/e2e/setup-infra.sh
@@ -183,6 +183,13 @@ function build_turing_apiserver_docker_image() {
     cd $workdir
 }
 
+function build_turing_swagger_docker_image() {
+    pushd "$script_dir/../../api/api"
+    docker build -t localhost:5000/turing-swagger .
+    docker push localhost:5000/turing-swagger
+    popd
+}
+
 function install_turing() {
     workdir=$(pwd)
     cd "$script_dir/../.."

--- a/test/e2e/turing.helm-values.yaml
+++ b/test/e2e/turing.helm-values.yaml
@@ -73,6 +73,12 @@ turing:
       MLPURL: http://mlp:8080/v1
       MLPEncryptionKey: secret
 
+swaggerUi:
+  image:
+    registry: localhost:5000/
+    repository: turing-swagger
+    tag: latest
+
 postgresql:
   resources:
     requests:


### PR DESCRIPTION
Previously, the refactoring of swagger yaml files have been split up and the process of how the yaml files were transferred to the SwaggerUI running container was not updated. As a result, SwaggerUI is not able to serve the openapi specs correctly.

This PR changes how SwaggerUI is built and deployed. A custom image will be built on top of SwaggerUI's Docker image to populate the openapi yaml files and deployed alongside with the Turing API pod.

Test for Docker build is here: https://github.com/gojek/turing/runs/3308105094?check_suite_focus=true, temporarily removed the guard for main branch only, will be reenabling that. I do not have the credentials so the pushing to GHCR will fail.