### PR TITLE
Fix nil pointer when accessing resources.

### DIFF
--- a/api/turing/service/ensembling_job_service.go
+++ b/api/turing/service/ensembling_job_service.go
@@ -420,4 +420,7 @@ func (s *ensemblingJobService) mergeDefaultConfigurations(job *models.Ensembling
 	if resources.ExecutorMemoryRequest == nil {
 		resources.ExecutorMemoryRequest = s.defaultConfig.BatchEnsemblingJobResources.ExecutorMemoryRequest
 	}
+
+	// Required as it returns a copy of resources and not the pointer address
+	job.InfraConfig.SetResources(resources)
 }


### PR DESCRIPTION
As pointed out in the comments, `GetResources` returns a copy of the resources object and not a pointer. So it has to be set back into the InfraConfig

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1a0b5ff]
goroutine 2109 [running]:
github.com/gojek/turing/api/turing/batch/ensembling.(*ensemblingController).createSparkApplication(0xc000a6fef0, 0xc001393c50, 0xc000fede40, 0x10, 0x0, 0x0)
	/app/vendor/github.com/gojek/turing/api/turing/batch/ensembling/controller.go:194 +0x35f
github.com/gojek/turing/api/turing/batch/ensembling.(*ensemblingController).Create(0xc000a6fef0, 0xc001393c50, 0x0, 0x0)
	/app/vendor/github.com/gojek/turing/api/turing/batch/ensembling/controller.go:166 +0x781
github.com/gojek/turing/api/turing/batch/ensembling.(*ensemblingJobRunner).processOneEnsemblingJob(0xc00059ed80, 0xc000610840)
	/app/vendor/github.com/gojek/turing/api/turing/batch/ensembling/runner.go:308 +0x2bc
created by github.com/gojek/turing/api/turing/batch/ensembling.(*ensemblingJobRunner).processJobs
	/app/vendor/github.com/gojek/turing/api/turing/batch/ensembling/runner.go:256 +0x1ac
```