### PR TITLE
Handle API path prefix in Authorization Middleware, allow templated Experiment Engine Homepage URL

### DIFF
--- a/api/turing/api/appcontext.go
+++ b/api/turing/api/appcontext.go
@@ -43,6 +43,7 @@ type AppContext struct {
 func NewAppContext(
 	db *gorm.DB,
 	cfg *config.Config,
+	apiPathPrefix string,
 	authEnforcer *enforcer.Enforcer,
 	vaultClient vault.VaultClient,
 ) (*AppContext, error) {
@@ -50,7 +51,7 @@ func NewAppContext(
 	var authorizer *middleware.Authorizer
 	var err error
 	if authEnforcer != nil {
-		authorizer, err = middleware.NewAuthorizer(*authEnforcer)
+		authorizer, err = middleware.NewAuthorizer(*authEnforcer, apiPathPrefix)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed initializing Authorizer")
 		}

--- a/api/turing/api/appcontext.go
+++ b/api/turing/api/appcontext.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 
-	"github.com/gojek/mlp/api/pkg/authz/enforcer"
 	"github.com/gojek/mlp/api/pkg/vault"
 	batchensembling "github.com/gojek/turing/api/turing/batch/ensembling"
 	batchrunner "github.com/gojek/turing/api/turing/batch/runner"
@@ -43,20 +42,9 @@ type AppContext struct {
 func NewAppContext(
 	db *gorm.DB,
 	cfg *config.Config,
-	apiPathPrefix string,
-	authEnforcer *enforcer.Enforcer,
+	authorizer *middleware.Authorizer,
 	vaultClient vault.VaultClient,
 ) (*AppContext, error) {
-	// Init Authorizer
-	var authorizer *middleware.Authorizer
-	var err error
-	if authEnforcer != nil {
-		authorizer, err = middleware.NewAuthorizer(*authEnforcer, apiPathPrefix)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed initializing Authorizer")
-		}
-	}
-
 	// Init Experiments Service
 	expSvc, err := service.NewExperimentsService(cfg.Experiment)
 	if err != nil {

--- a/api/turing/api/appcontext_test.go
+++ b/api/turing/api/appcontext_test.go
@@ -197,8 +197,9 @@ func TestNewAppContext(t *testing.T) {
 	// Patch the functions from other packages
 	defer monkey.UnpatchAll()
 	monkey.Patch(middleware.NewAuthorizer,
-		func(enforcer enforcer.Enforcer) (*middleware.Authorizer, error) {
+		func(enforcer enforcer.Enforcer, prefix string) (*middleware.Authorizer, error) {
 			assert.Equal(t, testEnforcer, enforcer)
+			assert.Equal(t, "/v1/", prefix)
 			return nil, nil
 		},
 	)
@@ -251,7 +252,7 @@ func TestNewAppContext(t *testing.T) {
 	)
 
 	// Create expected components
-	testAuthorizer, err := middleware.NewAuthorizer(testEnforcer)
+	testAuthorizer, err := middleware.NewAuthorizer(testEnforcer, "/v1/")
 	assert.NoError(t, err)
 	mlpService, err := service.NewMLPService(testCfg.MLPConfig.MLPURL,
 		testCfg.MLPConfig.MLPEncryptionKey, testCfg.MLPConfig.MerlinURL)
@@ -260,7 +261,7 @@ func TestNewAppContext(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Validate
-	appCtx, err := NewAppContext(nil, testCfg, &testEnforcer, testVaultClient)
+	appCtx, err := NewAppContext(nil, testCfg, "/v1/", &testEnforcer, testVaultClient)
 	assert.NoError(t, err)
 
 	alertService, err := service.NewGitlabOpsAlertService(nil, *testCfg.AlertConfig)

--- a/api/turing/middleware/authorization_test.go
+++ b/api/turing/middleware/authorization_test.go
@@ -15,7 +15,7 @@ func TestBootstrapTuringPolicies(t *testing.T) {
 		mock.Anything, mock.Anything).Return(nil, nil)
 
 	// Create new authorizer
-	_, err := NewAuthorizer(authzEnforcer)
+	_, err := NewAuthorizer(authzEnforcer, "/")
 
 	// Validate
 	assert.NoError(t, err)

--- a/api/turing/server/application.go
+++ b/api/turing/server/application.go
@@ -87,7 +87,8 @@ func Run() {
 	}
 
 	// Init app context
-	appCtx, err := api.NewAppContext(db, cfg, authEnforcer, vaultClient)
+	apiPathPrefix := "/v1"
+	appCtx, err := api.NewAppContext(db, cfg, apiPathPrefix, authEnforcer, vaultClient)
 	if err != nil {
 		log.Panicf("Failed initializing application context: %v", err)
 	}
@@ -114,7 +115,7 @@ func Run() {
 	AddHealthCheckHandler(r, "/v1/internal", db)
 
 	// API Handler
-	err = AddAPIRoutesHandler(r, "/v1", appCtx, cfg)
+	err = AddAPIRoutesHandler(r, apiPathPrefix, appCtx, cfg)
 	if err != nil {
 		log.Panicf("Failed to configure API routes: %v", err)
 	}

--- a/ui/src/router/components/configuration/RouterConfigDetails.js
+++ b/ui/src/router/components/configuration/RouterConfigDetails.js
@@ -7,7 +7,7 @@ import { EnsemblerConfigSection } from "./components/EnsemblerConfigSection";
 import { LoggingConfigSection } from "./components/LoggingConfigSection";
 import { ConfigSection } from "../../../components/config_section";
 
-export const RouterConfigDetails = ({ config }) => {
+export const RouterConfigDetails = ({ projectId, config }) => {
   const sections = [
     {
       title: "Router",
@@ -17,7 +17,9 @@ export const RouterConfigDetails = ({ config }) => {
     {
       title: "Experiment",
       iconType: "beaker",
-      children: <ExperimentConfigSection config={config} />,
+      children: (
+        <ExperimentConfigSection projectId={projectId} config={config} />
+      ),
     },
     {
       title: "Enricher",

--- a/ui/src/router/components/configuration/components/ExperimentConfigSection.js
+++ b/ui/src/router/components/configuration/components/ExperimentConfigSection.js
@@ -3,7 +3,10 @@ import { EuiPanel } from "@elastic/eui";
 import { ExperimentConfigGroup } from "./experiment_config_section/ExperimentConfigGroup";
 import { ExperimentEngineContextProvider } from "../../../../providers/experiments/ExperimentEngineContextProvider";
 
-export const ExperimentConfigSection = ({ config: { experiment_engine } }) => {
+export const ExperimentConfigSection = ({
+  projectId,
+  config: { experiment_engine },
+}) => {
   return (
     <Fragment>
       {experiment_engine.type === "nop" ? (
@@ -11,6 +14,7 @@ export const ExperimentConfigSection = ({ config: { experiment_engine } }) => {
       ) : (
         <ExperimentEngineContextProvider>
           <ExperimentConfigGroup
+            projectId={projectId}
             engineType={experiment_engine.type}
             engineConfig={experiment_engine.config}
           />

--- a/ui/src/router/components/configuration/components/TreatmentMappingConfigSection.js
+++ b/ui/src/router/components/configuration/components/TreatmentMappingConfigSection.js
@@ -8,7 +8,7 @@ import {
   EuiTitle,
 } from "@elastic/eui";
 import { ConfigSectionPanel } from "../../../../components/config_section";
-import getExperimentUrl from "./config";
+import { getExperimentUrl } from "./config";
 
 const TreatmentMappingConfigTable = ({ items }) => {
   const columns = [

--- a/ui/src/router/components/configuration/components/config.js
+++ b/ui/src/router/components/configuration/components/config.js
@@ -1,7 +1,16 @@
-const getExperimentUrl = (engineProps, experiment) => {
-  return engineProps && engineProps.home_page_url
-    ? `${engineProps.home_page_url}/experiments/${experiment.id}`
-    : "";
+import template from "lodash/template";
+import templateSettings from "lodash/templateSettings";
+
+export const getHomePageUrl = (engineProps, projectId) => {
+  // If {{projectId}} present in the URL, substitute with actual project id.
+  templateSettings.interpolate = /{{([\s\S]+?)}}/g;
+  return template(engineProps.home_page_url)({
+    projectId: projectId,
+  });
 };
 
-export default getExperimentUrl;
+export const getExperimentUrl = (engineProps, experiment) => {
+  return engineProps && engineProps.home_page_url
+    ? `${getHomePageUrl(engineProps)}/experiments/${experiment.id}`
+    : "";
+};

--- a/ui/src/router/components/configuration/components/experiment_config_section/ExperimentConfigGroup.js
+++ b/ui/src/router/components/configuration/components/experiment_config_section/ExperimentConfigGroup.js
@@ -6,7 +6,11 @@ import { ExperimentsConfigTable } from "./experiments/ExperimentsConfigTable";
 import { VariablesConfigTable } from "./variables/VariablesConfigTable";
 import ExperimentEngineContext from "../../../../../providers/experiments/context";
 
-export const ExperimentConfigGroup = ({ engineType, engineConfig }) => {
+export const ExperimentConfigGroup = ({
+  projectId,
+  engineType,
+  engineConfig,
+}) => {
   const { getEngineProperties } = useContext(ExperimentEngineContext);
   const engineProps = getEngineProperties(engineType);
 
@@ -19,6 +23,7 @@ export const ExperimentConfigGroup = ({ engineType, engineConfig }) => {
               title="Experiment Engine"
               className="experimentCredentials">
               <CredentialsConfigSection
+                projectId={projectId}
                 engineType={engineType}
                 deployment={engineConfig.deployment}
                 client={engineConfig.client}

--- a/ui/src/router/components/configuration/components/experiment_config_section/credentials/CredentialsConfigSection.js
+++ b/ui/src/router/components/configuration/components/experiment_config_section/credentials/CredentialsConfigSection.js
@@ -9,7 +9,10 @@ import {
 } from "@elastic/eui";
 import "./CredentialsConfigSection.scss";
 
+import { getHomePageUrl } from "../../../../../../router/components/configuration/components/config";
+
 export const CredentialsConfigSection = ({
+  projectId,
   engineType,
   deployment,
   client,
@@ -22,7 +25,10 @@ export const CredentialsConfigSection = ({
       <EuiTitle size="xs">
         {!!engineProps.home_page_url ? (
           <EuiTextColor color="secondary">
-            <EuiLink href={engineProps.home_page_url} target="_blank" external>
+            <EuiLink
+              href={getHomePageUrl(engineProps, projectId)}
+              target="_blank"
+              external>
               {engineProps.name}
             </EuiLink>
           </EuiTextColor>

--- a/ui/src/router/components/configuration/components/experiment_config_section/experiments/ExperimentsConfigTable.js
+++ b/ui/src/router/components/configuration/components/experiment_config_section/experiments/ExperimentsConfigTable.js
@@ -8,7 +8,7 @@ import {
   EuiTextColor,
   EuiTitle,
 } from "@elastic/eui";
-import getExperimentUrl from "../../config";
+import { getExperimentUrl } from "../../config";
 import "./ExperimentsConfigTable.scss";
 
 export const ExperimentsConfigTable = ({ experiments, engineProps }) => {

--- a/ui/src/router/details/config/RouterConfigView.js
+++ b/ui/src/router/details/config/RouterConfigView.js
@@ -36,7 +36,10 @@ export const RouterConfigView = ({ router }) => {
           {status === Status.PENDING && <EuiLoadingChart size="xl" mono />}
         </OverlayMask>
       )}
-      <RouterConfigDetails config={router.config} />
+      <RouterConfigDetails
+        projectId={router.project_id}
+        config={router.config}
+      />
     </div>
   ) : (
     <EuiEmptyPrompt

--- a/ui/src/router/versions/details/RouterVersionDetailsView.js
+++ b/ui/src/router/versions/details/RouterVersionDetailsView.js
@@ -119,11 +119,7 @@ export const RouterVersionDetailsView = ({
 
             <Router primary={false}>
               <Redirect from="/" to="details" noThrow />
-              <RouterVersionConfigView
-                path="details"
-                projectId={projectId}
-                config={version}
-              />
+              <RouterVersionConfigView path="details" config={version} />
               <Redirect from="any" to="/error/404" default noThrow />
             </Router>
           </Fragment>

--- a/ui/src/router/versions/details/RouterVersionDetailsView.js
+++ b/ui/src/router/versions/details/RouterVersionDetailsView.js
@@ -119,7 +119,11 @@ export const RouterVersionDetailsView = ({
 
             <Router primary={false}>
               <Redirect from="/" to="details" noThrow />
-              <RouterVersionConfigView path="details" config={version} />
+              <RouterVersionConfigView
+                path="details"
+                projectId={projectId}
+                config={version}
+              />
               <Redirect from="any" to="/error/404" default noThrow />
             </Router>
           </Fragment>

--- a/ui/src/router/versions/details/config/RouterVersionConfigView.js
+++ b/ui/src/router/versions/details/config/RouterVersionConfigView.js
@@ -3,7 +3,7 @@ import { replaceBreadcrumbs } from "@gojek/mlp-ui";
 import { RouterConfigDetails } from "../../../components/configuration/RouterConfigDetails";
 import { get } from "../../../../components/form/utils";
 
-export const RouterVersionConfigView = ({ config }) => {
+export const RouterVersionConfigView = ({ projectId, config }) => {
   useEffect(() => {
     replaceBreadcrumbs([
       {
@@ -25,5 +25,5 @@ export const RouterVersionConfigView = ({ config }) => {
     ]);
   }, [config]);
 
-  return <RouterConfigDetails config={config} />;
+  return <RouterConfigDetails projectId={projectId} config={config} />;
 };


### PR DESCRIPTION
This PR makes some minor modifications.
1. In an earlier [PR](https://github.com/gojek/turing/pull/103), the set up of the HTTP handler was refactored. The usage of the [Subrouter](https://pkg.go.dev/github.com/gorilla/mux#Route.Subrouter) with [PathPrefix](https://pkg.go.dev/github.com/gorilla/mux#Router.PathPrefix), however, broke the expectation within the Authorization Middleware, causing the resources to be formatted as `v1:projects:{id}:*` as opposed to `projects:{id}:*`. This MR propagates the API handler's path prefix to the Authorization middleware upon initialisation, so it can be ignored at the time of validation.
2. The UI now allows a templated string to be supplied by the experiment engine, for its `home_page_url` property so that the template `{{projectId}}` in the string would be replaced by the current MLP project ID. This is useful for the internal Experiment Engine used in Gojek.