### PR TITLE
Add instructions on ports that needs to be reachable from master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ This is the recommended way to install the prerequisites on a production Kuberne
 3. [Spark on K8s Operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator)
 
 Note that if you are using a cloud provider based Kubernetes, by default for Google Kubernetes Engine, most ports are closed from master to nodes except TCP/443 and TCP/10250.
-You must allow TCP/8080 for spark operator and TCP/8443 for Knative Serving mutating webhooks to be reached from the master node or the installion will fail.
+You must allow TCP/8080 for spark operator mutating webhooks and TCP/8443 for Knative Serving mutating webhooks to be reached from the master node or the installion will fail.
 
 To install the required components on your Kubernetes cluster, issue the following command:
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ This is the recommended way to install the prerequisites on a production Kuberne
 2. [Istio](https://istio.io/)
 3. [Spark on K8s Operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator)
 
+Note that if you are using a cloud provider based Kubernetes, by default for Google Kubernetes Engine, most ports are closed from master to nodes except TCP/443 and TCP/10250.
+You must allow TCP/8080 for spark operator and TCP/8443 for Knative Serving mutating webhooks to be reached from the master node or the installion will fail.
+
 To install the required components on your Kubernetes cluster, issue the following command:
 
 ```bash

--- a/infra/charts/turing-init/README.md
+++ b/infra/charts/turing-init/README.md
@@ -20,7 +20,7 @@ $ helm repo add turing https://turing-ml.github.io/charts
 ### Installing the chart
 
 Note that if you are using a cloud provider based Kubernetes, by default for Google Kubernetes Engine, most ports are closed from master to nodes except TCP/443 and TCP/10250.
-You must allow TCP/8080 for spark operator and TCP/8443 for Knative Serving mutating webhooks to be reached from the master node or the installion will fail.
+You must allow TCP/8080 for spark operator mutating webhooks and TCP/8443 for Knative Serving mutating webhooks to be reached from the master node or the installion will fail.
 
 This command will install turing-init named `turing-init` in the `default` namespace.
 Default chart values will be used for the installation:

--- a/infra/charts/turing-init/README.md
+++ b/infra/charts/turing-init/README.md
@@ -19,6 +19,9 @@ $ helm repo add turing https://turing-ml.github.io/charts
 
 ### Installing the chart
 
+Note that if you are using a cloud provider based Kubernetes, by default for Google Kubernetes Engine, most ports are closed from master to nodes except TCP/443 and TCP/10250.
+You must allow TCP/8080 for spark operator and TCP/8443 for Knative Serving mutating webhooks to be reached from the master node or the installion will fail.
+
 This command will install turing-init named `turing-init` in the `default` namespace.
 Default chart values will be used for the installation:
 ```shell

--- a/infra/charts/turing-init/README.md.gotmpl
+++ b/infra/charts/turing-init/README.md.gotmpl
@@ -20,7 +20,7 @@ $ helm repo add turing https://turing-ml.github.io/charts
 ### Installing the chart
 
 Note that if you are using a cloud provider based Kubernetes, by default for Google Kubernetes Engine, most ports are closed from master to nodes except TCP/443 and TCP/10250.
-You must allow TCP/8080 for spark operator and TCP/8443 for Knative Serving mutating webhooks to be reached from the master node or the installion will fail.
+You must allow TCP/8080 for spark operator mutating webhooks and TCP/8443 for Knative Serving mutating webhooks to be reached from the master node or the installion will fail.
 
 This command will install turing-init named `turing-init` in the `default` namespace.
 Default chart values will be used for the installation:

--- a/infra/charts/turing-init/README.md.gotmpl
+++ b/infra/charts/turing-init/README.md.gotmpl
@@ -19,6 +19,9 @@ $ helm repo add turing https://turing-ml.github.io/charts
 
 ### Installing the chart
 
+Note that if you are using a cloud provider based Kubernetes, by default for Google Kubernetes Engine, most ports are closed from master to nodes except TCP/443 and TCP/10250.
+You must allow TCP/8080 for spark operator and TCP/8443 for Knative Serving mutating webhooks to be reached from the master node or the installion will fail.
+
 This command will install turing-init named `turing-init` in the `default` namespace.
 Default chart values will be used for the installation:
 ```shell


### PR DESCRIPTION
Added some port requirements that needs to be allowed to the nodes from the master so that knative serving and spark operator mutating webhooks in the readme.