### PR TITLE
Batch predict endpoint

### DIFF
--- a/api/e2e/test/01_create_router_test.go
+++ b/api/e2e/test/01_create_router_test.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 
-	"github.com/gojek/turing/api/turing/service"
-
 	"github.com/gojek/turing/api/turing/models"
+	"github.com/gojek/turing/api/turing/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
 )
@@ -57,6 +57,47 @@ func TestCreateRouter(t *testing.T) {
 						}
 					  ]
 					}`
+					assert.JSONEq(t, expectedResponse, actualResponse)
+				})
+
+			batchEndpoint := strings.Replace(router.Endpoint, "/predict", "/batch_predict", -1)
+			t.Log("Testing router batch endpoint: POST " + batchEndpoint)
+			withRouterResponse(t,
+				http.MethodPost,
+				batchEndpoint,
+				nil,
+				"[{},{}]",
+				func(response *http.Response, responsePayload []byte) {
+					t.Log(string(responsePayload))
+					assert.Equal(t, http.StatusOK, response.StatusCode,
+						"Unexpected response (code %d): %s",
+						response.StatusCode, string(responsePayload))
+					actualResponse := gjson.GetBytes(responsePayload, "#.data.json.response").String()
+					expectedResponse := `[{
+					  "experiment": {},
+					  "route_responses": [
+						{
+						  "data": {
+							"version": "control"
+						  },
+						  "is_default": true,
+						  "route": "control"
+						}
+					  ]
+					},
+					{
+					  "experiment": {},
+					  "route_responses": [
+						{
+						  "data": {
+							"version": "control"
+						  },
+						  "is_default": true,
+						  "route": "control"
+						}
+					  ]
+					}
+					]`
 					assert.JSONEq(t, expectedResponse, actualResponse)
 				})
 

--- a/api/e2e/test/01_create_router_test.go
+++ b/api/e2e/test/01_create_router_test.go
@@ -68,7 +68,6 @@ func TestCreateRouter(t *testing.T) {
 				nil,
 				"[{},{}]",
 				func(response *http.Response, responsePayload []byte) {
-					t.Log(string(responsePayload))
 					assert.Equal(t, http.StatusOK, response.StatusCode,
 						"Unexpected response (code %d): %s",
 						response.StatusCode, string(responsePayload))

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -72,7 +72,7 @@ const (
 const (
 	defaultIstioGateway   = "istio-ingressgateway.istio-system.svc.cluster.local"
 	defaultGateway        = "knative-ingress-gateway.knative-serving"
-	defaultMatchURIPrefix = "/v1/predict"
+	defaultMatchURIPrefix = "/v1/predict,/v1/batch_predict"
 )
 
 // NewRouterService creates a new cluster Service object with the required config
@@ -158,7 +158,7 @@ func (sb *clusterSvcBuilder) NewRouterEndpoint(
 		Endpoint:        host,
 		DestinationHost: defaultIstioGateway,
 		HostRewrite:     veURL.Hostname(),
-		MatchURIPrefix:  defaultMatchURIPrefix,
+		MatchURIPrefix:  strings.Split(defaultMatchURIPrefix, ","),
 	}, nil
 }
 

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -70,10 +70,11 @@ const (
 
 // Router endpoint constants
 const (
-	defaultIstioGateway   = "istio-ingressgateway.istio-system.svc.cluster.local"
-	defaultGateway        = "knative-ingress-gateway.knative-serving"
-	defaultMatchURIPrefix = "/v1/predict,/v1/batch_predict"
+	defaultIstioGateway = "istio-ingressgateway.istio-system.svc.cluster.local"
+	defaultGateway      = "knative-ingress-gateway.knative-serving"
 )
+
+var defaultMatchURIPrefixes = []string{"/v1/predict", "/v1/batch_predict"}
 
 // NewRouterService creates a new cluster Service object with the required config
 // for the Turing router to be deployed.
@@ -151,14 +152,14 @@ func (sb *clusterSvcBuilder) NewRouterEndpoint(
 	host := strings.Replace(veURL.Hostname(), routerName, routerEndpointName, 1)
 
 	return &cluster.VirtualService{
-		Name:            routerEndpointName,
-		Namespace:       project.Name,
-		Labels:          labels,
-		Gateway:         defaultGateway,
-		Endpoint:        host,
-		DestinationHost: defaultIstioGateway,
-		HostRewrite:     veURL.Hostname(),
-		MatchURIPrefix:  strings.Split(defaultMatchURIPrefix, ","),
+		Name:             routerEndpointName,
+		Namespace:        project.Name,
+		Labels:           labels,
+		Gateway:          defaultGateway,
+		Endpoint:         host,
+		DestinationHost:  defaultIstioGateway,
+		HostRewrite:      veURL.Hostname(),
+		MatchURIPrefixes: defaultMatchURIPrefixes,
 	}, nil
 }
 

--- a/api/turing/cluster/servicebuilder/router_test.go
+++ b/api/turing/cluster/servicebuilder/router_test.go
@@ -5,6 +5,7 @@ package servicebuilder
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -521,7 +522,7 @@ func TestNewRouterEndpoint(t *testing.T) {
 		HostRewrite:     "test-svc-turing-router-1.models.example.com",
 		Gateway:         defaultGateway,
 		DestinationHost: defaultIstioGateway,
-		MatchURIPrefix:  defaultMatchURIPrefix,
+		MatchURIPrefix:  strings.Split(defaultMatchURIPrefix, ","),
 	}
 
 	got, err := sb.NewRouterEndpoint(&routerVersion, project, "test-env", versionEndpoint)

--- a/api/turing/cluster/servicebuilder/router_test.go
+++ b/api/turing/cluster/servicebuilder/router_test.go
@@ -5,7 +5,6 @@ package servicebuilder
 import (
 	"encoding/json"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -518,11 +517,11 @@ func TestNewRouterEndpoint(t *testing.T) {
 			"stream":       "test-stream",
 			"team":         "test-team",
 		},
-		Endpoint:        "test-svc-turing-router.models.example.com",
-		HostRewrite:     "test-svc-turing-router-1.models.example.com",
-		Gateway:         defaultGateway,
-		DestinationHost: defaultIstioGateway,
-		MatchURIPrefix:  strings.Split(defaultMatchURIPrefix, ","),
+		Endpoint:         "test-svc-turing-router.models.example.com",
+		HostRewrite:      "test-svc-turing-router-1.models.example.com",
+		Gateway:          defaultGateway,
+		DestinationHost:  defaultIstioGateway,
+		MatchURIPrefixes: defaultMatchURIPrefixes,
 	}
 
 	got, err := sb.NewRouterEndpoint(&routerVersion, project, "test-env", versionEndpoint)

--- a/api/turing/cluster/virtual_service.go
+++ b/api/turing/cluster/virtual_service.go
@@ -7,14 +7,14 @@ import (
 )
 
 type VirtualService struct {
-	Name            string            `json:"name"`
-	Namespace       string            `json:"namespace"`
-	Labels          map[string]string `json:"labels"`
-	Gateway         string            `json:"gateway"`
-	Endpoint        string            `json:"endpoint"`
-	DestinationHost string            `json:"destination_host"`
-	HostRewrite     string            `json:"host_rewrite"`
-	MatchURIPrefix  []string          `json:"match_uri_prefix"`
+	Name             string            `json:"name"`
+	Namespace        string            `json:"namespace"`
+	Labels           map[string]string `json:"labels"`
+	Gateway          string            `json:"gateway"`
+	Endpoint         string            `json:"endpoint"`
+	DestinationHost  string            `json:"destination_host"`
+	HostRewrite      string            `json:"host_rewrite"`
+	MatchURIPrefixes []string          `json:"match_uri_prefix"`
 }
 
 func (cfg VirtualService) BuildVirtualService() *v1alpha3.VirtualService {
@@ -29,8 +29,8 @@ func (cfg VirtualService) BuildVirtualService() *v1alpha3.VirtualService {
 		},
 		Weight: 100,
 	}
-	httpMatches := make([]*networking.HTTPMatchRequest, len(cfg.MatchURIPrefix))
-	for index, prefix := range cfg.MatchURIPrefix {
+	httpMatches := make([]*networking.HTTPMatchRequest, len(cfg.MatchURIPrefixes))
+	for index, prefix := range cfg.MatchURIPrefixes {
 		uri := networking.HTTPMatchRequest{
 			Uri: &networking.StringMatch{
 				MatchType: &networking.StringMatch_Prefix{

--- a/api/turing/cluster/virtual_service.go
+++ b/api/turing/cluster/virtual_service.go
@@ -14,7 +14,7 @@ type VirtualService struct {
 	Endpoint        string            `json:"endpoint"`
 	DestinationHost string            `json:"destination_host"`
 	HostRewrite     string            `json:"host_rewrite"`
-	MatchURIPrefix  string            `json:"match_uri_prefix"`
+	MatchURIPrefix  []string          `json:"match_uri_prefix"`
 }
 
 func (cfg VirtualService) BuildVirtualService() *v1alpha3.VirtualService {
@@ -29,6 +29,17 @@ func (cfg VirtualService) BuildVirtualService() *v1alpha3.VirtualService {
 		},
 		Weight: 100,
 	}
+	httpMatches := make([]*networking.HTTPMatchRequest, len(cfg.MatchURIPrefix))
+	for index, prefix := range cfg.MatchURIPrefix {
+		uri := networking.HTTPMatchRequest{
+			Uri: &networking.StringMatch{
+				MatchType: &networking.StringMatch_Prefix{
+					Prefix: prefix,
+				},
+			},
+		}
+		httpMatches[index] = &uri
+	}
 
 	return &v1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -41,15 +52,7 @@ func (cfg VirtualService) BuildVirtualService() *v1alpha3.VirtualService {
 			Gateways: []string{cfg.Gateway},
 			Http: []*networking.HTTPRoute{
 				{
-					Match: []*networking.HTTPMatchRequest{
-						{
-							Uri: &networking.StringMatch{
-								MatchType: &networking.StringMatch_Prefix{
-									Prefix: cfg.MatchURIPrefix,
-								},
-							},
-						},
-					},
+					Match: httpMatches,
 					Route: []*networking.HTTPRouteDestination{
 						httpRouteDest,
 					},

--- a/api/turing/cluster/virtual_service_test.go
+++ b/api/turing/cluster/virtual_service_test.go
@@ -19,11 +19,11 @@ func TestBuildVirtualService(t *testing.T) {
 		Labels: map[string]string{
 			"key": "value",
 		},
-		Gateway:         "gateway",
-		Endpoint:        "test-svc-turing-router.models.example.com",
-		DestinationHost: "istio",
-		HostRewrite:     "test-svc-turing-router-1.models.example.com",
-		MatchURIPrefix:  []string{"/v1/prefix"},
+		Gateway:          "gateway",
+		Endpoint:         "test-svc-turing-router.models.example.com",
+		DestinationHost:  "istio",
+		HostRewrite:      "test-svc-turing-router-1.models.example.com",
+		MatchURIPrefixes: []string{"/v1/prefix"},
 	}
 	expected := v1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{

--- a/api/turing/cluster/virtual_service_test.go
+++ b/api/turing/cluster/virtual_service_test.go
@@ -23,7 +23,7 @@ func TestBuildVirtualService(t *testing.T) {
 		Endpoint:        "test-svc-turing-router.models.example.com",
 		DestinationHost: "istio",
 		HostRewrite:     "test-svc-turing-router-1.models.example.com",
-		MatchURIPrefix:  "/v1/prefix",
+		MatchURIPrefix:  []string{"/v1/prefix"},
 	}
 	expected := v1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{

--- a/engines/router/missionctl/cmd/main.go
+++ b/engines/router/missionctl/cmd/main.go
@@ -107,6 +107,7 @@ func main() {
 		}),
 	))
 	http.Handle("/v1/predict", sentry.Recoverer(handlers.NewHTTPHandler(missionCtl)))
+	http.Handle("/v1/batch_predict", sentry.Recoverer(handlers.NewBatchHTTPHandler(missionCtl)))
 	// Register metrics handler
 	if cfg.AppConfig.CustomMetrics {
 		http.Handle("/metrics", promhttp.Handler())

--- a/engines/router/missionctl/handlers/batch_http_handler.go
+++ b/engines/router/missionctl/handlers/batch_http_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"sync"
 
 	"github.com/gojek/turing/engines/router/missionctl"
@@ -76,8 +77,9 @@ func (h *batchHTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 
 		go func(index int, jsonRequestBody json.RawMessage) {
 			defer waitGroup.Done()
+			requestContext := turingctx.NewTuringContextWithSuffix(ctx, strconv.Itoa(index))
 			var batchResponse batchResponse
-			resp, httpErr := h.getPrediction(ctx, req, ctxLogger, jsonRequestBody)
+			resp, httpErr := h.getPrediction(requestContext, req, ctxLogger, jsonRequestBody)
 			if httpErr != nil {
 				batchResponse.StatusCode = httpErr.Code
 				batchResponse.ErrorMsg = httpErr.Message

--- a/engines/router/missionctl/handlers/batch_http_handler.go
+++ b/engines/router/missionctl/handlers/batch_http_handler.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"github.com/gojek/turing/engines/router/missionctl"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/gojek/turing/engines/router/missionctl/errors"
+	"github.com/gojek/turing/engines/router/missionctl/log"
+	"github.com/gojek/turing/engines/router/missionctl/turingctx"
+)
+
+type batchHttpHandler struct {
+	httpHandler
+}
+
+// NewBatchHTTPHandler creates an instance of the Mission Control's prediction request handler
+func NewBatchHTTPHandler(mc missionctl.MissionControl) http.Handler {
+	return &batchHttpHandler{ httpHandler{mc}}
+}
+
+func (h *batchHttpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+
+	var httpErr *errors.HTTPError
+	h.measureRequestDuration(httpErr)
+
+	// Create context from the request context
+	ctx := turingctx.NewTuringContext(req.Context())
+	// Create context logger
+	ctxLogger := log.WithContext(ctx)
+	defer func() {
+		_ = ctxLogger.Sync()
+	}()
+
+	// Get the unique turing request id from the context
+	turingReqID, err := turingctx.GetRequestID(ctx)
+	if err != nil {
+		ctxLogger.Errorf("Could not retrieve Turing Request ID from context: %v",
+			err.Error())
+	}
+	ctxLogger.Debugf("Received batch request for %v", turingReqID)
+
+	ctx = h.enableTracingSpan(ctx, req)
+
+	// Read the request body
+	requestBody, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		h.error(ctx, rw, errors.NewHTTPError(err))
+		return
+	}
+
+	resp, httpErr := h.getPrediction(ctx, req, ctxLogger, requestBody)
+	if httpErr != nil {
+		h.error(ctx, rw, httpErr)
+		return
+	}
+	payload := resp.Body()
+
+	// Write the json response to the writer
+	rw.Header().Set("Content-Type", resp.Header().Get("Content-Type"))
+	rw.Header().Set(turingReqIDHeaderKey, turingReqID)
+	rw.WriteHeader(http.StatusOK)
+	contentLength, err := rw.Write(payload)
+	if err != nil {
+		ctxLogger.Errorf("Error occurred when copying content: %v", err.Error())
+	}
+	ctxLogger.Debugf("Written %d bytes", contentLength)
+}
+

--- a/engines/router/missionctl/handlers/batch_http_handler.go
+++ b/engines/router/missionctl/handlers/batch_http_handler.go
@@ -2,13 +2,13 @@ package handlers
 
 import (
 	"encoding/json"
-	"github.com/gojek/turing/engines/router/missionctl/instrumentation/tracing"
 	"io/ioutil"
 	"net/http"
 	"sync"
 
 	"github.com/gojek/turing/engines/router/missionctl"
 	"github.com/gojek/turing/engines/router/missionctl/errors"
+	"github.com/gojek/turing/engines/router/missionctl/instrumentation/tracing"
 	"github.com/gojek/turing/engines/router/missionctl/log"
 	"github.com/gojek/turing/engines/router/missionctl/turingctx"
 )

--- a/engines/router/missionctl/handlers/batch_http_handler_test.go
+++ b/engines/router/missionctl/handlers/batch_http_handler_test.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/gojek/turing/engines/experiment/runner/nop"
+	"github.com/gojek/turing/engines/router/missionctl"
+	"github.com/gojek/turing/engines/router/missionctl/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBatchHTTPHandler(t *testing.T) {
+	//Create missionctl with route for testing
+	missionCtl, err := missionctl.NewMissionControl(
+		nil,
+		&config.EnrichmentConfig{
+			Endpoint: "",
+			Timeout:  time.Second,
+		},
+		&config.RouterConfig{
+			//ConfigFile: filepath.Join("../testdata", "nop_default_router.yaml"),
+			ConfigFile: filepath.Join("../testdata", "batch_router_test.yaml"),
+			Timeout:    3 * time.Second,
+		},
+		&config.EnsemblerConfig{
+			Endpoint: "",
+			Timeout:  time.Second,
+		},
+		&config.AppConfig{
+			FiberDebugLog: false,
+		},
+	)
+	assert.Nil(t, err)
+
+	//Create test routes endpoint. Route will write request body as response
+	batchHTTPHandler := NewBatchHTTPHandler(missionCtl)
+	assert.NotNil(t, batchHTTPHandler)
+	testRouterHandler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requestBody, err := ioutil.ReadAll(request.Body)
+		assert.NoError(t, err)
+		_, err = writer.Write(requestBody)
+		assert.NoError(t, err)
+	})
+	mux := http.NewServeMux()
+	mux.Handle("/route1", testRouterHandler)
+	server := httptest.NewUnstartedServer(mux)
+	listener, err := net.Listen("tcp", "127.0.0.1:8080")
+	if err != nil {
+		t.Fatal("Failed to start test http server: " + err.Error())
+	}
+	server.Listener = listener
+	server.Start()
+	defer server.Close()
+
+	tests := map[string]struct {
+		payload              string
+		expectedResponseBody string
+		expectedStatusCode   int
+		expectedErrorMessage string
+	}{
+		"batch request": {
+			payload: `{"batch_request": [
+							{ "request1": "value1" },
+							{ "request2": "value2" }
+						]}`,
+			expectedResponseBody: `{"batch_result": [
+										{ "code": 200, 
+										  "data": {"request1": "value1"}
+										},
+										{ "code": 200, 
+										  "data": {"request2": "value2"}
+										}
+									]}`,
+			expectedStatusCode: 200,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/batch_predict", bytes.NewBuffer([]byte(test.payload)))
+			w := httptest.NewRecorder()
+			batchHTTPHandler.ServeHTTP(w, req)
+			res := w.Result()
+			defer res.Body.Close()
+			result, _ := ioutil.ReadAll(res.Body)
+
+			assert.JSONEq(t, test.expectedResponseBody, string(result))
+			assert.Equal(t, test.expectedStatusCode, res.StatusCode)
+			assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+		})
+	}
+}

--- a/engines/router/missionctl/handlers/batch_http_handler_test.go
+++ b/engines/router/missionctl/handlers/batch_http_handler_test.go
@@ -105,7 +105,7 @@ func TestNewBatchHTTPHandlerBadRoute(t *testing.T) {
 		expectedStatusCode   int
 		expectedContentType  string
 	}{
-		"ok request": {
+		"bad route request": {
 			payload: `{"batch_request": [
 							{ "request1": "value1" },
 							{ "request2": "value2" }

--- a/engines/router/missionctl/handlers/batch_http_handler_test.go
+++ b/engines/router/missionctl/handlers/batch_http_handler_test.go
@@ -39,36 +39,30 @@ func TestNewBatchHTTPHandler(t *testing.T) {
 		expectedContentType  string
 	}{
 		"ok request": {
-			payload: `{"batch_request": [
+			payload: `[
 							{ "request1": "value1" },
 							{ "request2": "value2" }
-						]}`,
-			expectedResponseBody: `{"batch_result": [
+					  ]`,
+			expectedResponseBody: `[
 										{ "code": 200, 
 										  "data": {"request1": "value1"}
 										},
 										{ "code": 200, 
 										  "data": {"request2": "value2"}
 										}
-									]}`,
+								  ]`,
 			expectedStatusCode:  200,
 			expectedContentType: "application/json",
 		},
 		"invalid json": {
-			payload:              `{"batch_request": [{ : }]}`,
-			expectedResponseBody: "Invalid json request format\n",
+			payload:              `[{ : }]`,
+			expectedResponseBody: "Invalid json request\n",
 			expectedStatusCode:   400,
 			expectedContentType:  "text/plain; charset=utf-8",
 		},
 		"invalid json request": {
 			payload:              `{"key": "value1"}`,
 			expectedResponseBody: "Invalid json request\n",
-			expectedStatusCode:   400,
-			expectedContentType:  "text/plain; charset=utf-8",
-		},
-		"invalid json request, no batch_request key": {
-			payload:              `{"key": [{"key1":"value1"}]}`,
-			expectedResponseBody: "batch_request\" not found in request\n",
 			expectedStatusCode:   400,
 			expectedContentType:  "text/plain; charset=utf-8",
 		},
@@ -106,18 +100,18 @@ func TestNewBatchHTTPHandlerBadRoute(t *testing.T) {
 		expectedContentType  string
 	}{
 		"bad route request": {
-			payload: `{"batch_request": [
+			payload: `[
 							{ "request1": "value1" },
 							{ "request2": "value2" }
-						]}`,
-			expectedResponseBody: `{"batch_result": [
+					  ]`,
+			expectedResponseBody: `[
 										{ "code": 500, 
 										  "error": "Bad Route Called"
 										},
 										{ "code": 500, 
 										  "error": "Bad Route Called"
 										}
-									]}`,
+								   ]`,
 			expectedStatusCode:  200,
 			expectedContentType: "application/json",
 		},

--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -65,13 +65,11 @@ func (h *httpHandler) measureRequestDuration(httpErr *errors.HTTPError) {
 
 // enableTracingSpan associates span to context, if applicable
 func (h *httpHandler) enableTracingSpan(ctx context.Context, req *http.Request) context.Context {
-	if tracing.Glob().IsEnabled() {
 		var sp opentracing.Span
 		sp, ctx = tracing.Glob().StartSpanFromRequestHeader(ctx, httpHandlerID, req.Header)
 		if sp != nil {
 			defer sp.Finish()
 		}
-	}
 	return ctx
 }
 
@@ -156,7 +154,9 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 	ctxLogger.Debugf("Received request for %v", turingReqID)
 
-	ctx = h.enableTracingSpan(ctx, req)
+	if tracing.Glob().IsEnabled() {
+		ctx = h.enableTracingSpan(ctx, req)
+	}
 
 	// Read the request body
 	requestBody, err := ioutil.ReadAll(req.Body)

--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -146,6 +146,13 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		_ = ctxLogger.Sync()
 	}()
 
+	// Get the unique turing request id from the context
+	turingReqID, err := turingctx.GetRequestID(ctx)
+	if err != nil {
+		ctxLogger.Errorf("Could not retrieve Turing Request ID from context: %v",
+			err.Error())
+	}
+
 	ctx = h.enableTracingSpan(ctx, req)
 
 	// Read the request body
@@ -161,13 +168,6 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	payload := resp.Body()
-
-	// Get the unique turing request id from the context
-	turingReqID, err := turingctx.GetRequestID(ctx)
-	if err != nil {
-		ctxLogger.Errorf("Could not retrieve Turing Request ID from context: %v",
-			err.Error())
-	}
 
 	// Write the json response to the writer
 	rw.Header().Set("Content-Type", resp.Header().Get("Content-Type"))

--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -65,11 +65,11 @@ func (h *httpHandler) measureRequestDuration(httpErr *errors.HTTPError) {
 
 // enableTracingSpan associates span to context, if applicable
 func (h *httpHandler) enableTracingSpan(ctx context.Context, req *http.Request) context.Context {
-		var sp opentracing.Span
-		sp, ctx = tracing.Glob().StartSpanFromRequestHeader(ctx, httpHandlerID, req.Header)
-		if sp != nil {
-			defer sp.Finish()
-		}
+	var sp opentracing.Span
+	sp, ctx = tracing.Glob().StartSpanFromRequestHeader(ctx, httpHandlerID, req.Header)
+	if sp != nil {
+		defer sp.Finish()
+	}
 	return ctx
 }
 

--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -152,6 +152,7 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		ctxLogger.Errorf("Could not retrieve Turing Request ID from context: %v",
 			err.Error())
 	}
+	ctxLogger.Debugf("Received request for %v", turingReqID)
 
 	ctx = h.enableTracingSpan(ctx, req)
 

--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -47,6 +47,7 @@ func (h *httpHandler) error(
 	logTuringRouterRequestError(ctx, err)
 }
 
+// measureRequestDuration measure the duration of the request
 func (h *httpHandler) measureRequestDuration(httpErr *errors.HTTPError) {
 	// Measure the duration of handler function
 	defer metrics.Glob().MeasureDurationMs(
@@ -62,8 +63,8 @@ func (h *httpHandler) measureRequestDuration(httpErr *errors.HTTPError) {
 	)()
 }
 
+// enableTracingSpan associates span to context, if applicable
 func (h *httpHandler) enableTracingSpan(ctx context.Context, req *http.Request) context.Context {
-	// Associate span to context, if applicable
 	if tracing.Glob().IsEnabled() {
 		var sp opentracing.Span
 		sp, ctx = tracing.Glob().StartSpanFromRequestHeader(ctx, httpHandlerID, req.Header)
@@ -74,6 +75,7 @@ func (h *httpHandler) enableTracingSpan(ctx context.Context, req *http.Request) 
 	return ctx
 }
 
+// getPrediction takes in a request and owns the flow of the request - enrich, route, ensemble
 func (h *httpHandler) getPrediction(
 	ctx context.Context,
 	req *http.Request,

--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -156,11 +156,11 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	resp, httpErr := h.getPrediction(ctx, req, ctxLogger, requestBody)
-	payload := resp.Body()
 	if httpErr != nil {
 		h.error(ctx, rw, httpErr)
 		return
 	}
+	payload := resp.Body()
 
 	// Get the unique turing request id from the context
 	turingReqID, err := turingctx.GetRequestID(ctx)

--- a/engines/router/missionctl/testdata/batch_router_test.yaml
+++ b/engines/router/missionctl/testdata/batch_router_test.yaml
@@ -1,0 +1,11 @@
+type: EAGER_ROUTER
+id: eager-router
+routes:
+  - id: route_id_1
+    type: PROXY
+    endpoint: "http://localhost:8080/route1"
+strategy:
+  type: fiber.DefaultTuringRoutingStrategy
+  properties:
+    default_route_id: route_id_1
+    experiment_engine: Nop

--- a/engines/router/missionctl/turingctx/context.go
+++ b/engines/router/missionctl/turingctx/context.go
@@ -30,8 +30,8 @@ func NewTestTuringContext(parent context.Context, turingReqID string) context.Co
 	return context.WithValue(parent, turingReqIDKey, turingReqID)
 }
 
-// NewTuringContextWithSuffix returns a context for testing, with the Turing Request ID set to
-// with the given suffix
+// NewTuringContextWithSuffix returns a context for batch request, with the Turing Request ID set to
+// with the given suffix and initial request context set as parent
 func NewTuringContextWithSuffix(parent context.Context, suffix string) context.Context {
 	turingReqIDKeyWithSuffix := fmt.Sprintf("%s_%s", parent.Value(turingReqIDKey), suffix)
 	return context.WithValue(parent, turingReqIDKey, turingReqIDKeyWithSuffix)

--- a/engines/router/missionctl/turingctx/context.go
+++ b/engines/router/missionctl/turingctx/context.go
@@ -2,6 +2,7 @@ package turingctx
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gojek/turing/engines/router/missionctl/errors"
 	"github.com/google/uuid"
@@ -27,6 +28,13 @@ func NewTuringContext(parent context.Context) context.Context {
 // the given value
 func NewTestTuringContext(parent context.Context, turingReqID string) context.Context {
 	return context.WithValue(parent, turingReqIDKey, turingReqID)
+}
+
+// NewTuringContextWithSuffix returns a context for testing, with the Turing Request ID set to
+// with the given suffix
+func NewTuringContextWithSuffix(parent context.Context, suffix string) context.Context {
+	turingReqIDKeyWithSuffix := fmt.Sprintf("%s_%s", parent.Value(turingReqIDKey), suffix)
+	return context.WithValue(parent, turingReqIDKey, turingReqIDKeyWithSuffix)
 }
 
 // GetRequestID returns the request id from the input context

--- a/engines/router/missionctl/turingctx/context_test.go
+++ b/engines/router/missionctl/turingctx/context_test.go
@@ -2,6 +2,7 @@ package turingctx
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,20 @@ func TestNewTuringContext(t *testing.T) {
 	// Check that a turing request id is present
 	reqID := turCtx.Value(turingReqIDKey)
 	assert.NotEmpty(t, reqID)
+}
+
+func TestNewTuringContextWithSuffix(t *testing.T) {
+	testReqID := "test-uuid"
+	turCtx := context.WithValue(context.Background(), turingReqIDKey, testReqID)
+	reqID, err := GetRequestID(turCtx)
+	assert.NoError(t, err)
+
+	turCtxWithSuffix := NewTuringContextWithSuffix(turCtx, "1")
+	reqIDWithSuffix, err := GetRequestID(turCtxWithSuffix)
+	assert.NoError(t, err)
+
+	expectedRedID := fmt.Sprintf("%s_%s", reqID, "1")
+	assert.Equal(t, expectedRedID, reqIDWithSuffix)
 }
 
 func TestGetRequestID(t *testing.T) {


### PR DESCRIPTION
### Overview
This PR will add a new endpoint, `batch_predict` to Turing router. 
Currently the individual request are handled async. Individual request will behave the same as current state (no retries). 
Individual request failures will not fail the entire request and be lodged as part of the response.

Current batch endpoint expects "batch_request" with an array of requests and will return a response with "batch_result" with the array of response with fields `code`, `error`, `data`. 

Sample request
![image](https://user-images.githubusercontent.com/30390872/143161732-49499ae9-4b26-4f96-9346-f69b69eac324.png)

Sample response
![image](https://user-images.githubusercontent.com/30390872/143161852-9d9b772e-02f0-4d74-8b89-0764abf9333a.png)
![image](https://user-images.githubusercontent.com/30390872/143161915-39813f7b-20f3-44ee-8a61-c2fd59ec47ea.png)


### Modification
`api/e2e/test/01_create_router_test.go` - Add batch_endpoint testing to e2e test
`api/turing/cluster/servicebuilder/router.go` - Change string to []string, to add batch_endpoint prefix to default
`api/turing/cluster/virtual_service.go` - Loop through prefixes to add multiple matches if provided

`engines/router/missionctl/handlers/http_handler.go` - Refactored `ServeHTTP` to extract common method for batch_predict. Primarily `getPrediction()`, `enableTracingSpan()`, `measureRequestDuration()`.

`engines/router/missionctl/handlers/batch_http_handler.go` - New handler for the batch endpoint. Embedding `httpHandler`   and providing implementation for `ServeHTTP` using common method refactored in `http_handler.go`. 

`engines/router/missionctl/turingctx/context.go` - Added new method to return original context as parent and create a new turingreqid with input suffix



