### PR TITLE
Add more Knative configs into turing-init for the setting up of Turing's infrastructure

### DIFF
--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -420,6 +420,7 @@ jobs:
             --set image.repository=${{ github.repository }}/cluster-init \
             --set image.tag=${{ env.CLUSTER_INIT_VERSION }} \
             --set knativeDomains="127.0.0.1.nip.io" \
+            --set knative_registries_skipping_tag_resolving=${{ env.LOCAL_REGISTRY }} \
             --install \
             --wait
 
@@ -428,10 +429,6 @@ jobs:
           kubectl get pod --all-namespaces
           kubectl get svc --all-namespaces
           kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/$(kubectl get job -n infrastructure | grep -v 'NAME' | head -n 1 | awk '{print $1}')
-
-          # Ignore resolving tags for local Docker registry
-          kubectl -n knative-serving patch configmap/config-deployment \
-            --type merge -p '{"data":{"registriesSkippingTagResolving": "${{ env.LOCAL_REGISTRY }}"}}'
 
       - name: "Install Vault"
         run: |

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -419,6 +419,7 @@ jobs:
             --set image.registry=${{ env.LOCAL_REGISTRY }}/ \
             --set image.repository=${{ github.repository }}/cluster-init \
             --set image.tag=${{ env.CLUSTER_INIT_VERSION }} \
+            --set knativeDomains="127.0.0.1.nip.io" \
             --install \
             --wait
 
@@ -427,10 +428,6 @@ jobs:
           kubectl get pod --all-namespaces
           kubectl get svc --all-namespaces
           kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/$(kubectl get job -n infrastructure | grep -v 'NAME' | head -n 1 | awk '{print $1}')
-
-          # Setting up DNS
-          kubectl -n knative-serving patch configmap/config-domain \
-            --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
 
           # Ignore resolving tags for local Docker registry
           kubectl -n knative-serving patch configmap/config-deployment \

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -419,8 +419,8 @@ jobs:
             --set image.registry=${{ env.LOCAL_REGISTRY }}/ \
             --set image.repository=${{ github.repository }}/cluster-init \
             --set image.tag=${{ env.CLUSTER_INIT_VERSION }} \
-            --set knativeDomains="127.0.0.1.nip.io" \
-            --set knativeRegistriesSkippingTagResolving=${{ env.LOCAL_REGISTRY }} \
+            --set knative.domains="127.0.0.1.nip.io" \
+            --set knative.registriesSkippingTagResolving=${{ env.LOCAL_REGISTRY }} \
             --install \
             --wait
 

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -420,7 +420,7 @@ jobs:
             --set image.repository=${{ github.repository }}/cluster-init \
             --set image.tag=${{ env.CLUSTER_INIT_VERSION }} \
             --set knativeDomains="127.0.0.1.nip.io" \
-            --set knative_registries_skipping_tag_resolving=${{ env.LOCAL_REGISTRY }} \
+            --set knativeRegistriesSkippingTagResolving=${{ env.LOCAL_REGISTRY }} \
             --install \
             --wait
 
@@ -428,7 +428,9 @@ jobs:
           kubectl logs -n infrastructure -f $(kubectl get pod --namespace infrastructure | grep -v 'NAME' | grep -v 'spark' | head -n 1 | awk '{print $1}')
           kubectl get pod --all-namespaces
           kubectl get svc --all-namespaces
-          kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/$(kubectl get job -n infrastructure | grep -v 'NAME' | head -n 1 | awk '{print $1}')
+          kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-spark-operator-webhook-init
+          # Might fail the first time but the 2nd run should work, rarely fails on the first try though.
+          kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-init
 
       - name: "Install Vault"
         run: |

--- a/infra/charts/turing-init/Chart.yaml
+++ b/infra/charts/turing-init/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: turing-init
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.1
+version: 0.0.2
 dependencies:
 - name: spark-operator
   version: 1.1.7

--- a/infra/charts/turing-init/README.md
+++ b/infra/charts/turing-init/README.md
@@ -1,6 +1,6 @@
 # turing-init
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -16,14 +16,14 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io/"` | Docker registry for Turing cluster init |
-| image.repository | string | `"gojek/turing-cluster-init"` | Docker image repository for Turing cluster init |
+| image.repository | string | `"gojek/turing/cluster-init"` | Docker image repository for Turing cluster init |
 | image.tag | string | `"latest"` | Docker image tag for Turing cluster init |
-| istioOperatorConfig | object | `{"apiVersion":"install.istio.io/v1alpha1","kind":"IstioOperator","spec":{"addonComponents":{"pilot":{"enabled":true}},"components":{"ingressGateways":[{"enabled":true,"name":"istio-ingressgateway"},{"enabled":true,"k8s":{"service":{"ports":[{"name":"status-port","port":15020},{"name":"http2","port":80},{"name":"https","port":443}],"type":"ClusterIP"}},"label":{"app":"cluster-local-gateway","istio":"cluster-local-gateway"},"name":"cluster-local-gateway"}]},"values":{"gateways":{"istio-ingressgateway":{"runAsRoot":true}},"global":{"proxy":{"autoInject":"enabled"},"useMCP":false}}}}` | istio operator config, defaults are the minimum to run turing |
-| istioVersion | string | `"1.9.9"` | Istio version to use |
-| knativeDomains | string | `""` | Knative domains, comma seperated values, i.e. www.example.com,www.gojek.com |
-| knativeIstioVersion | string | `"0.18.1"` | Knative Istio Version to use |
-| knativeVersion | string | `"0.18.3"` | Knative Version to use |
-| knative_registries_skipping_tag_resolving | string | `""` | Knative registries skipping tag resolving, comma seperated values, i.e. www.example.com,www.gojek.com |
+| istio.operatorConfig | object | `{"apiVersion":"install.istio.io/v1alpha1","kind":"IstioOperator","spec":{"addonComponents":{"pilot":{"enabled":true}},"components":{"ingressGateways":[{"enabled":true,"name":"istio-ingressgateway"},{"enabled":true,"k8s":{"service":{"ports":[{"name":"status-port","port":15020},{"name":"http2","port":80},{"name":"https","port":443}],"type":"ClusterIP"}},"label":{"app":"cluster-local-gateway","istio":"cluster-local-gateway"},"name":"cluster-local-gateway"}]},"values":{"gateways":{"istio-ingressgateway":{"runAsRoot":true}},"global":{"proxy":{"autoInject":"enabled"},"useMCP":false}}}}` | istio operator config, defaults are the minimum to run turing, see https://istio.io/v1.9/docs/reference/config/istio.operator.v1alpha1/ |
+| istio.version | string | `"1.9.9"` | Istio version to use |
+| knative.domains | string | `""` | Knative domains, comma seperated values, i.e. www.example.com,www.gojek.com |
+| knative.istioVersion | string | `"0.18.1"` | Knative Istio Version to use |
+| knative.registriesSkippingTagResolving | string | `""` | Knative registries skipping tag resolving, comma seperated values, i.e. www.example.com,www.gojek.com |
+| knative.version | string | `"0.18.3"` | Knative Version to use |
 | spark-operator | object | `{"image":{"repository":"gcr.io/spark-operator/spark-operator","tag":"v1beta2-1.2.3-3.1.1"},"replicas":1,"resources":{},"webhook":{"enable":true}}` | Override any spark-operator values here: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/charts/spark-operator-chart/README.md |
 | spark-operator.image.repository | string | `"gcr.io/spark-operator/spark-operator"` | repository of the spark operator |
 | spark-operator.image.tag | string | `"v1beta2-1.2.3-3.1.1"` | image tag of the spark operator |

--- a/infra/charts/turing-init/README.md
+++ b/infra/charts/turing-init/README.md
@@ -20,8 +20,10 @@ A Helm chart for Kubernetes
 | image.tag | string | `"latest"` | Docker image tag for Turing cluster init |
 | istioOperatorConfig | object | `{"apiVersion":"install.istio.io/v1alpha1","kind":"IstioOperator","spec":{"addonComponents":{"pilot":{"enabled":true}},"components":{"ingressGateways":[{"enabled":true,"name":"istio-ingressgateway"},{"enabled":true,"k8s":{"service":{"ports":[{"name":"status-port","port":15020},{"name":"http2","port":80},{"name":"https","port":443}],"type":"ClusterIP"}},"label":{"app":"cluster-local-gateway","istio":"cluster-local-gateway"},"name":"cluster-local-gateway"}]},"values":{"gateways":{"istio-ingressgateway":{"runAsRoot":true}},"global":{"proxy":{"autoInject":"enabled"},"useMCP":false}}}}` | istio operator config, defaults are the minimum to run turing |
 | istioVersion | string | `"1.9.9"` | Istio version to use |
-| knativeIstioVersion | string | `"0.18.1"` |  |
+| knativeDomains | string | `""` | Knative domains, comma seperated values, i.e. www.example.com,www.gojek.com |
+| knativeIstioVersion | string | `"0.18.1"` | Knative Istio Version to use |
 | knativeVersion | string | `"0.18.3"` | Knative Version to use |
+| knative_registries_skipping_tag_resolving | string | `""` | Knative registries skipping tag resolving, comma seperated values, i.e. www.example.com,www.gojek.com |
 | spark-operator | object | `{"image":{"repository":"gcr.io/spark-operator/spark-operator","tag":"v1beta2-1.2.3-3.1.1"},"replicas":1,"resources":{},"webhook":{"enable":true}}` | Override any spark-operator values here: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/charts/spark-operator-chart/README.md |
 | spark-operator.image.repository | string | `"gcr.io/spark-operator/spark-operator"` | repository of the spark operator |
 | spark-operator.image.tag | string | `"v1beta2-1.2.3-3.1.1"` | image tag of the spark operator |

--- a/infra/charts/turing-init/templates/cleanup-job.yaml
+++ b/infra/charts/turing-init/templates/cleanup-job.yaml
@@ -24,11 +24,11 @@ spec:
         - /app/cleanup.sh
         env:
         - name: ISTIO_VERSION
-          value: {{ .Values.istioVersion }}
+          value: {{ .Values.istio.version }}
         - name: KNATIVE_VERSION
-          value: {{ .Values.knativeVersion }}
+          value: {{ .Values.knative.version }}
         - name: KNATIVE_ISTIO_VERSION
-          value: {{ .Values.knativeIstioVersion }}
+          value: {{ .Values.knative.istioVersion }}
         - name: RELEASE_NAME
           value: {{ .Release.Name }}
         - name: RELEASE_NAMESPACE

--- a/infra/charts/turing-init/templates/cluster-role.yaml
+++ b/infra/charts/turing-init/templates/cluster-role.yaml
@@ -15,6 +15,7 @@ rules:
   - secrets
   - serviceaccounts
   - endpoints
+  - persistentvolumeclaims
   verbs:
   - "*"
 - apiGroups:
@@ -22,6 +23,7 @@ rules:
   resources:
   - deployments
   - replicasets
+  - daemonsets
   verbs:
   - "*"
 - apiGroups:
@@ -51,6 +53,7 @@ rules:
   - virtualservices
   - envoyfilters
   - gateways
+  - destinationrules
   verbs:
   - "*"
 - apiGroups:

--- a/infra/charts/turing-init/templates/init-job.yaml
+++ b/infra/charts/turing-init/templates/init-job.yaml
@@ -22,15 +22,15 @@ spec:
         - name: ISTIO_OPERATOR_PATH
           value: /etc/istio-operator/operator.yaml
         - name: ISTIO_VERSION
-          value: {{ .Values.istioVersion }}
+          value: {{ .Values.istio.version }}
         - name: KNATIVE_VERSION
-          value: {{ .Values.knativeVersion }}
+          value: {{ .Values.knative.version }}
         - name: KNATIVE_ISTIO_VERSION
-          value: {{ .Values.knativeIstioVersion }}
+          value: {{ .Values.knative.istioVersion }}
         - name: KNATIVE_DOMAINS
-          value: "{{ .Values.knativeDomains }}"
+          value: "{{ .Values.knative.domains }}"
         - name: KNATIVE_REGISTRIES_SKIPPING_TAG_RESOLVING
-          value: "{{ .Values.knativeRegistriesSkippingTagResolving }}"
+          value: "{{ .Values.knative.registriesSkippingTagResolving }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - mountPath: /etc/istio-operator

--- a/infra/charts/turing-init/templates/init-job.yaml
+++ b/infra/charts/turing-init/templates/init-job.yaml
@@ -27,6 +27,8 @@ spec:
           value: {{ .Values.knativeVersion }}
         - name: KNATIVE_ISTIO_VERSION
           value: {{ .Values.knativeIstioVersion }}
+        - name: KNATIVE_DOMAINS
+          value: "{{ .Values.knativeDomains }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - mountPath: /etc/istio-operator

--- a/infra/charts/turing-init/templates/init-job.yaml
+++ b/infra/charts/turing-init/templates/init-job.yaml
@@ -29,6 +29,8 @@ spec:
           value: {{ .Values.knativeIstioVersion }}
         - name: KNATIVE_DOMAINS
           value: "{{ .Values.knativeDomains }}"
+        - name: KNATIVE_REGISTRIES_SKIPPING_TAG_RESOLVING
+          value: "{{ .Values.knativeRegistriesSkippingTagResolving }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - mountPath: /etc/istio-operator

--- a/infra/charts/turing-init/templates/istio-operator-config-map.yaml
+++ b/infra/charts/turing-init/templates/istio-operator-config-map.yaml
@@ -4,4 +4,4 @@ metadata:
   name: {{ include "turing-init.fullname" . }}-istio-operator
 data:
   operator.yaml: |
-    {{- toYaml .Values.istioOperatorConfig | nindent 4 }}
+    {{- toYaml .Values.istio.operatorConfig | nindent 4 }}

--- a/infra/charts/turing-init/values.yaml
+++ b/infra/charts/turing-init/values.yaml
@@ -20,6 +20,8 @@ knativeVersion: 0.18.3
 knativeIstioVersion: 0.18.1
 # -- Knative domains, comma seperated values, i.e. www.example.com,www.gojek.com
 knativeDomains: ""
+# -- Knative registries skipping tag resolving, comma seperated values, i.e. www.example.com,www.gojek.com
+knativeRegistriesSkippingTagResolving: ""
 
 # -- istio operator config, defaults are the minimum to run turing
 istioOperatorConfig:

--- a/infra/charts/turing-init/values.yaml
+++ b/infra/charts/turing-init/values.yaml
@@ -16,7 +16,10 @@ image:
 istioVersion: 1.9.9
 # -- Knative Version to use
 knativeVersion: 0.18.3
+# -- Knative Istio Version to use
 knativeIstioVersion: 0.18.1
+# -- Knative domains, comma seperated values, i.e. www.example.com,www.gojek.com
+knativeDomains: ""
 
 # -- istio operator config, defaults are the minimum to run turing
 istioOperatorConfig:

--- a/infra/charts/turing-init/values.yaml
+++ b/infra/charts/turing-init/values.yaml
@@ -7,61 +7,63 @@ image:
   # -- Docker registry for Turing cluster init
   registry: ghcr.io/
   # -- Docker image repository for Turing cluster init
-  repository: gojek/turing-cluster-init
+  repository: gojek/turing/cluster-init
   # -- Docker image tag for Turing cluster init
   tag: latest
   pullPolicy: IfNotPresent
 
-# -- Istio version to use
-istioVersion: 1.9.9
-# -- Knative Version to use
-knativeVersion: 0.18.3
-# -- Knative Istio Version to use
-knativeIstioVersion: 0.18.1
-# -- Knative domains, comma seperated values, i.e. www.example.com,www.gojek.com
-knativeDomains: ""
-# -- Knative registries skipping tag resolving, comma seperated values, i.e. www.example.com,www.gojek.com
-knativeRegistriesSkippingTagResolving: ""
+knative:
+  # -- Knative Version to use
+  version: 0.18.3
+  # -- Knative Istio Version to use
+  istioVersion: 0.18.1
+  # -- Knative domains, comma seperated values, i.e. www.example.com,www.gojek.com
+  domains: ""
+  # -- Knative registries skipping tag resolving, comma seperated values, i.e. www.example.com,www.gojek.com
+  registriesSkippingTagResolving: ""
 
-# -- istio operator config, defaults are the minimum to run turing
-istioOperatorConfig:
-  apiVersion: install.istio.io/v1alpha1
-  kind: IstioOperator
-  spec:
-    values:
-      global:
-        proxy:
-          autoInject: enabled
-        useMCP: false
-      # Patch to fix validation error: port http2/80 in gateway cluster-local-gateway
-      # invalid: targetPort is set to 0, which requires root
-      gateways:
-        istio-ingressgateway:
-          runAsRoot: true
+istio:
+  # -- Istio version to use
+  version: 1.9.9
+  # -- istio operator config, defaults are the minimum to run turing, see https://istio.io/v1.9/docs/reference/config/istio.operator.v1alpha1/
+  operatorConfig:
+    apiVersion: install.istio.io/v1alpha1
+    kind: IstioOperator
+    spec:
+      values:
+        global:
+          proxy:
+            autoInject: enabled
+          useMCP: false
+        # Patch to fix validation error: port http2/80 in gateway cluster-local-gateway
+        # invalid: targetPort is set to 0, which requires root
+        gateways:
+          istio-ingressgateway:
+            runAsRoot: true
 
-    addonComponents:
-      pilot:
-        enabled: true
-
-    components:
-      ingressGateways:
-        - name: istio-ingressgateway
+      addonComponents:
+        pilot:
           enabled: true
-        - name: cluster-local-gateway
-          enabled: true
-          label:
-            istio: cluster-local-gateway
-            app: cluster-local-gateway
-          k8s:
-            service:
-              type: ClusterIP
-              ports:
-                - port: 15020
-                  name: status-port
-                - port: 80
-                  name: http2
-                - port: 443
-                  name: https
+
+      components:
+        ingressGateways:
+          - name: istio-ingressgateway
+            enabled: true
+          - name: cluster-local-gateway
+            enabled: true
+            label:
+              istio: cluster-local-gateway
+              app: cluster-local-gateway
+            k8s:
+              service:
+                type: ClusterIP
+                ports:
+                  - port: 15020
+                    name: status-port
+                  - port: 80
+                    name: http2
+                  - port: 443
+                    name: https
 
 # -- Override any spark-operator values here: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/charts/spark-operator-chart/README.md
 spark-operator:

--- a/infra/cluster-init/init.sh
+++ b/infra/cluster-init/init.sh
@@ -60,16 +60,16 @@ function install_knative {
         if [[ ! -z ${URL} ]]; then
             local domain_template='{"data":{"{URL_TO_CHANGE}":""}}'
             local domain_patch_data=$(echo ${domain_template} | sed -e "s|{URL_TO_CHANGE}|${URL}|g")
-            kubectl -n knative-serving patch configmap/config-domain --type merge -p ${domain_patch_data}
+            kubectl -n knative-serving patch configmap/config-domain --type merge -p "${domain_patch_data}"
         fi
     done
 
     # Patch registries
     echo "${KNATIVE_REGISTRIES_SKIPPING_TAG_RESOLVING}" | tr ',' '\n' | while read REGISTRY; do
         if [[ ! -z ${REGISTRY} ]]; then
-            local registry_template=''{"data":{"registriesSkippingTagResolving": "{REGISTRY_TO_CHANGE}"}}''
+            local registry_template='{"data":{"registriesSkippingTagResolving": "{REGISTRY_TO_CHANGE}"}}'
             local registry_patch_data=$(echo ${registry_template} | sed -e "s|{REGISTRY_TO_CHANGE}|${REGISTRY}|g")
-            kubectl -n knative-serving patch configmap/config-deployment --type merge -p ${registry_patch_data}
+            kubectl -n knative-serving patch configmap/config-deployment --type merge -p "${registry_patch_data}"
         fi
     done
 


### PR DESCRIPTION
This PR allows some extra configuration of the Knative service during the provisioning of third party software handled by the turing-init chart:
1. Allow extra Knative domains to be used
2. Allow custom container registries to be used.

This flow is tested using the e2e test flow.