### PR TITLE
Add module resolution for react-beautiful-dnd

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -39,7 +39,8 @@
     "react-scripts": "5.0.0-next.37"
   },
   "resolutions": {
-    "react-scripts/**/postcss-normalize": "10.0.1"
+    "react-scripts/**/postcss-normalize": "10.0.1",
+    "**/react-beautiful-dnd": "git+https://github.com/gojekfarm/react-beautiful-dnd.git#master"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9227,10 +9227,9 @@ react-app-polyfill@3.0.0-next.81+25f516f8:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
-react-beautiful-dnd@^13.0.0:
+react-beautiful-dnd@^13.0.0, "react-beautiful-dnd@git+https://github.com/gojekfarm/react-beautiful-dnd.git#master":
   version "13.1.0"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz#ec97c81093593526454b0de69852ae433783844d"
-  integrity sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==
+  resolved "git+https://github.com/gojekfarm/react-beautiful-dnd.git#cb6e6cf440b375521c96b2f494cfff29566c9bbf"
   dependencies:
     "@babel/runtime" "^7.9.2"
     css-box-model "^1.2.0"


### PR DESCRIPTION
Since our internal Experiment-Engine (EE) UI requires the use of Drag-And-Drop component from `eui` library which has dependency on `react-beautiful-dnd`, an issue as described in this [PR](https://github.com/gojekfarm/react-beautiful-dnd/pull/1) was found and needs to be resolved, by using the fix introduced (via module resolution).

Module resolution is required on Turing because it uses the same `eui` version as the EE (`32.3.0`). In the scenario where the EE uses a different minor/patch version, the change introduced in this PR will not be required since the dependency is not a singleton. Validation has been done and this behaviour is consistent with our conclusion in previous PR: #114 .

Regardless, this module resolution fix will be useful if Turing-UI starts using Drag-And-Drop component for 2 different lists.