### PR TITLE
Fix building cluster-init container on tags.

### DIFF
--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -5,7 +5,7 @@ on:
   # (only if there are changes to relevant paths)
   push:
     tags:
-      - "cluster-init/v[0-9]+.[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
     branches:
       - main
     paths:

--- a/infra/charts/turing-init/Chart.yaml
+++ b/infra/charts/turing-init/Chart.yaml
@@ -3,6 +3,7 @@ name: turing-init
 description: A Helm chart for Kubernetes
 type: application
 version: 0.0.2
+appVersion: v1.0.0
 dependencies:
 - name: spark-operator
   version: 1.1.7

--- a/infra/charts/turing-init/values.yaml
+++ b/infra/charts/turing-init/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- Docker image repository for Turing cluster init
   repository: gojek/turing/cluster-init
   # -- Docker image tag for Turing cluster init
-  tag: latest
+  tag: v1.0.0
   pullPolicy: IfNotPresent
 
 knative:


### PR DESCRIPTION
As of now, the pattern for building on release tags are not there, so it will not publish a tagged version. We also set the appVersion to 1.0.0 like turing charts and also set the default image to 1.0.0.

We should also retag version 1.0.0 since we missed this out. I'm also unsure if the `make version` works on tags, could you help to check if this will work?