### PR TITLE
Update ci teardown to cluster init

### DIFF
--- a/.github/actions/build-cluster-init/action.yaml
+++ b/.github/actions/build-cluster-init/action.yaml
@@ -1,0 +1,43 @@
+name: Build Cluster Init
+description: Set up Turing Cluster Init
+
+inputs:
+  artifact_retention_days: 
+    required: false
+    description: 'Artifact retention days'
+    default: 7
+outputs:
+  cluster-init-version:
+    description: 'Cluster Init Version built'
+    value: ${{ steps.build-image.outputs.cluster-init-version }}
+
+runs:
+  using: composite
+  env:
+    ARTIFACT_RETENTION_DAYS: 7
+  steps:
+    - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Build Docker image
+        id: build-image
+        working-directory: infra/cluster-init
+        run: |
+          set -o pipefail
+          make build-image | tee output.log
+          echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
+
+      - name: Save Docker image
+        run: |
+          docker image save \
+            --output cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar \
+            cluster-init:${{ steps.build-image.outputs.cluster-init-version }}
+
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar
+          path: cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}

--- a/.github/actions/build-cluster-init/action.yaml
+++ b/.github/actions/build-cluster-init/action.yaml
@@ -13,14 +13,7 @@ outputs:
 
 runs:
   using: composite
-  env:
-    ARTIFACT_RETENTION_DAYS: 7
   steps:
-    - name: Check out code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
       - name: Build Docker image
         id: build-image
         working-directory: infra/cluster-init
@@ -40,4 +33,4 @@ runs:
         with:
           name: cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar
           path: cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar
-          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          retention-days: ${{ inputs.artifact_retention_days }}

--- a/.github/actions/build-cluster-init/action.yaml
+++ b/.github/actions/build-cluster-init/action.yaml
@@ -17,12 +17,14 @@ runs:
       - name: Build Docker image
         id: build-image
         working-directory: infra/cluster-init
+        shell: bash
         run: |
           set -o pipefail
           make build-image | tee output.log
           echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
 
       - name: Save Docker image
+        shell: bash
         run: |
           docker image save \
             --output cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar \

--- a/.github/actions/cluster-init/action.yaml
+++ b/.github/actions/cluster-init/action.yaml
@@ -34,7 +34,7 @@ runs:
     - name: "Setup local k8s cluster"
       uses: AbsaOSS/k3d-action@v1.5.0
       with:
-        cluster-name: ${{ input.cluster_name }}
+        cluster-name: ${{ inputs.cluster_name }}
         use-default-registry: true
         args: >-
           --servers 1
@@ -60,7 +60,7 @@ runs:
 
     - name: Publish images to local registry
       env:
-        DOCKER_REPOSITORY: ${{ input.local_registry }}/${{ github.repository }}
+        DOCKER_REPOSITORY: ${{ inputs.local_registry }}/${{ github.repository }}
         CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
       shell: bash
       run: |
@@ -79,11 +79,11 @@ runs:
         kubectl create ns infrastructure
         helm upgrade turing-init infra/charts/turing-init \
           --namespace infrastructure \
-          --set image.registry=${{ input.local_registry }}/ \
+          --set image.registry=${{ inputs.local_registry }}/ \
           --set image.repository=${{ github.repository }}/cluster-init \
           --set image.tag=${{ env.CLUSTER_INIT_VERSION }} \
           --set knative.domains="127.0.0.1.nip.io" \
-          --set knative.registriesSkippingTagResolving=${{ input.local_registry }} \
+          --set knative.registriesSkippingTagResolving=${{ inputs.local_registry }} \
           --install \
           --wait
 

--- a/.github/actions/cluster-init/action.yaml
+++ b/.github/actions/cluster-init/action.yaml
@@ -24,11 +24,11 @@ inputs:
     default: ''
   build_image:
     required: false
-    description: 'Flag to build image from code'
+    description: '(Optional) Flag to build image from code'
     default: false
   cluster_init_version:
     required: false
-    description: 'Version of cluster to build'
+    description: '(Optional) Required if build_image is false, Version of cluster to install'
     default: ''
 
   

--- a/.github/actions/cluster-init/action.yaml
+++ b/.github/actions/cluster-init/action.yaml
@@ -84,7 +84,7 @@ runs:
 
     - name: Install Infrastructure
       env:
-        CLUSTER_INIT_VERSION: ${{ cluster_init_version || steps.build-image.outputs.cluster-init-version }}
+        CLUSTER_INIT_VERSION: ${{ inputs.cluster_init_version || steps.build-image.outputs.cluster-init-version }}
       shell: bash
       run: |
         kubectl create ns infrastructure

--- a/.github/actions/cluster-init/action.yaml
+++ b/.github/actions/cluster-init/action.yaml
@@ -4,24 +4,33 @@ description: Set up Turing Cluster Init
 inputs:
   cluster_name: 
     required: true
-    description: ''
+    description: 'Name of Cluster'
     default: ''
   istio_version:
     required: true
-    description: ''
+    description: 'Istio Version'
     default: ''
   knative_version:
     required: true
-    description: ''
+    description: 'Knative Version'
     default: ''
   knative_istio_version:
     required: true
-    description: ''
+    description: 'Knative Istio Version'
     default: ''
   local_registry:
     required: true
-    description: ''
+    description: 'Endpoint of local registry'
     default: ''
+  build_image:
+    required: false
+    description: 'Flag to build image from code'
+    default: false
+  cluster_init_version:
+    required: false
+    description: 'Version of cluster to build'
+    default: ''
+
   
 runs:
   using: composite
@@ -43,6 +52,7 @@ runs:
           --k3s-server-arg "--no-deploy=traefik,metrics-server"
 
     - name: Build Docker image
+      if: ${{ inputs.build_image }}
       id: build-image
       working-directory: infra/cluster-init
       shell: bash
@@ -52,6 +62,7 @@ runs:
         echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
 
     - name: Save Docker image
+      if: ${{ inputs.build_image }}
       shell: bash
       run: |
         docker image save \
@@ -61,7 +72,7 @@ runs:
     - name: Publish images to local registry
       env:
         DOCKER_REPOSITORY: ${{ inputs.local_registry }}/${{ github.repository }}
-        CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
+        CLUSTER_INIT_VERSION: ${{ inputs.cluster_init_version || steps.build-image.outputs.cluster-init-version }}
       shell: bash
       run: |
         # Cluster init
@@ -73,7 +84,7 @@ runs:
 
     - name: Install Infrastructure
       env:
-        CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
+        CLUSTER_INIT_VERSION: ${{ cluster_init_version || steps.build-image.outputs.cluster-init-version }}
       shell: bash
       run: |
         kubectl create ns infrastructure

--- a/.github/actions/cluster-init/action.yaml
+++ b/.github/actions/cluster-init/action.yaml
@@ -45,12 +45,14 @@ runs:
     - name: Build Docker image
       id: build-image
       working-directory: infra/cluster-init
+      shell: bash
       run: |
         set -o pipefail
         make build-image | tee output.log
         echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
 
     - name: Save Docker image
+      shell: bash
       run: |
         docker image save \
           --output cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar \
@@ -60,6 +62,7 @@ runs:
       env:
         DOCKER_REPOSITORY: ${{ local.local_registry }}/${{ github.repository }}
         CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
+      shell: bash
       run: |
         # Cluster init
         docker image load --input cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
@@ -71,6 +74,7 @@ runs:
     - name: Install Infrastructure
       env:
         CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
+      shell: bash
       run: |
         kubectl create ns infrastructure
         helm upgrade turing-init infra/charts/turing-init \

--- a/.github/actions/cluster-init/action.yaml
+++ b/.github/actions/cluster-init/action.yaml
@@ -47,7 +47,7 @@ runs:
           --k3s-server-arg "--no-deploy=traefik,metrics-server"
 
     - name: Build Docker image
-      if: ${{ inputs.build_image }}
+      if: ${{ inputs.build_image == 'true' }}
       id: build-image
       working-directory: infra/cluster-init
       shell: bash

--- a/.github/actions/cluster-init/action.yaml
+++ b/.github/actions/cluster-init/action.yaml
@@ -34,7 +34,7 @@ runs:
     - name: "Setup local k8s cluster"
       uses: AbsaOSS/k3d-action@v1.5.0
       with:
-        cluster-name: ${{ local.cluster_name }}
+        cluster-name: ${{ input.cluster_name }}
         use-default-registry: true
         args: >-
           --servers 1
@@ -60,7 +60,7 @@ runs:
 
     - name: Publish images to local registry
       env:
-        DOCKER_REPOSITORY: ${{ local.local_registry }}/${{ github.repository }}
+        DOCKER_REPOSITORY: ${{ input.local_registry }}/${{ github.repository }}
         CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
       shell: bash
       run: |
@@ -79,11 +79,11 @@ runs:
         kubectl create ns infrastructure
         helm upgrade turing-init infra/charts/turing-init \
           --namespace infrastructure \
-          --set image.registry=${{ local.local_registry }}/ \
+          --set image.registry=${{ input.local_registry }}/ \
           --set image.repository=${{ github.repository }}/cluster-init \
           --set image.tag=${{ env.CLUSTER_INIT_VERSION }} \
           --set knative.domains="127.0.0.1.nip.io" \
-          --set knative.registriesSkippingTagResolving=${{ local.local_registry }} \
+          --set knative.registriesSkippingTagResolving=${{ input.local_registry }} \
           --install \
           --wait
 

--- a/.github/actions/cluster-init/action.yaml
+++ b/.github/actions/cluster-init/action.yaml
@@ -57,7 +57,7 @@ runs:
         echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
 
     - name: Save Docker image
-      if: ${{ inputs.build_image }}
+      if: ${{ inputs.build_image == 'true' }}
       shell: bash
       run: |
         docker image save \

--- a/.github/actions/cluster-init/action.yaml
+++ b/.github/actions/cluster-init/action.yaml
@@ -1,0 +1,92 @@
+name: Cluster Init
+description: Set up Turing Cluster Init
+
+inputs:
+  cluster_name: 
+    required: true
+    description: ''
+    default: ''
+  istio_version:
+    required: true
+    description: ''
+    default: ''
+  knative_version:
+    required: true
+    description: ''
+    default: ''
+  knative_istio_version:
+    required: true
+    description: ''
+    default: ''
+  local_registry:
+    required: true
+    description: ''
+    default: ''
+  
+runs:
+  using: composite
+  steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    
+    - name: "Setup local k8s cluster"
+      uses: AbsaOSS/k3d-action@v1.5.0
+      with:
+        cluster-name: ${{ local.cluster_name }}
+        use-default-registry: true
+        args: >-
+          --servers 1
+          --agents 3
+          --port 80:80@loadbalancer
+          --k3s-server-arg "--no-deploy=traefik,metrics-server"
+
+    - name: Build Docker image
+      id: build-image
+      working-directory: infra/cluster-init
+      run: |
+        set -o pipefail
+        make build-image | tee output.log
+        echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
+
+    - name: Save Docker image
+      run: |
+        docker image save \
+          --output cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar \
+          cluster-init:${{ steps.build-image.outputs.cluster-init-version }}
+
+    - name: Publish images to local registry
+      env:
+        DOCKER_REPOSITORY: ${{ local.local_registry }}/${{ github.repository }}
+        CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
+      run: |
+        # Cluster init
+        docker image load --input cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
+        docker tag \
+          cluster-init:${{ env.CLUSTER_INIT_VERSION }} \
+          ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
+        docker push ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
+
+    - name: Install Infrastructure
+      env:
+        CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
+      run: |
+        kubectl create ns infrastructure
+        helm upgrade turing-init infra/charts/turing-init \
+          --namespace infrastructure \
+          --set image.registry=${{ local.local_registry }}/ \
+          --set image.repository=${{ github.repository }}/cluster-init \
+          --set image.tag=${{ env.CLUSTER_INIT_VERSION }} \
+          --set knative.domains="127.0.0.1.nip.io" \
+          --set knative.registriesSkippingTagResolving=${{ local.local_registry }} \
+          --install \
+          --wait
+
+        # wait for install infra job to finish
+        kubectl logs -n infrastructure -f $(kubectl get pod --namespace infrastructure | grep -v 'NAME' | grep -v 'spark' | head -n 1 | awk '{print $1}')
+        kubectl get pod --all-namespaces
+        kubectl get svc --all-namespaces
+        kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-spark-operator-webhook-init
+        # Might fail the first time but the 2nd run should work, rarely fails on the first try though.
+        kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-init

--- a/.github/actions/cluster-init/action.yaml
+++ b/.github/actions/cluster-init/action.yaml
@@ -28,18 +28,13 @@ inputs:
     default: false
   cluster_init_version:
     required: false
-    description: '(Optional) Required if build_image is false, Version of cluster to install'
+    description: '(Optional) Required if build_image is false, Version of cluster to install  '
     default: ''
 
   
 runs:
   using: composite
   steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    
     - name: "Setup local k8s cluster"
       uses: AbsaOSS/k3d-action@v1.5.0
       with:

--- a/.github/actions/run-cluster-init/action.yaml
+++ b/.github/actions/run-cluster-init/action.yaml
@@ -24,7 +24,7 @@ inputs:
     default: ''
   cluster_init_version:
     required: true
-    description: 'Version of cluster to install, tar file has to follow naming - cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar '
+    description: 'Version of cluster to install, tar file has to follow naming - cluster-init.(CLUSTER_INIT_VERSION).tar '
     default: ''
 
 runs:
@@ -44,7 +44,7 @@ runs:
     - name: Publish images to local registry
       env:
         DOCKER_REPOSITORY: ${{ inputs.local_registry }}/${{ github.repository }}
-        CLUSTER_INIT_VERSION: ${{ inputs.cluster_init_version || steps.build-image.outputs.cluster-init-version }}
+        CLUSTER_INIT_VERSION: ${{ inputs.cluster_init_version }}
       shell: bash
       run: |
         # Cluster init
@@ -56,7 +56,7 @@ runs:
 
     - name: Install Infrastructure
       env:
-        CLUSTER_INIT_VERSION: ${{ inputs.cluster_init_version || steps.build-image.outputs.cluster-init-version }}
+        CLUSTER_INIT_VERSION: ${{ inputs.cluster_init_version }}
       shell: bash
       run: |
         kubectl create ns infrastructure

--- a/.github/actions/run-cluster-init/action.yaml
+++ b/.github/actions/run-cluster-init/action.yaml
@@ -1,4 +1,4 @@
-name: Cluster Init
+name: Run Cluster Init
 description: Set up Turing Cluster Init
 
 inputs:
@@ -22,16 +22,11 @@ inputs:
     required: true
     description: 'Endpoint of local registry'
     default: ''
-  build_image:
-    required: false
-    description: '(Optional) Flag to build image from code'
-    default: false
   cluster_init_version:
-    required: false
-    description: '(Optional) Required if build_image is false, Version of cluster to install  '
+    required: true
+    description: 'Version of cluster to install, tar file has to follow naming - cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar '
     default: ''
 
-  
 runs:
   using: composite
   steps:
@@ -45,24 +40,6 @@ runs:
           --agents 3
           --port 80:80@loadbalancer
           --k3s-server-arg "--no-deploy=traefik,metrics-server"
-
-    - name: Build Docker image
-      if: ${{ inputs.build_image == 'true' }}
-      id: build-image
-      working-directory: infra/cluster-init
-      shell: bash
-      run: |
-        set -o pipefail
-        make build-image | tee output.log
-        echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
-
-    - name: Save Docker image
-      if: ${{ inputs.build_image == 'true' }}
-      shell: bash
-      run: |
-        docker image save \
-          --output cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar \
-          cluster-init:${{ steps.build-image.outputs.cluster-init-version }}
 
     - name: Publish images to local registry
       env:

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -154,6 +154,7 @@ jobs:
 
       - name: Smoke Test
         run: |
+          # Create hello world knative service
           tee service.yaml <<EOF 
           apiVersion: serving.knative.dev/v1
           kind: Service
@@ -170,12 +171,15 @@ jobs:
                         value: "Hello Knative Serving is up and running!!"
           EOF
 
-
           kubectl apply -f service.yaml
+
+          # wait till service is up
           timeout --foreground 120 bash -c 'until kubectl get service.serving.knative.dev/helloworld-go --output=jsonpath='{.status.conditions[1]}'  | grep "True"; do : ; done'
           kubectl get ksvc
-          curl -v http://helloworld-go.default.127.0.0.1.nip.io/
+
+          curl --f http://helloworld-go.default.127.0.0.1.nip.io/
           kubectl delete service helloworld-go 
       
+      # Invoke helm hooks on delete
       - name: Tear down infrastructure job
         run: helm delete --namespace infrastructure turing-init --timeout 15m

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -177,7 +177,7 @@ jobs:
           timeout --foreground 120 bash -c 'until kubectl get service.serving.knative.dev/helloworld-go --output=jsonpath='{.status.conditions[1]}'  | grep "True"; do : ; done'
           kubectl get ksvc
 
-          curl --f http://helloworld-go.default.127.0.0.1.nip.io/
+          curl -f http://helloworld-go.default.127.0.0.1.nip.io/
           kubectl delete service helloworld-go 
       
       # Invoke helm hooks on delete

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -78,7 +78,7 @@ jobs:
         run: docker push ${{ steps.build.outputs.cluster-init-image }}
 
 
-  cluster-init:
+  test-e2e:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -90,12 +90,7 @@ jobs:
           knative_version: v0.18.3
           knative_istio_version: v0.18.1
           local_registry: registry.localhost:5000
-
-  test-e2e:
-    runs-on: ubuntu-latest
-    needs:
-      - cluster-init
-    steps:
+          
       - name: Smoke Test
         run: |
           # Create hello world knative service

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -40,6 +40,11 @@ jobs:
     outputs:
       cluster-init-version: ${{ steps.build-cluster-init.outputs.cluster-init-version }}
     steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          
       - name: Run action build-cluster-init
         id: build-cluster-init
         uses: ./.github/actions/build-cluster-init

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -172,7 +172,7 @@ jobs:
 
 
           kubectl apply -f service.yaml
-          timeout --foreground 10s bash -c 'until kubectl get service.serving.knative.dev/helloworld-go --output=jsonpath='{.status.conditions[1]}'  | grep "True"; do : ; done'
+          timeout --foreground 120 bash -c 'until kubectl get service.serving.knative.dev/helloworld-go --output=jsonpath='{.status.conditions[1]}'  | grep "True"; do : ; done'
           kubectl get ksvc
           curl -v http://helloworld-go.default.127.0.0.1.sslip.io
           kubectl delete service helloworld-go 

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -77,81 +77,23 @@ jobs:
       - name: Publish Cluster Init Docker Image
         run: docker push ${{ steps.build.outputs.cluster-init-image }}
 
+
+  cluster-init:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: release-rules
+        uses: ./.github/actions/cluster-init
+        with:
+          cluster_name: turing-e2e
+          istio_version: 1.9.9
+          knative_version: v0.18.3
+          knative_istio_version: v0.18.1
+          local_registry: registry.localhost:5000
+
   test-e2e:
     runs-on: ubuntu-latest
-    env:
-      CLUSTER_NAME: turing-e2e
-      ISTIO_VERSION: 1.9.9
-      KNATIVE_VERSION: v0.18.3
-      KNATIVE_ISTIO_VERSION: v0.18.1
-      LOCAL_REGISTRY: registry.localhost:5000
-
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      
-      - name: "Setup local k8s cluster"
-        uses: AbsaOSS/k3d-action@v1.5.0
-        with:
-          cluster-name: ${{ env.CLUSTER_NAME }}
-          use-default-registry: true
-          args: >-
-            --servers 1
-            --agents 3
-            --port 80:80@loadbalancer
-            --k3s-server-arg "--no-deploy=traefik,metrics-server"
-
-      - name: Build Docker image
-        id: build-image
-        working-directory: infra/cluster-init
-        run: |
-          set -o pipefail
-          make build-image | tee output.log
-          echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
-
-      - name: Save Docker image
-        run: |
-          docker image save \
-            --output cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar \
-            cluster-init:${{ steps.build-image.outputs.cluster-init-version }}
-
-      - name: Publish images to local registry
-        env:
-          DOCKER_REPOSITORY: ${{ env.LOCAL_REGISTRY }}/${{ github.repository }}
-          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
-        run: |
-          # Cluster init
-          docker image load --input cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
-          docker tag \
-            cluster-init:${{ env.CLUSTER_INIT_VERSION }} \
-            ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
-          docker push ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
-
-      - name: Install Infrastructure
-        env:
-          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
-        run: |
-          kubectl create ns infrastructure
-          helm upgrade turing-init infra/charts/turing-init \
-            --namespace infrastructure \
-            --set image.registry=${{ env.LOCAL_REGISTRY }}/ \
-            --set image.repository=${{ github.repository }}/cluster-init \
-            --set image.tag=${{ env.CLUSTER_INIT_VERSION }} \
-            --set knative.domains="127.0.0.1.nip.io" \
-            --set knative.registriesSkippingTagResolving=${{ env.LOCAL_REGISTRY }} \
-            --install \
-            --wait
-
-          # wait for install infra job to finish
-          kubectl logs -n infrastructure -f $(kubectl get pod --namespace infrastructure | grep -v 'NAME' | grep -v 'spark' | head -n 1 | awk '{print $1}')
-          kubectl get pod --all-namespaces
-          kubectl get svc --all-namespaces
-          kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-spark-operator-webhook-init
-          # Might fail the first time but the 2nd run should work, rarely fails on the first try though.
-          kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-init
-
       - name: Smoke Test
         run: |
           # Create hello world knative service

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - id: release-rules
+      - id: cluster-init
         uses: ./.github/actions/cluster-init
         with:
           cluster_name: turing-e2e
@@ -90,7 +90,8 @@ jobs:
           knative_version: v0.18.3
           knative_istio_version: v0.18.1
           local_registry: registry.localhost:5000
-          
+          build_image: true
+
       - name: Smoke Test
         run: |
           # Create hello world knative service

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -154,11 +154,25 @@ jobs:
 
       - name: Smoke Test
         run: |
-          kn service create hello \
-            --image gcr.io/knative-samples/helloworld-go \
-            --port 8080 
-          curl http://hello.default.127.0.0.1.sslip.io
-          kn service delete hello
+          cat > service.yaml <<EOF
+            apiVersion: serving.knative.dev/v1
+            kind: Service
+            metadata:
+              name: helloworld-go 
+              namespace: default
+            spec:
+              template:
+                spec:
+                  containers:
+                    - image: gcr.io/knative-samples/helloworld-go
+                      env:
+                        - name: TARGET # The environment variable printed out by the sample app
+                          value: "Hello Knative Serving is up and running with Kourier!!"
+            EOF
+          kubectl apply --filename service.yaml
+          kubectl get ksvc
+          curl -v http://helloworld-go.default.127.0.0.1.sslip.io
+          kubectl delete service helloworld-go 
       
       - name: Tear down infrastructure job
         run: helm delete --namespace infrastructure turing-init --timeout 15m

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Download Cluster Init Docker tar archieve
         uses: actions/download-artifact@v2
         with:
-          name: cluster-init.${{ needs.build-cluster-init.outputs.cluster-init-version }}.tar
+          name: cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
       
       - name: Run action cluster-init
         uses: ./.github/actions/run-cluster-init

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -172,8 +172,7 @@ jobs:
 
 
           kubectl apply -f service.yaml
-          # kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.1.0/serving-default-domain.yaml
-          sleep 20
+          timeout --foreground 10s bash -c 'until kubectl get service.serving.knative.dev/helloworld-go --output=jsonpath='{.status.conditions[1]}'  | grep "True"; do : ; done'
           kubectl get ksvc
           curl -v http://helloworld-go.default.127.0.0.1.sslip.io
           kubectl delete service helloworld-go 

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release-rules
+      - test-e2e
     steps:
       - uses: actions/checkout@v2
         with:
@@ -75,3 +76,71 @@ jobs:
 
       - name: Publish Cluster Init Docker Image
         run: docker push ${{ steps.build.outputs.cluster-init-image }}
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    env:
+      LOCAL_REGISTRY: registry.localhost:5000
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Build Docker image
+        id: build-image
+        working-directory: infra/cluster-init
+        run: |
+          set -o pipefail
+          make build-image | tee output.log
+          echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
+
+      - name: Publish images to local registry
+        env:
+          DOCKER_REPOSITORY: ${{ env.LOCAL_REGISTRY }}/${{ github.repository }}
+          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
+        run: |
+          # Cluster init
+          docker image load --input cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
+          docker tag \
+            cluster-init:${{ env.CLUSTER_INIT_VERSION }} \
+            ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
+          docker push ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
+      
+      - name: "Setup local k8s cluster"
+        uses: AbsaOSS/k3d-action@v1.5.0
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          use-default-registry: true
+          args: >-
+            --servers 1
+            --agents 3
+            --port 80:80@loadbalancer
+            --k3s-server-arg "--no-deploy=traefik,metrics-server"
+
+      - name: "Install Infrastructure"
+        env:
+          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
+        run: |
+          kubectl create ns infrastructure
+          helm upgrade turing-init infra/charts/turing-init \
+            --namespace infrastructure \
+            --set image.registry=${{ env.LOCAL_REGISTRY }}/ \
+            --set image.repository=${{ github.repository }}/cluster-init \
+            --set image.tag=${{ env.CLUSTER_INIT_VERSION }} \
+            --set knative.domains="127.0.0.1.nip.io" \
+            --set knative.registriesSkippingTagResolving=${{ env.LOCAL_REGISTRY }} \
+            --install \
+            --wait
+
+          # wait for install infra job to finish
+          kubectl logs -n infrastructure -f $(kubectl get pod --namespace infrastructure | grep -v 'NAME' | grep -v 'spark' | head -n 1 | awk '{print $1}')
+          kubectl get pod --all-namespaces
+          kubectl get svc --all-namespaces
+          kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-spark-operator-webhook-init
+          # Might fail the first time but the 2nd run should work, rarely fails on the first try though.
+          kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-init
+      
+      - name: Tear down infrastructure job
+        run: helm delete --namespace infrastructure turing-init --timeout 15m

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Smoke Test
         run: |
-          cat > service.yaml <<EOF
+          cat <<EOF > service.yaml 
             apiVersion: serving.knative.dev/v1
             kind: Service
             metadata:
@@ -169,7 +169,7 @@ jobs:
                         - name: TARGET # The environment variable printed out by the sample app
                           value: "Hello Knative Serving is up and running with Kourier!!"
             EOF
-          kubectl apply --filename service.yaml
+          kubectl apply -f service.yaml
           kubectl get ksvc
           curl -v http://helloworld-go.default.127.0.0.1.sslip.io
           kubectl delete service helloworld-go 

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -35,63 +35,44 @@ jobs:
         with:
           prefix: cluster-init/
 
-  publish:
-    # Automatically publish release and pre-release artifacts.
-    #
-    # As for dev releases, make it possible to publish artifacts
-    # manually by approving 'deployment' in the 'manual' environment.
-    #
-    # Dev build can be released either from the 'main' branch or
-    # by running this workflow manually with `workflow_dispatch` event.
-    if: >-
-      contains('release,pre-release', needs.release-rules.outputs.release-type)
-        || ( github.event_name != 'pull_request' )
-        || ( github.event.pull_request.head.repo.full_name == github.repository )
-    environment: ${{ needs.release-rules.outputs.release-type == 'dev' && 'manual' || '' }}
+  build-cluster-init:
     runs-on: ubuntu-latest
-    needs:
-      - release-rules
-      - test-e2e
+    outputs:
+      cluster-init-version: ${{ steps.build-cluster-init.outputs.cluster-init-version }}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build Docker Image
-        id: build
-        working-directory: infra/cluster-init
-        env:
-          DOCKER_REGISTRY: ghcr.io/${{ github.repository }}
-        run: |
-          set -o pipefail
-          make build-image | tee output.log
-          echo "::set-output name=cluster-init-image::$(sed -n 's%Building docker image: \(.*\)%\1%p' output.log)"
-
-      - name: Publish Cluster Init Docker Image
-        run: docker push ${{ steps.build.outputs.cluster-init-image }}
-
+      - name: Run action build-cluster-init
+        id: build-cluster-init
+        uses: ./.github/actions/build-cluster-init
+ 
   test-e2e:
     runs-on: ubuntu-latest
+    env:
+      CLUSTER_INIT_VERSION: ${{ needs.build-cluster-init.outputs.cluster-init-version }}
+      CLUSTER_NAME: turing-e2e
+      ISTIO_VERSION: 1.9.9
+      KNATIVE_VERSION: v0.18.3
+      KNATIVE_ISTIO_VERSION: v0.18.1
+      LOCAL_REGISTRY: registry.localhost:5000
+    needs:
+      - build-cluster-init
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-        
-      - name: Run action cluster-init
-        uses: ./.github/actions/cluster-init
+
+      - name: Download Cluster Init Docker tar archieve
+        uses: actions/download-artifact@v2
         with:
-          cluster_name: turing-e2e
-          istio_version: 1.9.9
-          knative_version: v0.18.3
-          knative_istio_version: v0.18.1
-          local_registry: registry.localhost:5000
-          build_image: true
+          name: cluster-init.${{ needs.build-cluster-init.outputs.cluster-init-version }}.tar
+      
+      - name: Run action cluster-init
+        uses: ./.github/actions/run-cluster-init
+        with:
+          cluster_name: ${{ env.CLUSTER_NAME}}
+          istio_version: ${{ env.ISTIO_VERSION}}
+          knative_version: ${{ env.KNATIVE_VERSION}}
+          knative_istio_version: ${{ env.KNATIVE_ISTIO_VERSION}}
+          local_registry: ${{ env.LOCAL_REGISTRY}}
+          cluster_init_version: ${{ env.CLUSTER_INIT_VERSION }}
 
       - name: Smoke Test
         run: |
@@ -124,3 +105,42 @@ jobs:
       # Invoke helm hooks on delete
       - name: Tear down infrastructure job
         run: helm delete --namespace infrastructure turing-init --timeout 15m
+
+  publish:
+      # Automatically publish release and pre-release artifacts.
+      #
+      # As for dev releases, make it possible to publish artifacts
+      # manually by approving 'deployment' in the 'manual' environment.
+      #
+      # Dev build can be released either from the 'main' branch or
+      # by running this workflow manually with `workflow_dispatch` event.
+      if: >-
+        contains('release,pre-release', needs.release-rules.outputs.release-type)
+          || ( github.event_name != 'pull_request' )
+          || ( github.event.pull_request.head.repo.full_name == github.repository )
+      environment: ${{ needs.release-rules.outputs.release-type == 'dev' && 'manual' || '' }}
+      runs-on: ubuntu-latest
+      needs:
+        - release-rules
+        - build-cluster-init
+        - test-e2e
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+
+        - name: Log in to the Container registry
+          uses: docker/login-action@v1
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Download Cluster Init Docker tar archieve
+          uses: actions/download-artifact@v2
+          with:
+            name: cluster-init.${{ needs.build-cluster-init.outputs.cluster-init-version }}.tar
+
+        - name: Publish Cluster Init Docker Image
+          run: docker push ${{ steps.build.outputs.cluster-init-image }}
+

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -81,7 +81,9 @@ jobs:
   test-e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
+        
       - uses: ./.github/actions/cluster-init
         with:
           cluster_name: turing-e2e

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -166,11 +166,13 @@ jobs:
                 containers:
                   - image: gcr.io/knative-samples/helloworld-go
                     env:
-                      - name: TARGET # The environment variable printed out by the sample app
-                        value: "Hello Knative Serving is up and running with Kourier!!"
+                      - name: TARGET
+                        value: "Hello Knative Serving is up and running!!"
           EOF
 
+
           kubectl apply -f service.yaml
+          kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.1.0/serving-default-domain.yaml
           kubectl get ksvc
           curl -v http://helloworld-go.default.127.0.0.1.sslip.io
           kubectl delete service helloworld-go 

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -89,6 +89,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      
+      - name: "Setup local k8s cluster"
+        uses: AbsaOSS/k3d-action@v1.5.0
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          use-default-registry: true
+          args: >-
+            --servers 1
+            --agents 3
+            --port 80:80@loadbalancer
+            --k3s-server-arg "--no-deploy=traefik,metrics-server"
 
       - name: Build Docker image
         id: build-image
@@ -115,17 +126,6 @@ jobs:
             cluster-init:${{ env.CLUSTER_INIT_VERSION }} \
             ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
           docker push ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
-      
-      - name: "Setup local k8s cluster"
-        uses: AbsaOSS/k3d-action@v1.5.0
-        with:
-          cluster-name: ${{ env.CLUSTER_NAME }}
-          use-default-registry: true
-          args: >-
-            --servers 1
-            --agents 3
-            --port 80:80@loadbalancer
-            --k3s-server-arg "--no-deploy=traefik,metrics-server"
 
       - name: "Install Infrastructure"
         env:

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -77,7 +77,6 @@ jobs:
       - name: Publish Cluster Init Docker Image
         run: docker push ${{ steps.build.outputs.cluster-init-image }}
 
-
   test-e2e:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -174,6 +174,7 @@ jobs:
           kubectl apply -f service.yaml
           timeout --foreground 120 bash -c 'until kubectl get service.serving.knative.dev/helloworld-go --output=jsonpath='{.status.conditions[1]}'  | grep "True"; do : ; done'
           kubectl get ksvc
+          kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.1.0/serving-default-domain.yaml
           curl -v http://helloworld-go.default.127.0.0.1.sslip.io
           kubectl delete service helloworld-go 
       

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -79,10 +79,13 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
-    outputs:
-      cluster-init-version: ${{ steps.build-image.outputs.cluster-init-version }}
     env:
+      CLUSTER_NAME: turing-e2e
+      ISTIO_VERSION: 1.9.9
+      KNATIVE_VERSION: v0.18.3
+      KNATIVE_ISTIO_VERSION: v0.18.1
       LOCAL_REGISTRY: registry.localhost:5000
+      CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
 
     steps:
       - name: Check out code
@@ -118,7 +121,6 @@ jobs:
       - name: Publish images to local registry
         env:
           DOCKER_REPOSITORY: ${{ env.LOCAL_REGISTRY }}/${{ github.repository }}
-          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
         run: |
           # Cluster init
           docker image load --input cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
@@ -128,8 +130,6 @@ jobs:
           docker push ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
 
       - name: "Install Infrastructure"
-        env:
-          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
         run: |
           kubectl create ns infrastructure
           helm upgrade turing-init infra/charts/turing-init \

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -83,7 +83,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
         
-      - uses: ./.github/actions/cluster-init
+      - name: Run action cluster-init
+        uses: ./.github/actions/cluster-init
         with:
           cluster_name: turing-e2e
           istio_version: 1.9.9

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -129,7 +129,7 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
           docker push ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
 
-      - name: "Install Infrastructure"
+      - name: Install Infrastructure
         env:
           CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
         run: |
@@ -151,6 +151,14 @@ jobs:
           kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-spark-operator-webhook-init
           # Might fail the first time but the 2nd run should work, rarely fails on the first try though.
           kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-init
+
+      - name: Smoke Test
+        run: |
+          kn service create hello \
+            --image gcr.io/knative-samples/helloworld-go \
+            --port 8080 
+          curl http://hello.default.127.0.0.1.sslip.io
+          kn service delete hello
       
       - name: Tear down infrastructure job
         run: helm delete --namespace infrastructure turing-init --timeout 15m

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -107,6 +107,7 @@ jobs:
       - name: Publish images to local registry
         env:
           DOCKER_REPOSITORY: ${{ env.LOCAL_REGISTRY }}/${{ github.repository }}
+          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
         run: |
           # Cluster init
           docker image load --input cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
@@ -127,6 +128,8 @@ jobs:
             --k3s-server-arg "--no-deploy=traefik,metrics-server"
 
       - name: "Install Infrastructure"
+        env:
+          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
         run: |
           kubectl create ns infrastructure
           helm upgrade turing-init infra/charts/turing-init \

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -82,8 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - id: cluster-init
-        uses: ./.github/actions/cluster-init
+      - uses: ./.github/actions/cluster-init
         with:
           cluster_name: turing-e2e
           istio_version: 1.9.9

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -93,6 +93,8 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
+    needs:
+      - cluster-init
     steps:
       - name: Smoke Test
         run: |

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -85,7 +85,6 @@ jobs:
       KNATIVE_VERSION: v0.18.3
       KNATIVE_ISTIO_VERSION: v0.18.1
       LOCAL_REGISTRY: registry.localhost:5000
-      CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
 
     steps:
       - name: Check out code
@@ -121,6 +120,7 @@ jobs:
       - name: Publish images to local registry
         env:
           DOCKER_REPOSITORY: ${{ env.LOCAL_REGISTRY }}/${{ github.repository }}
+          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
         run: |
           # Cluster init
           docker image load --input cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
@@ -130,6 +130,8 @@ jobs:
           docker push ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
 
       - name: "Install Infrastructure"
+        env:
+          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
         run: |
           kubectl create ns infrastructure
           helm upgrade turing-init infra/charts/turing-init \

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -154,21 +154,22 @@ jobs:
 
       - name: Smoke Test
         run: |
-          cat <<EOF > service.yaml 
-            apiVersion: serving.knative.dev/v1
-            kind: Service
-            metadata:
-              name: helloworld-go 
-              namespace: default
-            spec:
-              template:
-                spec:
-                  containers:
-                    - image: gcr.io/knative-samples/helloworld-go
-                      env:
-                        - name: TARGET # The environment variable printed out by the sample app
-                          value: "Hello Knative Serving is up and running with Kourier!!"
-            EOF
+          tee service.yaml <<EOF 
+          apiVersion: serving.knative.dev/v1
+          kind: Service
+          metadata:
+            name: helloworld-go 
+            namespace: default
+          spec:
+            template:
+              spec:
+                containers:
+                  - image: gcr.io/knative-samples/helloworld-go
+                    env:
+                      - name: TARGET # The environment variable printed out by the sample app
+                        value: "Hello Knative Serving is up and running with Kourier!!"
+          EOF
+
           kubectl apply -f service.yaml
           kubectl get ksvc
           curl -v http://helloworld-go.default.127.0.0.1.sslip.io

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -172,7 +172,8 @@ jobs:
 
 
           kubectl apply -f service.yaml
-          kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.1.0/serving-default-domain.yaml
+          # kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.1.0/serving-default-domain.yaml
+          sleep 20
           kubectl get ksvc
           curl -v http://helloworld-go.default.127.0.0.1.sslip.io
           kubectl delete service helloworld-go 

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -174,8 +174,7 @@ jobs:
           kubectl apply -f service.yaml
           timeout --foreground 120 bash -c 'until kubectl get service.serving.knative.dev/helloworld-go --output=jsonpath='{.status.conditions[1]}'  | grep "True"; do : ; done'
           kubectl get ksvc
-          kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.1.0/serving-default-domain.yaml
-          curl -v http://helloworld-go.default.127.0.0.1.sslip.io
+          curl -v http://helloworld-go.default.127.0.0.1.nip.io/
           kubectl delete service helloworld-go 
       
       - name: Tear down infrastructure job

--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -79,6 +79,8 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
+    outputs:
+      cluster-init-version: ${{ steps.build-image.outputs.cluster-init-version }}
     env:
       LOCAL_REGISTRY: registry.localhost:5000
 
@@ -96,10 +98,15 @@ jobs:
           make build-image | tee output.log
           echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
 
+      - name: Save Docker image
+        run: |
+          docker image save \
+            --output cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar \
+            cluster-init:${{ steps.build-image.outputs.cluster-init-version }}
+
       - name: Publish images to local registry
         env:
           DOCKER_REPOSITORY: ${{ env.LOCAL_REGISTRY }}/${{ github.repository }}
-          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
         run: |
           # Cluster init
           docker image load --input cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
@@ -120,8 +127,6 @@ jobs:
             --k3s-server-arg "--no-deploy=traefik,metrics-server"
 
       - name: "Install Infrastructure"
-        env:
-          CLUSTER_INIT_VERSION: ${{ steps.build-image.outputs.cluster-init-version }}
         run: |
           kubectl create ns infrastructure
           helm upgrade turing-init infra/charts/turing-init \

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -363,7 +363,8 @@ jobs:
             valuesFile: "turing.values.remote.yaml"
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
 
       - name: Download Turing API Docker tar archieve
         uses: actions/download-artifact@v2

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -418,26 +418,6 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
           docker push ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
 
-        run: |
-          kubectl create ns infrastructure
-          helm upgrade turing-init infra/charts/turing-init \
-            --namespace infrastructure \
-            --set image.registry=${{ env.LOCAL_REGISTRY }}/ \
-            --set image.repository=${{ github.repository }}/cluster-init \
-            --set image.tag=${{ env.CLUSTER_INIT_VERSION }} \
-            --set knative.domains="127.0.0.1.nip.io" \
-            --set knative.registriesSkippingTagResolving=${{ env.LOCAL_REGISTRY }} \
-            --install \
-            --wait
-
-          # wait for install infra job to finish
-          kubectl logs -n infrastructure -f $(kubectl get pod --namespace infrastructure | grep -v 'NAME' | grep -v 'spark' | head -n 1 | awk '{print $1}')
-          kubectl get pod --all-namespaces
-          kubectl get svc --all-namespaces
-          kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-spark-operator-webhook-init
-          # Might fail the first time but the 2nd run should work, rarely fails on the first try though.
-          kubectl wait -n infrastructure --for=condition=complete --timeout=10m job/turing-init-init
-
       - name: "Install Vault"
         if: ${{ !matrix.useInClusterConfig }}
         env:

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -392,9 +392,10 @@ jobs:
           knative_version: ${{ env.KNATIVE_VERSION}}
           knative_istio_version: ${{ env.KNATIVE_ISTIO_VERSION}}
           local_registry: ${{ env.LOCAL_REGISTRY}}
+          build-image: false
           cluster_init_version: ${{ env.CLUSTER_INIT_VERSION }}
 
-      - name: Publish images to local registry
+      - name: Publish Turing images to local registry
         env:
           DOCKER_REPOSITORY: ${{ env.LOCAL_REGISTRY }}/${{ github.repository }}
         run: |
@@ -411,13 +412,6 @@ jobs:
             turing-router:${{ env.TURING_ROUTER_VERSION }} \
             ${{ env.DOCKER_REPOSITORY }}/turing-router:${{ env.TURING_ROUTER_VERSION }}
           docker push ${{ env.DOCKER_REPOSITORY }}/turing-router:${{ env.TURING_ROUTER_VERSION }}
-
-          # Cluster init
-          docker image load --input cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
-          docker tag \
-            cluster-init:${{ env.CLUSTER_INIT_VERSION }} \
-            ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
-          docker push ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
 
       - name: "Install Vault"
         if: ${{ !matrix.useInClusterConfig }}

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -305,7 +305,7 @@ jobs:
   build-cluster-init:
     runs-on: ubuntu-latest
     outputs:
-      cluster-init-version: ${{ steps.cluster-init-version.outputs.cluster-init-version }}
+      cluster-init-version: ${{ steps.build-cluster-init.outputs.cluster-init-version }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -363,6 +363,8 @@ jobs:
             valuesFile: "turing.values.remote.yaml"
 
     steps:
+      - uses: actions/checkout@v2
+
       - name: Download Turing API Docker tar archieve
         uses: actions/download-artifact@v2
         with:
@@ -383,8 +385,7 @@ jobs:
         with:
           go-version: "1.14"
 
-      - id: cluster-init
-        uses: ./.github/actions/cluster-init
+      - uses: ./.github/actions/cluster-init
         with:
           cluster_name: ${{ env.CLUSTER_NAME}}
           istio_version: ${{ env.ISTIO_VERSION}}

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -305,7 +305,7 @@ jobs:
   build-cluster-init:
     runs-on: ubuntu-latest
     outputs:
-      cluster-init-version: ${{ steps.build-image.outputs.cluster-init-version }}
+      cluster-init-version: ${{ steps.cluster-init-version.outputs.cluster-init-version }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -360,12 +360,12 @@ jobs:
       - name: Download Turing Router Docker tar archieve
         uses: actions/download-artifact@v2
         with:
-          name: turing-router.${{ needs.build-router.outputs.router-version }}.tar
+          name: turing-router.${{ env.TURING_ROUTER_VERSION }}.tar
 
       - name: Download Cluster Init Docker tar archieve
         uses: actions/download-artifact@v2
         with:
-          name: cluster-init.${{ needs.build-cluster-init.outputs.cluster-init-version }}.tar
+          name: cluster-init.${{ env.CLUSTER_INIT_VERSION }}.tar
 
       - name: Set up Go 1.14
         uses: actions/setup-go@v2

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -571,10 +571,6 @@ jobs:
           KUBECONFIG_USE_LOCAL: true
         run: go test -v -parallel=2 ./e2e/... -tags=e2e -run TestEndToEnd
 
-      # Invoke helm hooks on delete
-      - name: Tear down infrastructure job
-        run: helm delete --namespace infrastructure turing-init --timeout 15m
-
   release-rules:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -386,7 +386,8 @@ jobs:
         with:
           go-version: "1.14"
 
-      - uses: ./.github/actions/cluster-init
+      - name: Run action cluster-init
+        uses: ./.github/actions/cluster-init
         with:
           cluster_name: ${{ env.CLUSTER_NAME}}
           istio_version: ${{ env.ISTIO_VERSION}}
@@ -471,7 +472,8 @@ jobs:
         run: |
           kubectl apply -f infra/e2e/turing.mockserver.yaml
 
-      - uses: jupyterhub/action-k8s-await-workloads@v1
+      - name: Run action await k8 workloads
+        uses: jupyterhub/action-k8s-await-workloads@v1
         id: wait-for-deployment
         with:
           workloads: >-

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -312,26 +312,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build Docker image
-        id: build-image
-        working-directory: infra/cluster-init
-        run: |
-          set -o pipefail
-          make build-image | tee output.log
-          echo "::set-output name=cluster-init-version::$(sed -n 's%turing-cluster-init version: \(.*\)%\1%p' output.log)"
-
-      - name: Save Docker image
-        run: |
-          docker image save \
-            --output cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar \
-            cluster-init:${{ steps.build-image.outputs.cluster-init-version }}
-
-      - name: Publish Artifact
-        uses: actions/upload-artifact@v2
+      - name: Run action build-cluster-init
+        id: build-cluster-init
+        uses: ./.github/actions/build-cluster-init
         with:
-          name: cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar
-          path: cluster-init.${{ steps.build-image.outputs.cluster-init-version }}.tar
-          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          artifact_retention_days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        
 
   test-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -386,12 +386,11 @@ jobs:
       - id: cluster-init
         uses: ./.github/actions/cluster-init
         with:
-          cluster_name: turing-e2e
-          istio_version: 1.9.9
-          knative_version: v0.18.3
-          knative_istio_version: v0.18.1
-          local_registry: registry.localhost:5000
-          build_image: true
+          cluster_name: ${{ env.CLUSTER_NAME}}
+          istio_version: ${{ env.ISTIO_VERSION}}
+          knative_version: ${{ env.KNATIVE_VERSION}}
+          knative_istio_version: ${{ env.KNATIVE_ISTIO_VERSION}}
+          local_registry: ${{ env.LOCAL_REGISTRY}}
           cluster_init_version: ${{ env.CLUSTER_INIT_VERSION }}
 
       - name: Publish images to local registry

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -363,25 +363,6 @@ jobs:
             valuesFile: "turing.values.remote.yaml"
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v2
-        with:
-          go-version: "1.14"
-
-      - name: "Setup local k8s cluster"
-        uses: AbsaOSS/k3d-action@v1.5.0
-        with:
-          cluster-name: ${{ env.CLUSTER_NAME }}
-          use-default-registry: true
-          args: >-
-            --servers 1
-            --agents 3
-            --port 80:80@loadbalancer
-            --k3s-server-arg "--no-deploy=traefik,metrics-server"
-
       - name: Download Turing API Docker tar archieve
         uses: actions/download-artifact@v2
         with:
@@ -396,6 +377,22 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: cluster-init.${{ needs.build-cluster-init.outputs.cluster-init-version }}.tar
+
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.14"
+
+      - id: cluster-init
+        uses: ./.github/actions/cluster-init
+        with:
+          cluster_name: turing-e2e
+          istio_version: 1.9.9
+          knative_version: v0.18.3
+          knative_istio_version: v0.18.1
+          local_registry: registry.localhost:5000
+          build_image: true
+          cluster_init_version: ${{ env.CLUSTER_INIT_VERSION }}
 
       - name: Publish images to local registry
         env:
@@ -422,7 +419,6 @@ jobs:
             ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
           docker push ${{ env.DOCKER_REPOSITORY }}/cluster-init:${{ env.CLUSTER_INIT_VERSION }}
 
-      - name: "Install Infrastructure"
         run: |
           kubectl create ns infrastructure
           helm upgrade turing-init infra/charts/turing-init \

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -392,7 +392,7 @@ jobs:
           knative_version: ${{ env.KNATIVE_VERSION}}
           knative_istio_version: ${{ env.KNATIVE_ISTIO_VERSION}}
           local_registry: ${{ env.LOCAL_REGISTRY}}
-          build-image: false
+          build_image: false
           cluster_init_version: ${{ env.CLUSTER_INIT_VERSION }}
 
       - name: Publish Turing images to local registry

--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -387,14 +387,13 @@ jobs:
           go-version: "1.14"
 
       - name: Run action cluster-init
-        uses: ./.github/actions/cluster-init
+        uses: ./.github/actions/run-cluster-init
         with:
           cluster_name: ${{ env.CLUSTER_NAME}}
           istio_version: ${{ env.ISTIO_VERSION}}
           knative_version: ${{ env.KNATIVE_VERSION}}
           knative_istio_version: ${{ env.KNATIVE_ISTIO_VERSION}}
           local_registry: ${{ env.LOCAL_REGISTRY}}
-          build_image: false
           cluster_init_version: ${{ env.CLUSTER_INIT_VERSION }}
 
       - name: Publish Turing images to local registry


### PR DESCRIPTION
# Summary
Refactor existing Turing CI workflow, to remove tear down of cluster and do it as an e2e test part of cluster-init workflow.

# Modification 
`.github/actions/cluster-init/action.yaml` - New github action to be called by both Turing and cluster-init workflow to init the cluster. It will contain inputs to optionally build an image or to use an built jar.
The steps involved are:
1. Setup k3d cluster
2. (Optional) Build and save Cluster-Init Image
3. Push image to local registry
4. Install cluster

`.github/workflows/cluster-init.yaml` - Updated to include an e2e test.
Steps
1.  Trigger `cluster-init` github action 
2. Deploy an knative service for smoke test
3. Tear down infra

`.github/workflows/turing.yaml` - Extracted installation of cluster as github action and to call the action instead. Removed tearing down of cluster.