### PR TITLE
Display router timeout if available

### DIFF
--- a/ui/src/router/details/components/router_details_header/RouterDetailsPageHeader.js
+++ b/ui/src/router/details/components/router_details_header/RouterDetailsPageHeader.js
@@ -1,13 +1,15 @@
 import React from "react";
-import { EuiBadge, EuiText } from "@elastic/eui";
+import { EuiBadge, EuiTextColor } from "@elastic/eui";
 import { DateFromNow } from "@gojek/mlp-ui";
 import { HorizontalDescriptionList } from "../../../../components/horizontal_description_list/HorizontalDescriptionList";
 import { PageSecondaryHeader } from "../../../components/page_header/PageSecondaryHeader";
 import { RouterEndpoint } from "../../../components/router_endpoint/RouterEndpoint";
+import { Status } from "../../../../services/status/Status";
 
 import "./RouterDetailsPageHeader.scss";
 
 export const RouterDetailsPageHeader = ({ router }) => {
+  const isRouterUpdating = router.status === Status.PENDING.toString();
   const headerItems = [
     {
       title: "Endpoint",
@@ -24,18 +26,10 @@ export const RouterDetailsPageHeader = ({ router }) => {
     },
     {
       title: "Timeout",
-      description: <EuiText size="s">{router.config.timeout}</EuiText>,
-      flexProps: {
-        grow: 1,
-        style: {
-          minWidth: "100px",
-        },
-      },
-    },
-    {
-      title: "Environment",
       description: (
-        <EuiBadge color="default">{router.environment_name}</EuiBadge>
+        <EuiTextColor size="s" color={isRouterUpdating ? "subdued" : "default"}>
+          {isRouterUpdating ? "Not available" : router.config?.timeout}
+        </EuiTextColor>
       ),
       flexProps: {
         grow: 1,
@@ -57,6 +51,18 @@ export const RouterDetailsPageHeader = ({ router }) => {
     {
       title: "Updated At",
       description: <DateFromNow date={router.updated_at} size="s" />,
+      flexProps: {
+        grow: 1,
+        style: {
+          minWidth: "100px",
+        },
+      },
+    },
+    {
+      title: "Environment",
+      description: (
+        <EuiBadge color="default">{router.environment_name}</EuiBadge>
+      ),
       flexProps: {
         grow: 1,
         style: {


### PR DESCRIPTION
This PR addresses edge cases from https://github.com/gojek/turing/pull/115

* Show the router timeout value only if available (new routers would not have a `config` property)
* Show "Not available" in place of router timeout if it is currently updating (rationale: when the router is updating, it is not clear if this value belongs to the new config or old config).