### PR TITLE
Make it possible to configure Turing UI dynamically after static build is done

### DIFF
--- a/ui/.env
+++ b/ui/.env
@@ -1,0 +1,28 @@
+REACT_APP_ENVIRONMENT=production
+
+PUBLIC_URL=/turing
+
+# Default timeout for all API calls (in ms)
+REACT_APP_API_TIMEOUT=10000
+
+REACT_APP_TURING_API=*** set api server base url ***
+REACT_APP_MERLIN_API=*** set api server base url ***
+REACT_APP_MLP_API=*** set api server base url ***
+
+# Comma separated list of Docker registries to use, besides Docker Hub. Optional.
+REACT_APP_PRIVATE_DOCKER_REGISTRIES=
+
+# Registry to use as default, for display in the UI. If left unset, Docker Hub will be used.
+REACT_APP_DEFAULT_DOCKER_REGISTRY="docker.io"
+
+# Link to the Turing App User Documentation
+REACT_APP_USER_DOCS_URL=[{"href":"https://github.com/gojek/turing","label":"Turing User Guide"}]
+
+# Link to the .proto file used by the Kafka Result Logger when using Protobuf serialization
+REACT_APP_RESULT_LOG_PROTO_URL=
+
+REACT_APP_OAUTH_CLIENT_ID=*** set clientId ***
+
+REACT_APP_MAX_ALLOWED_REPLICA=10
+
+REACT_APP_SENTRY_DSN

--- a/ui/.env.development
+++ b/ui/.env.development
@@ -1,17 +1,3 @@
-REACT_APP_HOMEPAGE=/turing
+REACT_APP_ENVIRONMENT=dev
 
-REACT_APP_TURING_API=*** set api server base url ***
-REACT_APP_MERLIN_API=*** set api server base url ***
-REACT_APP_MLP_API=*** set api server base url ***
-
-# Comma separated list of Docker registries to use, besides Docker Hub. Optional.
-REACT_APP_PRIVATE_DOCKER_REGISTRIES=
-# Registry to use as default, for display in the UI. If left unset, Docker Hub will be used.
-REACT_APP_DEFAULT_DOCKER_REGISTRY=
-
-# Link to the Turing App User Documentation
-REACT_APP_USER_DOCS_URL=[{"href":"https://github.com/gojek/turing","label":"Turing User Guide"}]
-# Link to the .proto file used by the Kafka Result Logger when using Protobuf serialization
-REACT_APP_RESULT_LOG_PROTO_URL=
-
-REACT_APP_OAUTH_CLIENT_ID=*** set clientId ***
+REACT_APP_TURING_API=http://localhost:8080/v1

--- a/ui/README.md
+++ b/ui/README.md
@@ -18,13 +18,13 @@ yarn install
 ## Configuration
 
 The React application can be configured using environment variables. By default, 
-it will read from config values from `.env.development` file. Refer to 
+it will read from config values from `.env` file. Refer to 
 this [documentation](https://create-react-app.dev/docs/adding-custom-environment-variables/) for more details.
 
 ### Config Variables
 | Environment Variable            | Required | Default  | Description     |
 | ------------------------------- | -------- | -------- | --------------- |
-| `REACT_APP_API_TIMEOUT`         | No       | 5000     | Timeout (in milliseconds) for requests to API | 
+| `REACT_APP_API_TIMEOUT`         | No       | 10000    | Timeout (in milliseconds) for requests to API | 
 | `REACT_APP_TURING_API`          | Yes      |          | Endpoint of Turing API | 
 | `REACT_APP_MERLIN_API`          | Yes      |          | Endpoint of Merlin API | 
 | `REACT_APP_MLP_API`             | Yes      |          | Endpoint of MLP API | 

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,6 @@
   "name": "turing-ui",
   "version": "0.1.0",
   "private": true,
-  "homepage": "/turing",
   "dependencies": {
     "@elastic/datemath": "5.0.3",
     "@elastic/eui": "32.3.0",

--- a/ui/public/app.config.js
+++ b/ui/public/app.config.js
@@ -1,0 +1,1 @@
+var config = {};

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -14,6 +14,12 @@
       name="description"
       content="Machine Learning Platform"
   />
+
+  <!--
+    app.config.js contains user-provided configuration to customize default
+    application settings
+  -->
+  <script type="text/javascript" src="%PUBLIC_URL%/app.config.js"></script>
   <!--
     manifest.json provides metadata used when your web app is installed on a
     user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -11,81 +11,85 @@ import {
 } from "@gojek/mlp-ui";
 import Home from "./Home";
 import { CreateRouterView } from "./router/create/CreateRouterView";
-import { apiConfig, appConfig, authConfig } from "./config";
 import { ListRoutersView } from "./router/list/ListRoutersView";
 import { RouterDetailsView } from "./router/details/RouterDetailsView";
 import { RouterVersionDetailsView } from "./router/versions/details/RouterVersionDetailsView";
 import { PrivateLayout } from "./PrivateLayout";
 import { ListEnsemblersView } from "./ensembler/list/ListEnsemblersView";
 import { EnsemblingJobsRouter } from "./jobs/EnsemblingJobsRouter";
+import { useConfig } from "./config";
 
-const App = () => (
-  <ErrorBoundary>
-    <MlpApiContextProvider
-      mlpApiUrl={apiConfig.mlpApiUrl}
-      timeout={apiConfig.apiTimeout}
-      useMockData={apiConfig.useMockData}>
-      <AuthProvider clientId={authConfig.oauthClientId}>
-        <Router role="group">
-          <Login path="/login" />
+const App = () => {
+  const { apiConfig, appConfig, authConfig } = useConfig();
 
-          <Redirect from="/" to={appConfig.homepage} noThrow />
+  return (
+    <ErrorBoundary>
+      <MlpApiContextProvider
+        mlpApiUrl={apiConfig.mlpApiUrl}
+        timeout={apiConfig.apiTimeout}
+        useMockData={apiConfig.useMockData}>
+        <AuthProvider clientId={authConfig.oauthClientId}>
+          <Router role="group">
+            <Login path="/login" />
 
-          <Redirect
-            from={`${appConfig.homepage}/projects/:projectId`}
-            to={`${appConfig.homepage}/projects/:projectId/routers`}
-            noThrow
-          />
+            <Redirect from="/" to={appConfig.homepage} noThrow />
 
-          {/* HOME */}
-          <PrivateRoute
-            path={appConfig.homepage}
-            render={PrivateLayout(Home)}
-          />
+            <Redirect
+              from={`${appConfig.homepage}/projects/:projectId`}
+              to={`${appConfig.homepage}/projects/:projectId/routers`}
+              noThrow
+            />
 
-          {/* BATCH JOBS */}
-          <PrivateRoute
-            path={`${appConfig.homepage}/projects/:projectId/jobs/*`}
-            render={PrivateLayout(EnsemblingJobsRouter)}
-          />
+            {/* HOME */}
+            <PrivateRoute
+              path={appConfig.homepage}
+              render={PrivateLayout(Home)}
+            />
 
-          {/* ENSEMBLERS */}
-          <PrivateRoute
-            path={`${appConfig.homepage}/projects/:projectId/ensemblers`}
-            render={PrivateLayout(ListEnsemblersView)}
-          />
+            {/* BATCH JOBS */}
+            <PrivateRoute
+              path={`${appConfig.homepage}/projects/:projectId/jobs/*`}
+              render={PrivateLayout(EnsemblingJobsRouter)}
+            />
 
-          {/* CREATE ROUTER */}
-          <PrivateRoute
-            path={`${appConfig.homepage}/projects/:projectId/routers/create`}
-            render={PrivateLayout(CreateRouterView)}
-          />
+            {/* ENSEMBLERS */}
+            <PrivateRoute
+              path={`${appConfig.homepage}/projects/:projectId/ensemblers`}
+              render={PrivateLayout(ListEnsemblersView)}
+            />
 
-          {/* LIST ROUTER */}
-          <PrivateRoute
-            path={`${appConfig.homepage}/projects/:projectId/routers`}
-            render={PrivateLayout(ListRoutersView)}
-          />
+            {/* CREATE ROUTER */}
+            <PrivateRoute
+              path={`${appConfig.homepage}/projects/:projectId/routers/create`}
+              render={PrivateLayout(CreateRouterView)}
+            />
 
-          {/* ROUTER DETAILS */}
-          <PrivateRoute
-            path={`${appConfig.homepage}/projects/:projectId/routers/:routerId/*`}
-            render={PrivateLayout(RouterDetailsView)}
-          />
+            {/* LIST ROUTER */}
+            <PrivateRoute
+              path={`${appConfig.homepage}/projects/:projectId/routers`}
+              render={PrivateLayout(ListRoutersView)}
+            />
 
-          {/* ROUTER VERSION DETAILS */}
-          <PrivateRoute
-            path={`${appConfig.homepage}/projects/:projectId/routers/:routerId/versions/:versionId/*`}
-            render={PrivateLayout(RouterVersionDetailsView)}
-          />
+            {/* ROUTER DETAILS */}
+            <PrivateRoute
+              path={`${appConfig.homepage}/projects/:projectId/routers/:routerId/*`}
+              render={PrivateLayout(RouterDetailsView)}
+            />
 
-          {/* DEFAULT */}
-          <Empty default />
-        </Router>
-        <Toast />
-      </AuthProvider>
-    </MlpApiContextProvider>
-  </ErrorBoundary>
-);
+            {/* ROUTER VERSION DETAILS */}
+            <PrivateRoute
+              path={`${appConfig.homepage}/projects/:projectId/routers/:routerId/versions/:versionId/*`}
+              render={PrivateLayout(RouterVersionDetailsView)}
+            />
+
+            {/* DEFAULT */}
+            <Empty default />
+          </Router>
+          <Toast />
+        </AuthProvider>
+      </MlpApiContextProvider>
+    </ErrorBoundary>
+  );
+};
 
 export default App;

--- a/ui/src/Home.js
+++ b/ui/src/Home.js
@@ -1,17 +1,21 @@
 import React, { Fragment } from "react";
 import { EuiEmptyPrompt } from "@elastic/eui";
-import { appConfig } from "./config";
+import { useConfig } from "./config";
 
-const Home = () => (
-  <EuiEmptyPrompt
-    iconType={appConfig.appIcon}
-    title={<h2>Turing: ML Experiments</h2>}
-    body={
-      <Fragment>
-        <p>To start off, please select a project from the dropdown.</p>
-      </Fragment>
-    }
-  />
-);
+const Home = () => {
+  const { appConfig } = useConfig();
+
+  return (
+    <EuiEmptyPrompt
+      iconType={appConfig.appIcon}
+      title={<h2>Turing: ML Experiments</h2>}
+      body={
+        <Fragment>
+          <p>To start off, please select a project from the dropdown.</p>
+        </Fragment>
+      }
+    />
+  );
+};
 
 export default Home;

--- a/ui/src/PrivateLayout.js
+++ b/ui/src/PrivateLayout.js
@@ -6,11 +6,13 @@ import {
   Header,
   ProjectsContextProvider,
 } from "@gojek/mlp-ui";
-import { appConfig } from "./config";
+import { useConfig } from "./config";
 import { EnvironmentsContextProvider } from "./providers/environments/context";
 import "./PrivateLayout.scss";
 
 export const PrivateLayout = (Component) => {
+  const { appConfig } = useConfig();
+
   return (props) => (
     <ApplicationsContextProvider>
       <ProjectsContextProvider>

--- a/ui/src/components/page/PageTitle.js
+++ b/ui/src/components/page/PageTitle.js
@@ -1,19 +1,22 @@
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiTitle } from "@elastic/eui";
-import { appConfig } from "../../config";
 import React from "react";
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiTitle } from "@elastic/eui";
+import { useConfig } from "../../config";
 
-export const PageTitle = ({ title, size, icon, iconSize, prepend }) => (
-  <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
-    <EuiFlexItem grow={false}>
-      <EuiIcon type={icon || appConfig.appIcon} size={iconSize || "xl"} />
-    </EuiFlexItem>
+export const PageTitle = ({ title, size, icon, iconSize, prepend }) => {
+  const { appConfig } = useConfig();
+  return (
+    <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiIcon type={icon || appConfig.appIcon} size={iconSize || "xl"} />
+      </EuiFlexItem>
 
-    <EuiFlexItem grow={false}>
-      <EuiTitle size={size || "l"}>
-        <span>{title}</span>
-      </EuiTitle>
-    </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiTitle size={size || "l"}>
+          <span>{title}</span>
+        </EuiTitle>
+      </EuiFlexItem>
 
-    {!!prepend && <EuiFlexItem grow={false}>{prepend}</EuiFlexItem>}
-  </EuiFlexGroup>
-);
+      {!!prepend && <EuiFlexItem grow={false}>{prepend}</EuiFlexItem>}
+    </EuiFlexGroup>
+  );
+};

--- a/ui/src/components/pod_logs_viewer/hooks/useLogsEmitter.js
+++ b/ui/src/components/pod_logs_viewer/hooks/useLogsEmitter.js
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from "react";
-import { appConfig } from "../../../config";
 import { useTuringPollingApiEmitter } from "../../../hooks/useTuringPollingApiEmitter";
 import { useLogsApiEmitter } from "./useLogsApiEmitter";
 
@@ -7,9 +6,9 @@ export const useLogsEmitter = (
   apiEndpoint,
   query,
   extractTimestamp,
-  processLogs
+  processLogs,
+  configOptions
 ) => {
-  const { podLogs: configOptions } = appConfig;
   const [apiOptions, setApiOptions] = useState({ query });
 
   const setQuery = useCallback(

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -1,3 +1,4 @@
+import React from "react";
 import objectAssignDeep from "object-assign-deep";
 
 /*
@@ -87,8 +88,15 @@ const buildTimeConfig = {
   alertConfig,
 };
 
-export const useConfig = () => {
-  const runTimeConfig = window.config;
+const ConfigContext = React.createContext({});
 
-  return objectAssignDeep({}, buildTimeConfig, runTimeConfig);
+export const ConfigProvider = ({ children }) => {
+  const runTimeConfig = window.config;
+  const config = objectAssignDeep({}, buildTimeConfig, runTimeConfig);
+
+  return (
+    <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>
+  );
 };
+
+export const useConfig = () => React.useContext(ConfigContext);

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -1,3 +1,5 @@
+import objectAssignDeep from "object-assign-deep";
+
 /*
  * In development environment, we set turingApiUrl, merlinApiUrl and mlpApiUrl
  * to unreachable paths so that the requests will be made to the given API
@@ -7,8 +9,8 @@
  * to the UI if the API is served from the same host. When the API's origin differs from
  * that of the UI, appropriate CORS policies are expected to be in place on the API server.
  */
-export const apiConfig = {
-  apiTimeout: process.env.REACT_APP_API_TIMEOUT || 5000,
+const apiConfig = {
+  apiTimeout: process.env.REACT_APP_API_TIMEOUT,
   useMockData: process.env.REACT_APP_USE_MOCK_DATA || false,
   turingApiUrl:
     process.env.NODE_ENV === "development"
@@ -24,26 +26,22 @@ export const apiConfig = {
       : process.env.REACT_APP_MLP_API,
 };
 
-export const authConfig = {
+const authConfig = {
   oauthClientId: process.env.REACT_APP_OAUTH_CLIENT_ID,
 };
 
-export const appConfig = {
-  environment: process.env.REACT_APP_ENVIRONMENT || "dev",
-  homepage: process.env.REACT_APP_HOMEPAGE || process.env.PUBLIC_URL,
+const appConfig = {
+  environment: process.env.REACT_APP_ENVIRONMENT,
+  homepage: process.env.PUBLIC_URL,
   appIcon: "graphApp",
-  docsUrl: process.env.REACT_APP_USER_DOCS_URL
-    ? JSON.parse(process.env.REACT_APP_USER_DOCS_URL)
-    : [{ href: "https://github.com/gojek/turing", label: "Turing User Guide" }],
+  docsUrl: JSON.parse(process.env.REACT_APP_USER_DOCS_URL),
   privateDockerRegistries: process.env.REACT_APP_PRIVATE_DOCKER_REGISTRIES
     ? process.env.REACT_APP_PRIVATE_DOCKER_REGISTRIES.split(",")
     : [],
-  defaultDockerRegistry:
-    process.env.REACT_APP_DEFAULT_DOCKER_REGISTRY || "docker.io", // User Docker Hub as the default
+  defaultDockerRegistry: process.env.REACT_APP_DEFAULT_DOCKER_REGISTRY,
   scaling: {
-    maxAllowedReplica: process.env.REACT_APP_MAX_ALLOWED_REPLICA
-      ? parseInt(process.env.REACT_APP_MAX_ALLOWED_REPLICA)
-      : 10,
+    // Max number of router/enricher/ensembler replica allowed to set during the deployment
+    maxAllowedReplica: parseInt(process.env.REACT_APP_MAX_ALLOWED_REPLICA),
   },
   pagination: {
     defaultPageSize: 10,
@@ -63,16 +61,34 @@ export const appConfig = {
   },
 };
 
-export const sentryConfig = {
+const sentryConfig = {
   dsn: process.env.REACT_APP_SENTRY_DSN,
   environment: appConfig.environment,
+  tags: {
+    app: "turing-ui",
+  },
 };
 
-export const resultLoggingConfig = {
+const resultLoggingConfig = {
   protoUrl: process.env.REACT_APP_RESULT_LOG_PROTO_URL,
 };
 
-export const alertConfig = {
+const alertConfig = {
   environment:
     appConfig.environment === "dev" ? "development" : appConfig.environment,
+};
+
+const buildTimeConfig = {
+  apiConfig,
+  authConfig,
+  appConfig,
+  sentryConfig,
+  resultLoggingConfig,
+  alertConfig,
+};
+
+export const useConfig = () => {
+  const runTimeConfig = window.config;
+
+  return objectAssignDeep({}, buildTimeConfig, runTimeConfig);
 };

--- a/ui/src/ensembler/list/ListEnsemblersTable.js
+++ b/ui/src/ensembler/list/ListEnsemblersTable.js
@@ -7,14 +7,12 @@ import {
   EuiSearchBar,
   EuiSpacer,
   EuiText,
-  EuiToolTip,
 } from "@elastic/eui";
-import { appConfig } from "../../config";
+import { useConfig } from "../../config";
 import { EnsemblerType } from "../../services/ensembler/EnsemblerType";
 import moment from "moment";
 import { FormLabelWithToolTip } from "../../components/form/label_with_tooltip/FormLabelWithToolTip";
-
-const { defaultTextSize, defaultIconSize, dateFormat } = appConfig.tables;
+import { DateFromNow } from "@gojek/mlp-ui";
 
 export const ListEnsemblersTable = ({
   items,
@@ -28,6 +26,11 @@ export const ListEnsemblersTable = ({
   onRowClick,
   ...props
 }) => {
+  const {
+    appConfig: {
+      tables: { defaultTextSize, defaultIconSize },
+    },
+  } = useConfig();
   const searchQuery = useMemo(() => {
     const parts = [];
     if (!!filter.search) {
@@ -79,29 +82,13 @@ export const ListEnsemblersTable = ({
       name: "Created",
       sortable: true,
       width: "20%",
-      render: (date) => (
-        <EuiToolTip
-          position="top"
-          content={moment(date, dateFormat).toLocaleString()}>
-          <EuiText size={defaultTextSize}>
-            {moment(date, dateFormat).fromNow()}
-          </EuiText>
-        </EuiToolTip>
-      ),
+      render: (date) => <DateFromNow date={date} size={defaultTextSize} />,
     },
     {
       field: "updated_at",
       name: "Updated",
       width: "20%",
-      render: (date) => (
-        <EuiToolTip
-          position="top"
-          content={moment(date, dateFormat).toLocaleString()}>
-          <EuiText size={defaultTextSize}>
-            {moment(date, dateFormat).fromNow()}
-          </EuiText>
-        </EuiToolTip>
-      ),
+      render: (date) => <DateFromNow date={date} size={defaultTextSize} />,
     },
     {
       field: "id",

--- a/ui/src/ensembler/list/ListEnsemblersView.js
+++ b/ui/src/ensembler/list/ListEnsemblersView.js
@@ -10,12 +10,15 @@ import {
 } from "@elastic/eui";
 import { PageTitle } from "../../components/page/PageTitle";
 import { ListEnsemblersTable } from "./ListEnsemblersTable";
-import { appConfig } from "../../config";
+import { useConfig } from "../../config";
 import { parse, stringify } from "query-string";
 
-const { defaultPageSize } = appConfig.pagination;
-
 export const ListEnsemblersView = ({ projectId, ...props }) => {
+  const {
+    appConfig: {
+      pagination: { defaultPageSize },
+    },
+  } = useConfig();
   const [results, setResults] = useState({ items: [], totalItemCount: 0 });
   const [page, setPage] = useState({ index: 0, size: defaultPageSize });
   const filter = useMemo(

--- a/ui/src/hooks/useMerlinApi.js
+++ b/ui/src/hooks/useMerlinApi.js
@@ -1,6 +1,6 @@
 import { AuthContext, useApi } from "@gojek/mlp-ui";
 import { useContext } from "react";
-import { apiConfig } from "../config";
+import { useConfig } from "../config";
 
 export const useMerlinApi = (
   endpoint,
@@ -8,6 +8,7 @@ export const useMerlinApi = (
   result,
   callImmediately = true
 ) => {
+  const { apiConfig } = useConfig();
   const authCtx = useContext(AuthContext);
 
   return useApi(

--- a/ui/src/hooks/useTuringApi.js
+++ b/ui/src/hooks/useTuringApi.js
@@ -1,6 +1,6 @@
 import { AuthContext, useApi } from "@gojek/mlp-ui";
 import { useContext } from "react";
-import { apiConfig } from "../config";
+import { useConfig } from "../config";
 
 export const useTuringApi = (
   endpoint,
@@ -8,6 +8,7 @@ export const useTuringApi = (
   result,
   callImmediately = true
 ) => {
+  const { apiConfig } = useConfig();
   const authCtx = useContext(AuthContext);
 
   return useApi(

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -4,14 +4,20 @@ import "./assets/style.scss";
 import * as serviceWorker from "./serviceWorker";
 import App from "./App";
 import * as Sentry from "@sentry/browser";
+import { useConfig } from "./config";
 
-import { sentryConfig } from "./config";
+const SentryApp = (App) => {
+  const {
+    sentryConfig: { dsn, environment, tags },
+  } = useConfig();
 
-Sentry.init(sentryConfig);
-// Set custom tag 'app', for filtering
-Sentry.setTag("app", "turing-ui");
+  Sentry.init({ dsn, environment });
+  Sentry.setTags(tags);
 
-ReactDOM.render(<App />, document.getElementById("root"));
+  return <App />;
+};
+
+ReactDOM.render(SentryApp(App), document.getElementById("root"));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -4,9 +4,9 @@ import "./assets/style.scss";
 import * as serviceWorker from "./serviceWorker";
 import App from "./App";
 import * as Sentry from "@sentry/browser";
-import { useConfig } from "./config";
+import { ConfigProvider, useConfig } from "./config";
 
-const SentryApp = (App) => {
+const SentryApp = ({ children }) => {
   const {
     sentryConfig: { dsn, environment, tags },
   } = useConfig();
@@ -14,10 +14,18 @@ const SentryApp = (App) => {
   Sentry.init({ dsn, environment });
   Sentry.setTags(tags);
 
-  return <App />;
+  return children;
 };
 
-ReactDOM.render(SentryApp(App), document.getElementById("root"));
+const TuringUI = () => (
+  <ConfigProvider>
+    <SentryApp>
+      <App />
+    </SentryApp>
+  </ConfigProvider>
+);
+
+ReactDOM.render(TuringUI(), document.getElementById("root"));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/ui/src/jobs/details/logs/EnsemblingJobLogsView.js
+++ b/ui/src/jobs/details/logs/EnsemblingJobLogsView.js
@@ -11,7 +11,7 @@ import {
   EuiPanel,
   EuiText,
 } from "@elastic/eui";
-import { appConfig } from "../../../config";
+import { useConfig } from "../../../config";
 import { useLogsEmitter } from "../../../components/pod_logs_viewer/hooks/useLogsEmitter";
 
 const components = [
@@ -30,7 +30,9 @@ const components = [
 ];
 
 export const EnsemblingJobLogsView = ({ job }) => {
-  const { podLogs: configOptions } = appConfig;
+  const {
+    appConfig: { podLogs: configOptions },
+  } = useConfig();
   const [loggingUrl, setLoggingUrl] = useState();
 
   useEffect(() => {
@@ -70,7 +72,8 @@ export const EnsemblingJobLogsView = ({ job }) => {
       return (data.logs || []).map((entry) =>
         LogEntry.fromJson(entry).toString()
       );
-    }
+    },
+    configOptions
   );
 
   return (

--- a/ui/src/jobs/list/ListEnsemblingJobsTable.js
+++ b/ui/src/jobs/list/ListEnsemblingJobsTable.js
@@ -9,15 +9,13 @@ import {
   EuiSearchBar,
   EuiSpacer,
   EuiText,
-  EuiToolTip,
 } from "@elastic/eui";
-import { appConfig } from "../../config";
+import { useConfig } from "../../config";
 import moment from "moment";
 import { DeploymentStatusHealth } from "../../components/status_health/DeploymentStatusHealth";
 import { JobStatus } from "../../services/job/JobStatus";
 import EnsemblersContext from "../../providers/ensemblers/context";
-
-const { defaultTextSize, defaultIconSize, dateFormat } = appConfig.tables;
+import { DateFromNow } from "@gojek/mlp-ui";
 
 export const ListEnsemblingJobsTable = ({
   items,
@@ -31,6 +29,11 @@ export const ListEnsemblingJobsTable = ({
   onRowClick,
   ...props
 }) => {
+  const {
+    appConfig: {
+      tables: { defaultTextSize, defaultIconSize },
+    },
+  } = useConfig();
   const { ensemblers } = useContext(EnsemblersContext);
 
   const searchQuery = useMemo(() => {
@@ -109,28 +112,12 @@ export const ListEnsemblingJobsTable = ({
       field: "created_at",
       name: "Created",
       sortable: true,
-      render: (date) => (
-        <EuiToolTip
-          position="top"
-          content={moment(date, dateFormat).toLocaleString()}>
-          <EuiText size={defaultTextSize}>
-            {moment(date, dateFormat).fromNow()}
-          </EuiText>
-        </EuiToolTip>
-      ),
+      render: (date) => <DateFromNow date={date} size={defaultTextSize} />,
     },
     {
       field: "updated_at",
       name: "Updated",
-      render: (date) => (
-        <EuiToolTip
-          position="top"
-          content={moment(date, dateFormat).toLocaleString()}>
-          <EuiText size={defaultTextSize}>
-            {moment(date, dateFormat).fromNow()}
-          </EuiText>
-        </EuiToolTip>
-      ),
+      render: (date) => <DateFromNow date={date} size={defaultTextSize} />,
     },
     {
       name: "Actions",

--- a/ui/src/jobs/list/ListEnsemblingJobsView.js
+++ b/ui/src/jobs/list/ListEnsemblingJobsView.js
@@ -11,12 +11,15 @@ import { PageTitle } from "../../components/page/PageTitle";
 import React, { useEffect, useMemo, useState } from "react";
 import { ListEnsemblingJobsTable } from "./ListEnsemblingJobsTable";
 import { replaceBreadcrumbs } from "@gojek/mlp-ui";
-import { appConfig } from "../../config";
+import { useConfig } from "../../config";
 import { parse, stringify } from "query-string";
 
-const { defaultPageSize } = appConfig.pagination;
-
 export const ListEnsemblingJobsView = ({ projectId, ...props }) => {
+  const {
+    appConfig: {
+      pagination: { defaultPageSize },
+    },
+  } = useConfig();
   const [results, setResults] = useState({ items: [], totalItemCount: 0 });
   const [page, setPage] = useState({ index: 0, size: defaultPageSize });
   const filter = useMemo(

--- a/ui/src/providers/docker/context.js
+++ b/ui/src/providers/docker/context.js
@@ -1,9 +1,11 @@
 import React from "react";
-import { appConfig } from "../../config";
+import { useConfig } from "../../config";
 
 const DockerRegistriesContext = React.createContext([]);
 
 export const DockerRegistriesContextProvider = ({ children }) => {
+  const { appConfig } = useConfig();
+
   const registries = [
     ...appConfig.privateDockerRegistries.map((registry) => ({
       value: registry,

--- a/ui/src/router/alerts/edit/EditAlertsView.js
+++ b/ui/src/router/alerts/edit/EditAlertsView.js
@@ -3,9 +3,11 @@ import { addToast, replaceBreadcrumbs } from "@gojek/mlp-ui";
 import { FormContextProvider } from "../../../components/form/context";
 import { EditAlertsForm } from "../components/edit_alerts_form/components/EditAlertsForm";
 import { TuringAlerts } from "../../../services/alerts/TuringAlerts";
-import { alertConfig } from "../../../config";
+import { useConfig } from "../../../config";
 
 export const EditAlertsView = ({ router, alerts, ...props }) => {
+  const { alertConfig } = useConfig();
+
   useEffect(() => {
     replaceBreadcrumbs([
       {

--- a/ui/src/router/components/form/CreateRouterForm.js
+++ b/ui/src/router/components/form/CreateRouterForm.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useMemo } from "react";
 import { RouterStep } from "./steps/RouterStep";
 import { StepsWizardHorizontal } from "../../../components/multi_steps_form/StepsWizardHorizontal";
 import { ExperimentStep } from "./steps/ExperimentStep";
@@ -12,8 +12,20 @@ import { ConfirmationModal } from "../../../components/confirmation_modal/Confir
 import { DeploymentSummary } from "./components/DeploymentSummary";
 import { addToast } from "@gojek/mlp-ui";
 import ExperimentEngineContext from "../../../providers/experiments/context";
+import { useConfig } from "../../../config";
 
 export const CreateRouterForm = ({ projectId, onCancel, onSuccess }) => {
+  const {
+    appConfig: {
+      scaling: { maxAllowedReplica },
+    },
+  } = useConfig();
+
+  const validationSchema = useMemo(
+    () => schema(maxAllowedReplica),
+    [maxAllowedReplica]
+  );
+
   const { data: router } = useContext(FormContext);
 
   const [submissionResponse, submitForm] = useTuringApi(
@@ -46,28 +58,28 @@ export const CreateRouterForm = ({ projectId, onCancel, onSuccess }) => {
     {
       title: "Router",
       children: <RouterStep projectId={projectId} />,
-      validationSchema: schema[0],
+      validationSchema: validationSchema[0],
     },
     {
       title: "Experiments",
       children: <ExperimentStep />,
-      validationSchema: schema[1],
+      validationSchema: validationSchema[1],
       validationContext: { experimentEngineOptions },
     },
     {
       title: "Enricher",
       children: <EnricherStep projectId={projectId} />,
-      validationSchema: schema[2],
+      validationSchema: validationSchema[2],
     },
     {
       title: "Ensembler",
       children: <EnsemblerStep projectId={projectId} />,
-      validationSchema: schema[3],
+      validationSchema: validationSchema[3],
     },
     {
       title: "Outcome Tracking",
       children: <OutcomeStep projectId={projectId} />,
-      validationSchema: schema[4],
+      validationSchema: validationSchema[4],
     },
   ];
 

--- a/ui/src/router/components/form/UpdateRouterForm.js
+++ b/ui/src/router/components/form/UpdateRouterForm.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useMemo } from "react";
 import { AccordionForm } from "../../../components/accordion_form";
 import { RouterStep } from "./steps/RouterStep";
 import schema from "./validation/schema";
@@ -8,8 +8,20 @@ import { EnsemblerStep } from "./steps/EnsemblerStep";
 import { OutcomeStep } from "./steps/OutcomeStep";
 import { ConfigSectionTitle } from "../../../components/config_section";
 import ExperimentEngineContext from "../../../providers/experiments/context";
+import { useConfig } from "../../../config";
 
 export const UpdateRouterForm = ({ projectId, onCancel, onNext }) => {
+  const {
+    appConfig: {
+      scaling: { maxAllowedReplica },
+    },
+  } = useConfig();
+
+  const validationSchema = useMemo(
+    () => schema(maxAllowedReplica),
+    [maxAllowedReplica]
+  );
+
   const { experimentEngineOptions } = useContext(ExperimentEngineContext);
 
   const sections = [
@@ -17,32 +29,32 @@ export const UpdateRouterForm = ({ projectId, onCancel, onNext }) => {
       title: "Router",
       iconType: "bolt",
       children: <RouterStep projectId={projectId} />,
-      validationSchema: schema[0],
+      validationSchema: validationSchema[0],
     },
     {
       title: "Experiments",
       iconType: "beaker",
       children: <ExperimentStep />,
-      validationSchema: schema[1],
+      validationSchema: validationSchema[1],
       validationContext: { experimentEngineOptions },
     },
     {
       title: "Enricher",
       iconType: "package",
       children: <EnricherStep projectId={projectId} />,
-      validationSchema: schema[2],
+      validationSchema: validationSchema[2],
     },
     {
       title: "Ensembler",
       iconType: "aggregate",
       children: <EnsemblerStep projectId={projectId} />,
-      validationSchema: schema[3],
+      validationSchema: validationSchema[3],
     },
     {
       title: "Outcome Tracking",
       iconType: "visTagCloud",
       children: <OutcomeStep projectId={projectId} />,
-      validationSchema: schema[4],
+      validationSchema: validationSchema[4],
     },
   ];
 

--- a/ui/src/router/components/form/components/docker_config/DockerConfigFormGroup.js
+++ b/ui/src/router/components/form/components/docker_config/DockerConfigFormGroup.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useEffect } from "react";
 import { EuiFlexItem } from "@elastic/eui";
-import { appConfig } from "../../../../../config";
+import { useConfig } from "../../../../../config";
 import { DockerDeploymentPanel } from "./DockerDeploymentPanel";
 import { DockerEnsembler } from "../../../../../services/ensembler";
 import { DockerRegistriesContextProvider } from "../../../../../providers/docker/context";
@@ -15,6 +15,11 @@ export const DockerConfigFormGroup = ({
   onChangeHandler,
   errors = {},
 }) => {
+  const {
+    appConfig: {
+      scaling: { maxAllowedReplica },
+    },
+  } = useConfig();
   const { onChange } = useOnChangeHandler(onChangeHandler);
 
   useEffect(() => {
@@ -50,7 +55,7 @@ export const DockerConfigFormGroup = ({
             resourcesConfig={dockerConfig.resource_request}
             onChangeHandler={onChange("resource_request")}
             errors={errors.resource_request}
-            maxAllowedReplica={appConfig.scaling.maxAllowedReplica}
+            maxAllowedReplica={maxAllowedReplica}
           />
         </EuiFlexItem>
       </Fragment>

--- a/ui/src/router/components/form/components/docker_config/DockerDeploymentPanel.js
+++ b/ui/src/router/components/form/components/docker_config/DockerDeploymentPanel.js
@@ -18,7 +18,7 @@ import SecretsContext from "../../../../../providers/secrets/context";
 import DockerRegistriesContext from "../../../../../providers/docker/context";
 import { useOnChangeHandler } from "../../../../../components/form/hooks/useOnChangeHandler";
 import { ServiceAccountComboBox } from "../../../../../components/form/service_account_combo_box/ServiceAccoutComboBox";
-import { appConfig } from "../../../../../config";
+import { useConfig } from "../../../../../config";
 
 const imageOptions = [];
 
@@ -28,6 +28,9 @@ export const DockerDeploymentPanel = ({
   onChangeHandler,
   errors = {},
 }) => {
+  const {
+    appConfig: { defaultDockerRegistry },
+  } = useConfig();
   const secrets = useContext(SecretsContext);
   const { onChange } = useOnChangeHandler(onChangeHandler);
   const registries = useContext(DockerRegistriesContext);
@@ -43,7 +46,7 @@ export const DockerDeploymentPanel = ({
           display="row">
           <SelectDockerImageComboBox
             fullWidth
-            value={image || `${appConfig.defaultDockerRegistry}/`}
+            value={image || `${defaultDockerRegistry}/`}
             placeholder="echo:1.0.2"
             registryOptions={registries}
             imageOptions={imageOptions}

--- a/ui/src/router/components/form/components/outcome_config/kafka/KafkaConfigPanel.js
+++ b/ui/src/router/components/form/components/outcome_config/kafka/KafkaConfigPanel.js
@@ -10,9 +10,9 @@ import {
 } from "@elastic/eui";
 import { FormLabelWithToolTip } from "../../../../../../components/form/label_with_tooltip/FormLabelWithToolTip";
 import { useOnChangeHandler } from "../../../../../../components/form/hooks/useOnChangeHandler";
-import { resultLoggingConfig } from "../../../../../../config.js";
+import { useConfig } from "../../../../../../config.js";
 
-const logSerializationFormatOptions = [
+const logSerializationFormatOptions = (protoUrl) => [
   {
     value: "json",
     inputDisplay: "JSON",
@@ -20,8 +20,8 @@ const logSerializationFormatOptions = [
   {
     value: "protobuf",
     inputDisplay: "Protobuf",
-    helpText: !!resultLoggingConfig.protoUrl ? (
-      <EuiLink href={resultLoggingConfig.protoUrl} target="_blank" external>
+    helpText: !!protoUrl ? (
+      <EuiLink href={protoUrl} target="_blank" external>
         TuringResultLog.proto
       </EuiLink>
     ) : (
@@ -35,8 +35,12 @@ export const KafkaConfigPanel = ({
   onChangeHandler,
   errors = {},
 }) => {
+  const {
+    resultLoggingConfig: { protoUrl: kafkaProtoUrl },
+  } = useConfig();
   const { onChange } = useOnChangeHandler(onChangeHandler);
-  const selectedFormat = logSerializationFormatOptions.find(
+
+  const selectedFormat = logSerializationFormatOptions(kafkaProtoUrl).find(
     (option) => option.value === kafkaConfig.serialization_format
   );
 
@@ -97,7 +101,7 @@ export const KafkaConfigPanel = ({
           display="row">
           <EuiSuperSelect
             fullWidth
-            options={logSerializationFormatOptions}
+            options={logSerializationFormatOptions(kafkaProtoUrl)}
             valueOfSelected={(selectedFormat || {}).value || ""}
             onChange={onChange("serialization_format")}
             isInvalid={!!errors.serialization_format}

--- a/ui/src/router/components/form/steps/EnricherStep.js
+++ b/ui/src/router/components/form/steps/EnricherStep.js
@@ -6,7 +6,7 @@ import { EnvVariablesPanel } from "../components/docker_config/EnvVariablesPanel
 import { EnricherTypePanel } from "../components/enricher_config/EnricherTypePanel";
 import { DockerDeploymentPanel } from "../components/docker_config/DockerDeploymentPanel";
 import { DockerRegistriesContextProvider } from "../../../../providers/docker/context";
-import { appConfig } from "../../../../config";
+import { useConfig } from "../../../../config";
 import FormValidationContext from "../../../../components/form/validation/context";
 import { get } from "../../../../components/form/utils";
 import { useOnChangeHandler } from "../../../../components/form/hooks/useOnChangeHandler";
@@ -14,6 +14,11 @@ import { enricherTypeOptions } from "../components/enricher_config/typeOptions";
 import { SecretsContextProvider } from "../../../../providers/secrets/context";
 
 export const EnricherStep = ({ projectId }) => {
+  const {
+    appConfig: {
+      scaling: { maxAllowedReplica },
+    },
+  } = useConfig();
   const {
     data: {
       config: { enricher },
@@ -62,7 +67,7 @@ export const EnricherStep = ({ projectId }) => {
             <ResourcesPanel
               resourcesConfig={enricher.resource_request}
               onChangeHandler={onChange("config.enricher.resource_request")}
-              maxAllowedReplica={appConfig.scaling.maxAllowedReplica}
+              maxAllowedReplica={maxAllowedReplica}
               errors={get(errors, "config.enricher.resource_request")}
             />
           </EuiFlexItem>

--- a/ui/src/router/components/form/steps/RouterStep.js
+++ b/ui/src/router/components/form/steps/RouterStep.js
@@ -5,13 +5,18 @@ import { RoutesPanel } from "../components/router_config/RoutesPanel";
 import { ResourcesPanel } from "../components/ResourcesPanel";
 import { FormContext } from "../../../../components/form/context";
 import { MerlinEndpointsProvider } from "../../../../providers/endpoints/MerlinEndpointsProvider";
-import { appConfig } from "../../../../config";
+import { useConfig } from "../../../../config";
 import { get } from "../../../../components/form/utils";
 import FormValidationContext from "../../../../components/form/validation/context";
 import { useOnChangeHandler } from "../../../../components/form/hooks/useOnChangeHandler";
 import { RulesPanel } from "../components/router_config/RulesPanel";
 
 export const RouterStep = ({ projectId }) => {
+  const {
+    appConfig: {
+      scaling: { maxAllowedReplica },
+    },
+  } = useConfig();
   const { data, onChangeHandler } = useContext(FormContext);
   const { onChange } = useOnChangeHandler(onChangeHandler);
   const { errors } = useContext(FormValidationContext);
@@ -53,7 +58,7 @@ export const RouterStep = ({ projectId }) => {
         <ResourcesPanel
           resourcesConfig={get(data, "config.resource_request")}
           onChangeHandler={onChange("config.resource_request")}
-          maxAllowedReplica={appConfig.scaling.maxAllowedReplica}
+          maxAllowedReplica={maxAllowedReplica}
           errors={get(errors, "config.resource_request")}
         />
       </EuiFlexItem>

--- a/ui/src/router/details/logs/RouterLogsView.js
+++ b/ui/src/router/details/logs/RouterLogsView.js
@@ -5,7 +5,7 @@ import { get } from "../../../components/form/utils";
 import { replaceBreadcrumbs } from "@gojek/mlp-ui";
 import { PodLogsViewer } from "../../../components/pod_logs_viewer/PodLogsViewer";
 import { EuiPanel } from "@elastic/eui";
-import { appConfig } from "../../../config";
+import { useConfig } from "../../../config";
 import { useLogsEmitter } from "../../../components/pod_logs_viewer/hooks/useLogsEmitter";
 
 const components = [
@@ -24,7 +24,9 @@ const components = [
 ];
 
 export const RouterLogsView = ({ router }) => {
-  const { podLogs: configOptions } = appConfig;
+  const {
+    appConfig: { podLogs: configOptions },
+  } = useConfig();
 
   useEffect(() => {
     replaceBreadcrumbs([
@@ -52,7 +54,8 @@ export const RouterLogsView = ({ router }) => {
     query,
     (entries) =>
       !!entries.length ? entries[entries.length - 1].timestamp : undefined,
-    (entries) => entries.map((entry) => LogEntry.fromJson(entry).toString())
+    (entries) => entries.map((entry) => LogEntry.fromJson(entry).toString()),
+    configOptions
   );
 
   const availableComponents = components.filter(

--- a/ui/src/router/list/ListRoutersTable.js
+++ b/ui/src/router/list/ListRoutersTable.js
@@ -7,19 +7,23 @@ import {
   EuiLoadingChart,
   EuiText,
   EuiTextAlign,
-  EuiToolTip,
   EuiSearchBar,
 } from "@elastic/eui";
 import { RouterEndpoint } from "../components/router_endpoint/RouterEndpoint";
 import { FormLabelWithToolTip } from "../../components/form/label_with_tooltip/FormLabelWithToolTip";
-import { appConfig } from "../../config";
+import { useConfig } from "../../config";
 import moment from "moment";
 import { DeploymentStatusHealth } from "../../components/status_health/DeploymentStatusHealth";
 import { Status } from "../../services/status/Status";
-
-const { defaultTextSize, defaultIconSize, dateFormat } = appConfig.tables;
+import { DateFromNow } from "@gojek/mlp-ui";
 
 const ListRoutersTable = ({ items, isLoaded, error, onRowClick }) => {
+  const {
+    appConfig: {
+      tables: { defaultTextSize, defaultIconSize },
+    },
+  } = useConfig();
+
   const [config, setConfig] = useState({
     environments: [],
   });
@@ -81,29 +85,13 @@ const ListRoutersTable = ({ items, isLoaded, error, onRowClick }) => {
       name: "Created",
       sortable: true,
       width: "10%",
-      render: (date) => (
-        <EuiToolTip
-          position="top"
-          content={moment(date, dateFormat).toLocaleString()}>
-          <EuiText size={defaultTextSize}>
-            {moment(date, dateFormat).fromNow()}
-          </EuiText>
-        </EuiToolTip>
-      ),
+      render: (date) => <DateFromNow date={date} size={defaultTextSize} />,
     },
     {
       field: "updated_at",
       name: "Updated",
       width: "10%",
-      render: (date) => (
-        <EuiToolTip
-          position="top"
-          content={moment(date, dateFormat).toLocaleString()}>
-          <EuiText size={defaultTextSize}>
-            {moment(date, dateFormat).fromNow()}
-          </EuiText>
-        </EuiToolTip>
-      ),
+      render: (date) => <DateFromNow date={date} size={defaultTextSize} />,
     },
     {
       name: (

--- a/ui/src/router/versions/list/ListRouterVersionsTable.js
+++ b/ui/src/router/versions/list/ListRouterVersionsTable.js
@@ -10,7 +10,7 @@ import {
 import { DateFromNow } from "@gojek/mlp-ui";
 import { FormLabelWithToolTip } from "../../../components/form/label_with_tooltip/FormLabelWithToolTip";
 import { DefaultItemAction } from "../components/DefaultItemAction";
-import { appConfig } from "../../../config";
+import { useConfig } from "../../../config";
 import { DeploymentStatusHealth } from "../../../components/status_health/DeploymentStatusHealth";
 import { Status } from "../../../services/status/Status";
 
@@ -23,6 +23,11 @@ export const ListRouterVersionsTable = ({
   onRowClick,
   ...props
 }) => {
+  const {
+    appConfig: {
+      tables: { defaultTextSize, defaultIconSize },
+    },
+  } = useConfig();
   // Map that holds a mapping between selected version number
   // and it's position in the `selection` array
   const [selectedIds, setSelectedIds] = useState({});
@@ -103,7 +108,7 @@ export const ListRouterVersionsTable = ({
       width: "21%",
       render: (version) => (
         <EuiText
-          size={appConfig.tables.defaultTextSize}
+          size={defaultTextSize}
           style={{ display: "flex", alignItems: "center" }}>
           {version}&nbsp;&nbsp;
           {version === deployedVersion && (
@@ -124,23 +129,19 @@ export const ListRouterVersionsTable = ({
       field: "created_at",
       name: "Created",
       width: "23%",
-      render: (date) => (
-        <DateFromNow date={date} size={appConfig.tables.defaultTextSize} />
-      ),
+      render: (date) => <DateFromNow date={date} size={defaultTextSize} />,
     },
     {
       field: "updated_at",
       name: "Updated",
       width: "23%",
-      render: (date) => (
-        <DateFromNow date={date} size={appConfig.tables.defaultTextSize} />
-      ),
+      render: (date) => <DateFromNow date={date} size={defaultTextSize} />,
     },
     {
       name: (
         <FormLabelWithToolTip
           label="Actions"
-          size={appConfig.tables.defaultIconSize}
+          size={defaultIconSize}
           content="Router version actions"
         />
       ),


### PR DESCRIPTION
## Problem:
Currently, Turing UI configuration consists of a mix of hard-coded values (defined at [`config.js`](https://github.com/gojek/turing/blob/main/ui/src/config.js)) and a set of `REACT_APP_*` environment variables, that are supplied during the build time. This approach implies that we need to re-build the entire application just to change some configuration keys. It also forces us to release separate builds of Turing for different environments (i.e. dev/staging/production) because the configuration of different environments is naturally expected to be different. 

## Solution:
This PR introduces necessary changes to support overriding Turing UI settings at the run time (after the application is bundled as an optimized static release). This is achieved by including `app.config.js` into `index.html` and merging the runtime config (defined at `app.config.js`) with build-time config (defined at [`config.js`](https://github.com/gojek/turing/blob/main/ui/src/config.js)).
So, if the user wants to override Sentry DSN in Turing's static build, she can update `app.config.js` file in `dist` directory with a desired value like this:

```js
var config = {
    sentryConfig: {
        dsn: "my-new-dsn"
    }
};
```

## Changes:
The main change in the codebase is that config objects (i.e. `appConfig`, `sentryConfig` etc) should no longer be imported directly into components where they are used, but instead, required configuration should be retrieved with a custom `useConfig` React hook. This hook merges user-provided configuration with the configuration defined during the build. 
