### PR TITLE
Add RunID Generation for ensembling jobs.

### DIFF
--- a/api/api/specs/ensemblers.yaml
+++ b/api/api/specs/ensemblers.yaml
@@ -149,7 +149,7 @@ components:
         name:
           type: "string"
           minLength: 3
-          maxLength: 15
+          maxLength: 20
         created_at:
           type: "string"
           format: "date-time"

--- a/api/api/specs/jobs.yaml
+++ b/api/api/specs/jobs.yaml
@@ -146,6 +146,7 @@ components:
           type: "string"
           minLength: 3
           maxLength: 50
+          readOnly: true
         project_id:
           $ref: "#/components/schemas/Id"
         ensembler_id:

--- a/api/db-migrations/000009_ensembling_job.up.sql
+++ b/api/db-migrations/000009_ensembling_job.up.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS ensembling_jobs
     infra_config     jsonb NOT NULL,
     job_config       jsonb NOT NULL,
     retry_count      integer NOT NULL default 0,
+    run_id           integer NOT NULL,
     status           ensembling_job_status NOT NULL default 'pending',
     error            text,
     created_at       timestamp   NOT NULL default current_timestamp,
@@ -27,3 +28,4 @@ CREATE TABLE IF NOT EXISTS ensembling_jobs
 );
 
 CREATE INDEX ensembling_jobs_status_updated_at_idx on ensembling_jobs (status, updated_at);
+CREATE INDEX ensembling_job_ensembler_id_idx on ensembling_jobs (ensembler_id);

--- a/api/turing/models/ensembling_job.go
+++ b/api/turing/models/ensembling_job.go
@@ -26,10 +26,6 @@ type EnsemblingJob struct {
 	RunID           int          `json:"-"`
 }
 
-type runIDProjection struct {
-	RunID int
-}
-
 // BeforeCreate sets the ensembling job name and run_id before creating
 func (job *EnsemblingJob) BeforeCreate(tx *gorm.DB) error {
 	var latest EnsemblingJob

--- a/api/turing/models/pyfunc_ensembler.go
+++ b/api/turing/models/pyfunc_ensembler.go
@@ -38,7 +38,7 @@ type GenericEnsembler struct {
 
 	Type EnsemblerType `json:"type" gorm:"column:type" validate:"required,oneof=pyfunc"`
 
-	Name string `json:"name" gorm:"column:name" validate:"required,hostname_rfc1123,lte=15,gte=3"`
+	Name string `json:"name" gorm:"column:name" validate:"required,hostname_rfc1123,lte=20,gte=3"`
 }
 
 func (e *GenericEnsembler) GetProjectID() ID {

--- a/api/turing/service/ensembling_job_service.go
+++ b/api/turing/service/ensembling_job_service.go
@@ -225,11 +225,6 @@ func (s *ensemblingJobService) List(options EnsemblingJobListOptions) (*Paginate
 	return paginatedResults, nil
 }
 
-func generateDefaultJobName(ensemblerName string) string {
-	t := time.Now().Unix()
-	return fmt.Sprintf("%s-%d", ensemblerName, t)
-}
-
 func getEnsemblerDirectory(ensembler *models.PyFuncEnsembler) string {
 	// Ensembler URI will be a local directory
 	// Dockerfile will build copy the artifact into the local directory.

--- a/api/turing/service/ensembling_job_service.go
+++ b/api/turing/service/ensembling_job_service.go
@@ -250,10 +250,9 @@ func (s *ensemblingJobService) generateMonitoringURL(job *models.EnsemblingJob, 
 		return "", nil
 	}
 
-	name := job.Name
 	values := EnsemblingMonitoringVariables{
 		Project: project.Name,
-		Job:     name,
+		Job:     job.Name,
 	}
 
 	var b bytes.Buffer

--- a/api/turing/service/ensembling_job_service.go
+++ b/api/turing/service/ensembling_job_service.go
@@ -24,8 +24,7 @@ const (
 	SparkHomeFolder = "/home/spark"
 	// EnsemblerFolder is the folder created by the Turing SDK that contains
 	// the ensembler dependencies and pickled Python files.
-	EnsemblerFolder  = "ensembler"
-	jobNameMaxLength = 25
+	EnsemblerFolder = "ensembler"
 
 	kubernetesSparkRoleLabel         = "spark-role"
 	kubernetesSparkRoleDriverValue   = "driver"
@@ -257,10 +256,6 @@ func (s *ensemblingJobService) generateMonitoringURL(job *models.EnsemblingJob, 
 	}
 
 	name := job.Name
-	if len(name) > jobNameMaxLength {
-		name = name[:jobNameMaxLength]
-	}
-
 	values := EnsemblingMonitoringVariables{
 		Project: project.Name,
 		Job:     name,
@@ -283,11 +278,6 @@ func (s *ensemblingJobService) CreateEnsemblingJob(
 ) (*models.EnsemblingJob, error) {
 	job.ProjectID = projectID
 	job.EnvironmentName = s.defaultEnvironment
-
-	// Populate name if the user does not define a name for the job
-	if job.Name == "" {
-		job.Name = generateDefaultJobName(ensembler.Name)
-	}
 
 	job.JobConfig.Spec.Ensembler.Uri = getEnsemblerDirectory(ensembler)
 	job.InfraConfig.ArtifactURI = ensembler.ArtifactURI

--- a/api/turing/service/ensembling_job_service_test.go
+++ b/api/turing/service/ensembling_job_service_test.go
@@ -218,9 +218,19 @@ func TestSaveAndFindByIDEnsemblingJobIntegration(t *testing.T) {
 			assert.Equal(t, models.JobPending, ensemblingJob.Status)
 			assert.Equal(t, found.InfraConfig, ensemblingJob.InfraConfig)
 			assert.Equal(t, found.JobConfig, ensemblingJob.JobConfig)
+			oldRunID := found.RunID
+			assert.NotEqual(t, oldRunID, 0)
 
 			expected := generateEnsemblingJobFixture(1, ensemblerID, projectID, true)
 			assert.Contains(t, found.MonitoringURL, expected.MonitoringURL)
+
+			// save again to test if RunID has incremented.
+			ensemblingJob = generateEnsemblingJobFixture(1, ensemblerID, projectID, false)
+			ensemblingJob.InfraConfig.EnsemblerName = EnsemblerFolder
+			err = ensemblingJobService.Save(ensemblingJob)
+			assert.NoError(t, err)
+			assert.NotEqual(t, models.ID(0), ensemblingJob.ID)
+			assert.Equal(t, oldRunID+1, ensemblingJob.RunID)
 		})
 	})
 }

--- a/api/turing/service/ensembling_job_service_test.go
+++ b/api/turing/service/ensembling_job_service_test.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	artifactFolder           string = "artifact"
+	artifactFolder string = "artifact"
+	// Actually this var-job=%s has a run_id appended to it, but it's ok since we use assert.Contains
 	dashboardURLStringFormat string = "https://a.co/dashboard?var-project=%s&var-job=%s"
 	mlpProjectName           string = "foo"
 )
@@ -63,11 +64,9 @@ func generateEnsemblingJobFixture(
 	i int,
 	ensemblerID models.ID,
 	projectID models.ID,
-	name string,
 	genExpected bool,
 ) *models.EnsemblingJob {
 	value := &models.EnsemblingJob{
-		Name:            name,
 		EnsemblerID:     ensemblerID,
 		ProjectID:       projectID,
 		EnvironmentName: "dev",
@@ -178,7 +177,7 @@ func generateEnsemblingJobFixture(
 		value.EnvironmentName = "dev"
 		value.InfraConfig.ArtifactURI = fmt.Sprintf("gs://bucket/%s", artifactFolder)
 		value.InfraConfig.EnsemblerName = EnsemblerFolder
-		value.MonitoringURL = fmt.Sprintf(dashboardURLStringFormat, mlpProjectName, name)
+		value.MonitoringURL = fmt.Sprintf(dashboardURLStringFormat, mlpProjectName, EnsemblerFolder)
 	}
 
 	return value
@@ -199,7 +198,8 @@ func TestSaveAndFindByIDEnsemblingJobIntegration(t *testing.T) {
 
 			projectID := models.ID(1)
 			ensemblerID := models.ID(1000)
-			ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, "test-ensembler", false)
+			ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, false)
+			ensemblingJob.InfraConfig.EnsemblerName = EnsemblerFolder
 			err := ensemblingJobService.Save(ensemblingJob)
 			assert.NoError(t, err)
 			assert.NotEqual(t, models.ID(0), ensemblingJob.ID)
@@ -219,7 +219,7 @@ func TestSaveAndFindByIDEnsemblingJobIntegration(t *testing.T) {
 			assert.Equal(t, found.InfraConfig, ensemblingJob.InfraConfig)
 			assert.Equal(t, found.JobConfig, ensemblingJob.JobConfig)
 
-			expected := generateEnsemblingJobFixture(1, ensemblerID, projectID, "test-ensembler", true)
+			expected := generateEnsemblingJobFixture(1, ensemblerID, projectID, true)
 			assert.Contains(t, found.MonitoringURL, expected.MonitoringURL)
 		})
 	})
@@ -285,7 +285,7 @@ func TestListEnsemblingJobIntegration(t *testing.T) {
 				for saveCounter := 0; saveCounter < tt.saveQuantity; saveCounter++ {
 					projectID := models.ID(1)
 					ensemblerID := models.ID(1000)
-					ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, "test-ensembler", false)
+					ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, false)
 					err := ensemblingJobService.Save(ensemblingJob)
 					assert.NoError(t, err)
 					assert.NotEqual(t, models.ID(0), ensemblingJob.ID)
@@ -327,7 +327,8 @@ func TestFindPendingJobsAndUpdateIntegration(t *testing.T) {
 			// Save job
 			projectID := models.ID(1)
 			ensemblerID := models.ID(1000)
-			ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, "test-ensembler", false)
+			ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, false)
+			ensemblingJob.InfraConfig.EnsemblerName = EnsemblerFolder
 			err := ensemblingJobService.Save(ensemblingJob)
 			assert.NoError(t, err)
 			assert.NotEqual(t, models.ID(0), ensemblingJob.ID)
@@ -366,7 +367,7 @@ func TestFindPendingJobsAndUpdateIntegration(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, models.JobFailedSubmission, found.Status)
 
-			expected := generateEnsemblingJobFixture(1, ensemblerID, projectID, "test-ensembler", true)
+			expected := generateEnsemblingJobFixture(1, ensemblerID, projectID, true)
 			assert.Contains(t, found.MonitoringURL, expected.MonitoringURL)
 		})
 	})
@@ -391,38 +392,38 @@ func TestCreateEnsemblingJob(t *testing.T) {
 				},
 				ArtifactURI: fmt.Sprintf("gs://bucket/%s", artifactFolder),
 			},
-			request:                generateEnsemblingJobFixture(1, 1, 1, "", false),
-			expected:               generateEnsemblingJobFixture(1, 1, 1, EnsemblerFolder, true),
+			request:                generateEnsemblingJobFixture(1, 1, 1, false),
+			expected:               generateEnsemblingJobFixture(1, 1, 1, true),
 			removeDefaultResources: false,
 			removeDriverCPURequest: false,
 		},
 		"success | default resources removed": {
 			ensembler: &models.PyFuncEnsembler{
 				GenericEnsembler: &models.GenericEnsembler{
-					Name:      "ensembler",
+					Name:      EnsemblerFolder,
 					Model:     models.Model{ID: 1},
 					Type:      models.EnsemblerTypePyFunc,
 					ProjectID: 1,
 				},
 				ArtifactURI: fmt.Sprintf("gs://bucket/%s", artifactFolder),
 			},
-			request:                generateEnsemblingJobFixture(1, 1, 1, "test-ensembler", false),
-			expected:               generateEnsemblingJobFixture(1, 1, 1, "test-ensembler", true),
+			request:                generateEnsemblingJobFixture(1, 1, 1, false),
+			expected:               generateEnsemblingJobFixture(1, 1, 1, true),
 			removeDefaultResources: true,
 			removeDriverCPURequest: false,
 		},
 		"success | remove 1 setting from resources": {
 			ensembler: &models.PyFuncEnsembler{
 				GenericEnsembler: &models.GenericEnsembler{
-					Name:      "ensembler",
+					Name:      EnsemblerFolder,
 					Model:     models.Model{ID: 1},
 					Type:      models.EnsemblerTypePyFunc,
 					ProjectID: 1,
 				},
 				ArtifactURI: fmt.Sprintf("gs://bucket/%s", artifactFolder),
 			},
-			request:                generateEnsemblingJobFixture(1, 1, 1, "test-ensembler", false),
-			expected:               generateEnsemblingJobFixture(1, 1, 1, "test-ensembler", true),
+			request:                generateEnsemblingJobFixture(1, 1, 1, false),
+			expected:               generateEnsemblingJobFixture(1, 1, 1, true),
 			removeDefaultResources: false,
 			removeDriverCPURequest: true,
 		},
@@ -460,7 +461,7 @@ func TestCreateEnsemblingJob(t *testing.T) {
 
 				assert.NotEqual(t, models.ID(0), result.ID)
 
-				assert.NotEqual(t, result.Name, "")
+				assert.Contains(t, result.Name, EnsemblerFolder)
 				assert.Equal(t, expected.EnsemblerID, result.EnsemblerID)
 				assert.Equal(t, expected.ProjectID, result.ProjectID)
 				assert.Equal(t, expected.EnvironmentName, result.EnvironmentName)
@@ -519,7 +520,8 @@ func TestMarkEnsemblingJobForTermination(t *testing.T) {
 			// Save job
 			projectID := models.ID(1)
 			ensemblerID := models.ID(1000)
-			ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, "test-ensembler", false)
+			ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, false)
+			ensemblingJob.InfraConfig.EnsemblerName = EnsemblerFolder
 			err := ensemblingJobService.Save(ensemblingJob)
 			assert.NoError(t, err)
 			assert.NotEqual(t, models.ID(0), ensemblingJob.ID)
@@ -536,7 +538,7 @@ func TestMarkEnsemblingJobForTermination(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, models.JobTerminating, found.Status)
 
-			expected := generateEnsemblingJobFixture(1, ensemblerID, projectID, "test-ensembler", true)
+			expected := generateEnsemblingJobFixture(1, ensemblerID, projectID, true)
 			assert.Contains(t, found.MonitoringURL, expected.MonitoringURL)
 		})
 	})
@@ -558,7 +560,7 @@ func TestPhysicalDeleteEnsemblingJob(t *testing.T) {
 			// Save job
 			projectID := models.ID(1)
 			ensemblerID := models.ID(1000)
-			ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, "test-ensembler", false)
+			ensemblingJob := generateEnsemblingJobFixture(1, ensemblerID, projectID, false)
 			err := ensemblingJobService.Save(ensemblingJob)
 			assert.NoError(t, err)
 			assert.NotEqual(t, models.ID(0), ensemblingJob.ID)

--- a/infra/chart/Chart.yaml
+++ b/infra/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.1.4
+version: 0.1.5


### PR DESCRIPTION
As requested from this [thread](https://github.com/gojek/turing/pull/87#discussion_r694403174) we are supplying a `run_id` to give ensembling jobs more sane and shorter names.