### PR TITLE
Removing experiment and treamtent labels from experiment engine metrics

### DIFF
--- a/engines/router/missionctl/experiment/interceptors.go
+++ b/engines/router/missionctl/experiment/interceptors.go
@@ -37,8 +37,8 @@ func (i *MetricsInterceptor) AfterCompletion(
 	err error,
 ) {
 	labels := map[string]string{
-		"status":     metrics.GetStatusString(err == nil),
-		"engine":     "",
+		"status": metrics.GetStatusString(err == nil),
+		"engine": "",
 	}
 
 	if engine, ok := ctx.Value(runner.ExperimentEngineKey).(string); ok {

--- a/engines/router/missionctl/experiment/interceptors.go
+++ b/engines/router/missionctl/experiment/interceptors.go
@@ -46,12 +46,6 @@ func (i *MetricsInterceptor) AfterCompletion(
 	if engine, ok := ctx.Value(runner.ExperimentEngineKey).(string); ok {
 		labels["engine"] = engine
 	}
-	if experiment, ok := ctx.Value(runner.ExperimentNameKey).(string); ok {
-		labels["experiment"] = experiment
-	}
-	if treatment, ok := ctx.Value(runner.TreatmentNameKey).(string); ok {
-		labels["treatment"] = treatment
-	}
 
 	// Get start time
 	if startTime, ok := ctx.Value(startTimeKey).(time.Time); ok {

--- a/engines/router/missionctl/experiment/interceptors.go
+++ b/engines/router/missionctl/experiment/interceptors.go
@@ -39,8 +39,6 @@ func (i *MetricsInterceptor) AfterCompletion(
 	labels := map[string]string{
 		"status":     metrics.GetStatusString(err == nil),
 		"engine":     "",
-		"experiment": "",
-		"treatment":  "",
 	}
 
 	if engine, ok := ctx.Value(runner.ExperimentEngineKey).(string); ok {

--- a/engines/router/missionctl/instrumentation/metrics/prometheus.go
+++ b/engines/router/missionctl/instrumentation/metrics/prometheus.go
@@ -37,10 +37,10 @@ var histogramMap map[MetricName]*prometheus.HistogramVec = map[MetricName]*prome
 		Namespace: Namespace,
 		Subsystem: Subsystem,
 		Name:      string(ExperimentEngineRequestMs),
-		Help:      "Histogram for the runtime (in milliseconds) of Litmus requests.",
+		Help:      "Histogram for the runtime (in milliseconds) of Experiment Engine requests.",
 		Buckets:   requestLatencyBuckets,
 	},
-		[]string{"status", "engine", "experiment", "treatment"},
+		[]string{"status", "engine"},
 	),
 	RouteRequestDurationMs: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,


### PR DESCRIPTION
This PR removes the experiment and treatments for experiment engine metrics.

The flexibility to allow experiment engine to log additional labels which might cause a huge cardinality. 

Also, it is recommended not use dimensions with high cardinality - 
https://prometheus.io/docs/practices/naming/
https://www.robustperception.io/cardinality-is-key
```
CAUTION: Remember that every unique combination of key-value label pairs represents a new time series, 
which can dramatically increase the amount of data stored.
Do not use labels to store dimensions with high cardinality (many different label values), 
such as user IDs, email addresses, or other unbounded sets of values.
```