### PR TITLE
Relax MLP library dependency version

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@elastic/datemath": "5.0.3",
     "@elastic/eui": "32.3.0",
-    "@gojek/mlp-ui": "1.4.10",
+    "@gojek/mlp-ui": "^1.4.10",
     "@reach/router": "1.3.4",
     "@sentry/browser": "5.15.5",
     "js-yaml": "^4.0.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1303,12 +1303,13 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gojek/mlp-ui@1.4.10":
-  version "1.4.10"
-  resolved "https://registry.yarnpkg.com/@gojek/mlp-ui/-/mlp-ui-1.4.10.tgz#11af092be8d1d9779ce4dbc04dab8c181646d19b"
-  integrity sha512-wJ/Bp6VWDHwRiruuXRc5p60izLV7ggf9JNI1suut/tarToxtaW1AC6GLTafqetwIRyURuTDC5QPNKhgSG0Dd2w==
+"@gojek/mlp-ui@^1.4.10":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@gojek/mlp-ui/-/mlp-ui-1.4.15.tgz#76e825dc4844978ea3139aef70fa58926b9b1e0e"
+  integrity sha512-xgtBElz4/AB+JDU8qe9IgUbbzpxGd28OcOc+w/O0hJGJN7BaTAZLDYjmnSJbTIirgDYodKbtZbLJNrNHKqJbkA==
   dependencies:
     classnames "^2.2.6"
+    json-bigint "1.0.0"
     lodash "^4.17.21"
     prop-types "^15.7.2"
     proper-url-join "2.1.1"
@@ -3036,6 +3037,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+bignumber.js@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
+  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -6978,6 +6984,13 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
+
+json-bigint@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
 
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
With the introduction of Module Federation [previously](https://github.com/gojek/turing/pull/101), we'll want to support the use of different semver for shared libraries (such as `@gojek/mlp-ui`).

In `v1.4.15` for `@gojek/mlp-ui`, BigInt conversion support was added which is required by our internal experiment engine's MFE. With strictly defined version on the parent application (i.e Turing), the Module Federation's `singleton` declaration on the experiment engine's MFE is unable to resolve to the latest compatible version.Hence, this PR relaxes the dependency version for shared library `@gojek/mlp-ui`.