### PR TITLE
Update OpenAPI library version

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/GoogleCloudPlatform/spark-on-k8s-operator v0.0.0-20200424034326-7cd886c7ec44
 	github.com/antihax/optional v1.0.0
-	github.com/getkin/kin-openapi v0.20.0
+	github.com/getkin/kin-openapi v0.75.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-playground/validator/v10 v10.3.0
 	github.com/gojek/fiber v0.0.0-20201008181849-4f0f8284dc84
@@ -18,7 +18,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.11.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-containerregistry v0.0.0-20200331213917-3d03ed9b1ca2
-	github.com/gorilla/mux v1.7.4
+	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/schema v1.1.0
 	github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40
 	github.com/jinzhu/gorm v1.9.12

--- a/api/go.sum
+++ b/api/go.sum
@@ -419,8 +419,8 @@ github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYis
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell v1.3.0/go.mod h1:Hjvr+Ofd+gLglo7RYKxxnzCBmev3BzsS67MebKS4zMM=
 github.com/getkin/kin-openapi v0.2.0/go.mod h1:V1z9xl9oF5Wt7v32ne4FmiF1alpS4dM6mNzoywPOXlk=
-github.com/getkin/kin-openapi v0.20.0 h1:bVW07wyErauTMBQPRQxt6TvzjqD9pvKWGEzjyi3vn2U=
-github.com/getkin/kin-openapi v0.20.0/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
+github.com/getkin/kin-openapi v0.75.0 h1:JEt2etuOJvejeoj7VBslrpGFGKd3FNOyhFAM0uTiOOw=
+github.com/getkin/kin-openapi v0.75.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -466,8 +466,9 @@ github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
-github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
+github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
+github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
@@ -708,8 +709,9 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/schema v1.1.0 h1:CamqUDOFUBqzrvxuz2vEwo8+SUdwsluFh7IlzJh30LY=
 github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=

--- a/api/turing/middleware/openapi_validation_test.go
+++ b/api/turing/middleware/openapi_validation_test.go
@@ -51,11 +51,12 @@ func TestOpenAPIValidationValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:          "bad path parameter",
-			method:        "GET",
-			url:           "/projects/NOT_NUMBER/routers",
-			wantErr:       true,
-			wantErrSubstr: `parameter "project_id" in path has an error: value NOT_NUMBER: an invalid integer: strconv.ParseFloat: parsing "NOT_NUMBER": invalid syntax`,
+			name:    "bad path parameter",
+			method:  "GET",
+			url:     "/projects/NOT_NUMBER/routers",
+			wantErr: true,
+			wantErrSubstr: strings.Join([]string{`parameter "project_id" in path has an error: value NOT_NUMBER: `,
+				`an invalid integer: strconv.ParseFloat: parsing "NOT_NUMBER": invalid syntax`}, ""),
 		},
 		{
 			name:   "Missing property in body",
@@ -88,8 +89,9 @@ func TestOpenAPIValidationValidate(t *testing.T) {
   }
 }
 `,
-			wantErr:       true,
-			wantErrSubstr: `request body has an error: doesn't match the schema: Error at "/environment_name": property "environment_name" is missing`,
+			wantErr: true,
+			wantErrSubstr: strings.Join([]string{`request body has an error: doesn't match the schema: `,
+				`Error at "/environment_name": property "environment_name" is missing`}, ""),
 		},
 		{
 			name:   "invalid enum",
@@ -126,8 +128,9 @@ func TestOpenAPIValidationValidate(t *testing.T) {
   }
 }
 `,
-			wantErr:       true,
-			wantErrSubstr: `request body has an error: doesn't match the schema: Error at "/config/ensembler/type": value is not one of the allowed values`,
+			wantErr: true,
+			wantErrSubstr: strings.Join([]string{`request body has an error: doesn't match the schema: `,
+				`Error at "/config/ensembler/type": value is not one of the allowed values`}, ""),
 		},
 	}
 	for _, tt := range tests {

--- a/api/turing/middleware/openapi_validation_test.go
+++ b/api/turing/middleware/openapi_validation_test.go
@@ -55,7 +55,7 @@ func TestOpenAPIValidationValidate(t *testing.T) {
 			method:        "GET",
 			url:           "/projects/NOT_NUMBER/routers",
 			wantErr:       true,
-			wantErrSubstr: "Parameter 'project_id' in path has an error: value NOT_NUMBER: an invalid integer",
+			wantErrSubstr: `parameter "project_id" in path has an error: value NOT_NUMBER: an invalid integer: strconv.ParseFloat: parsing "NOT_NUMBER": invalid syntax`,
 		},
 		{
 			name:   "Missing property in body",
@@ -89,7 +89,7 @@ func TestOpenAPIValidationValidate(t *testing.T) {
 }
 `,
 			wantErr:       true,
-			wantErrSubstr: `Error at "/environment_name":Property 'environment_name' is missing`,
+			wantErrSubstr: `request body has an error: doesn't match the schema: Error at "/environment_name": property "environment_name" is missing`,
 		},
 		{
 			name:   "invalid enum",
@@ -127,7 +127,7 @@ func TestOpenAPIValidationValidate(t *testing.T) {
 }
 `,
 			wantErr:       true,
-			wantErrSubstr: `Error at "/config/ensembler/type":JSON value is not one of the allowed values`,
+			wantErrSubstr: `request body has an error: doesn't match the schema: Error at "/config/ensembler/type": value is not one of the allowed values`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR updates the `getkin/kin-openapi` library version used by the Turing API to the latest at `v0.75.0`. This is required because the internal Turing repo's dependencies use a newer version of the same library which causes conflicts.