### PR TITLE
Fix Swagger UI base URL.

### DIFF
--- a/infra/chart/Chart.yaml
+++ b/infra/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.1.4
+version: 0.1.5

--- a/infra/chart/templates/deployment.yaml
+++ b/infra/chart/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
         args:
         - |
           echo "Update Swagger config..."
-          sed -r -i 's%^((\s*)-(\s*)url\s*:).*$$%\1 "'$${API_SERVER}'"%' $${SWAGGER_JSON}
+          sed -i "s|localhost:8080/v1|$${API_SERVER}|g" $${SWAGGER_JSON}
           echo "Running Swagger UI..."
           /usr/share/nginx/run.sh
       {{- with .Values.turing.extraContainers }}


### PR DESCRIPTION
The `sed` script was not updating the values properly after the refactoring of the openapi yamls. This PR fixes it.

Tested by deploying manually: 
![Screenshot 2021-08-17 at 6 18 55 PM](https://user-images.githubusercontent.com/13537118/129708990-69701b79-f77d-4027-add4-b9c71a32e3f4.png)
