### PR TITLE
Allow Swagger UI to use file instead of serving it on a URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,12 @@ RUN apk add --no-cache bash
 
 # Override the swagger ui config
 ENV OPENAPICONFIG_SWAGGERUICONFIG_SERVINGDIRECTORY "/app/swagger-ui"
-ENV OPENAPICONFIG_YAMLSERVINGURL "/static/openapi.bundle.yaml"
+ENV OPENAPICONFIG_MERGEDSPECFILE "/app/swagger-ui/openapi.bundle.yaml"
 
 # Build swagger ui deps
 COPY ./scripts/swagger-ui-generator /app/swagger-ui-generator
 RUN cd /app/swagger-ui-generator && ./swagger-ui-generator.sh \
-    --spec-url ${OPENAPICONFIG_YAMLSERVINGURL} \
+    --spec-file ${OPENAPICONFIG_MERGEDSPECFILE} \
     --output ${OPENAPICONFIG_SWAGGERUICONFIG_SERVINGDIRECTORY}
 RUN rm -rf /app/swagger-ui-generator
 

--- a/api/api/Makefile
+++ b/api/api/Makefile
@@ -18,5 +18,5 @@ bundle-openapi:
 .PHONY: swagger-ui-dist
 swagger-ui-dist: bundle-openapi
 	@../../scripts/swagger-ui-generator/swagger-ui-generator.sh \
-		--spec-url "/static/openapi.bundle.yaml" \
+		--spec-file openapi.bundle.yaml \
 		--output swagger-ui-dist

--- a/api/api/openapi.bundle.yaml
+++ b/api/api/openapi.bundle.yaml
@@ -1757,15 +1757,16 @@ components:
       example:
         endpoint: endpoint
         updated_at: 2000-01-23T04:56:07.000+00:00
+        project_id: 1
         name: name
         created_at: 2000-01-23T04:56:07.000+00:00
-        project: 1
         id: 6
         monitoring_url: monitoring_url
         environment_name: environment_name
+      nullable: true
       properties:
         id:
-          readOnly: true
+          format: int32
           type: integer
         name:
           type: string
@@ -1777,11 +1778,12 @@ components:
           format: date-time
           readOnly: true
           type: string
-        project:
+        project_id:
           type: integer
         environment_name:
           type: string
         endpoint:
+          readOnly: true
           type: string
         monitoring_url:
           readOnly: true
@@ -1801,12 +1803,42 @@ components:
       example:
         image: image
         created_at: 2000-01-23T04:56:07.000+00:00
+        rules:
+        - routes:
+          - routes
+          - routes
+          conditions:
+          - field: field
+            values:
+            - values
+            - values
+            operator: in
+          - field: field
+            values:
+            - values
+            - values
+            operator: in
+        - routes:
+          - routes
+          - routes
+          conditions:
+          - field: field
+            values:
+            - values
+            - values
+            operator: in
+          - field: field
+            values:
+            - values
+            - values
+            operator: in
         error: error
         default_route: default_route
         version: 5
         log_config:
           custom_metrics_enabled: true
           bigquery_config:
+            batch_load: true
             table: table
             service_account_secret: service_account_secret
           kafka_config:
@@ -1818,17 +1850,21 @@ components:
         timeout: timeout
         monitoring_url: monitoring_url
         experiment_engine:
-          config: ""
+          type: nop
+          config: '{}'
         enricher:
           service_account: secret-name-for-google-service-account
           image: image
           endpoint: endpoint
-          port: 1
+          updated_at: 2000-01-23T04:56:07.000+00:00
+          port: 5
+          created_at: 2000-01-23T04:56:07.000+00:00
           resource_request:
             min_replica: 0
             max_replica: 6
             memory_request: memory_request
             cpu_request: cpu_request
+          id: 1
           env:
           - name: name
             value: value
@@ -1837,23 +1873,26 @@ components:
           timeout: timeout
         routes:
         - endpoint: endpoint
+          annotations: '{}'
           id: id
           type: type
           timeout: timeout
         - endpoint: endpoint
+          annotations: '{}'
           id: id
           type: type
           timeout: timeout
         router:
           endpoint: endpoint
           updated_at: 2000-01-23T04:56:07.000+00:00
+          project_id: 1
           name: name
           created_at: 2000-01-23T04:56:07.000+00:00
-          project: 1
           id: 6
           monitoring_url: monitoring_url
           environment_name: environment_name
         updated_at: 2000-01-23T04:56:07.000+00:00
+        default_route_id: default_route_id
         resource_request:
           min_replica: 0
           max_replica: 6
@@ -1861,6 +1900,7 @@ components:
           cpu_request: cpu_request
         id: 0
         ensembler:
+          updated_at: 2000-01-23T04:56:07.000+00:00
           standard_config:
             experiment_mappings:
             - treatment: treatment-1
@@ -1869,12 +1909,14 @@ components:
             - treatment: treatment-1
               route: route-1
               experiment: experiment-1
+          created_at: 2000-01-23T04:56:07.000+00:00
+          id: 5
           type: standard
           docker_config:
             service_account: secret-name-for-google-service-account
             image: image
             endpoint: endpoint
-            port: 5
+            port: 2
             resource_request:
               min_replica: 0
               max_replica: 6
@@ -1925,10 +1967,16 @@ components:
         enricher:
           $ref: '#/components/schemas/Enricher'
         ensembler:
-          $ref: '#/components/schemas/Ensembler_1'
+          $ref: '#/components/schemas/RouterEnsemblerConfig'
         monitoring_url:
           readOnly: true
           type: string
+        default_route_id:
+          type: string
+        rules:
+          items:
+            $ref: '#/components/schemas/TrafficRule'
+          type: array
       type: object
     RouterVersionStatus:
       default: pending
@@ -1941,6 +1989,7 @@ components:
     Route:
       example:
         endpoint: endpoint
+        annotations: '{}'
         id: id
         type: type
         timeout: timeout
@@ -1953,6 +2002,9 @@ components:
           type: string
         timeout:
           type: string
+        annotations:
+          nullable: true
+          type: object
       required:
       - endpoint
       - id
@@ -1992,6 +2044,7 @@ components:
       type: string
     BigQueryConfig:
       example:
+        batch_load: true
         table: table
         service_account_secret: service_account_secret
       properties:
@@ -1999,6 +2052,9 @@ components:
           type: string
         service_account_secret:
           type: string
+        batch_load:
+          nullable: true
+          type: boolean
       required:
       - service_account_secret
       - table
@@ -2030,12 +2086,15 @@ components:
         service_account: secret-name-for-google-service-account
         image: image
         endpoint: endpoint
-        port: 1
+        updated_at: 2000-01-23T04:56:07.000+00:00
+        port: 5
+        created_at: 2000-01-23T04:56:07.000+00:00
         resource_request:
           min_replica: 0
           max_replica: 6
           memory_request: memory_request
           cpu_request: cpu_request
+        id: 1
         env:
         - name: name
           value: value
@@ -2043,6 +2102,9 @@ components:
           value: value
         timeout: timeout
       properties:
+        id:
+          format: int32
+          type: integer
         image:
           type: string
         resource_request:
@@ -2062,6 +2124,14 @@ components:
             (Optional) Name of the secret registered in the current MLP project that contains the Google service account JSON key. This secret will be mounted as a file inside the container and the environment variable GOOGLE_APPLICATION_CREDENTIALS will point to the service account file."
           example: secret-name-for-google-service-account
           type: string
+        created_at:
+          format: date-time
+          readOnly: true
+          type: string
+        updated_at:
+          format: date-time
+          readOnly: true
+          type: string
       required:
       - endpoint
       - env
@@ -2070,8 +2140,9 @@ components:
       - resource_request
       - timeout
       type: object
-    Ensembler_1:
+    RouterEnsemblerConfig:
       example:
+        updated_at: 2000-01-23T04:56:07.000+00:00
         standard_config:
           experiment_mappings:
           - treatment: treatment-1
@@ -2080,12 +2151,14 @@ components:
           - treatment: treatment-1
             route: route-1
             experiment: experiment-1
+        created_at: 2000-01-23T04:56:07.000+00:00
+        id: 5
         type: standard
         docker_config:
           service_account: secret-name-for-google-service-account
           image: image
           endpoint: endpoint
-          port: 5
+          port: 2
           resource_request:
             min_replica: 0
             max_replica: 6
@@ -2098,6 +2171,9 @@ components:
             value: value
           timeout: timeout
       properties:
+        id:
+          format: int32
+          type: integer
         type:
           description: type of ensembler
           enum:
@@ -2108,6 +2184,14 @@ components:
           $ref: '#/components/schemas/EnsemblerStandardConfig'
         docker_config:
           $ref: '#/components/schemas/EnsemblerDockerConfig'
+        created_at:
+          format: date-time
+          readOnly: true
+          type: string
+        updated_at:
+          format: date-time
+          readOnly: true
+          type: string
       required:
       - type
       type: object
@@ -2121,6 +2205,7 @@ components:
         - treatment: treatment-1
           route: route-1
           experiment: experiment-1
+      nullable: true
       properties:
         experiment_mappings:
           items:
@@ -2135,7 +2220,7 @@ components:
         service_account: secret-name-for-google-service-account
         image: image
         endpoint: endpoint
-        port: 5
+        port: 2
         resource_request:
           min_replica: 0
           max_replica: 6
@@ -2147,6 +2232,7 @@ components:
         - name: name
           value: value
         timeout: timeout
+      nullable: true
       properties:
         image:
           type: string
@@ -2174,120 +2260,6 @@ components:
       - port
       - resource_request
       - timeout
-      type: object
-    RouterConfig:
-      example:
-        name: name
-        config:
-          enricher:
-            service_account: secret-name-for-google-service-account
-            image: image
-            endpoint: endpoint
-            port: 1
-            resource_request:
-              min_replica: 0
-              max_replica: 6
-              memory_request: memory_request
-              cpu_request: cpu_request
-            env:
-            - name: name
-              value: value
-            - name: name
-              value: value
-            timeout: timeout
-          routes:
-          - endpoint: endpoint
-            id: id
-            type: type
-            timeout: timeout
-          - endpoint: endpoint
-            id: id
-            type: type
-            timeout: timeout
-          default_route_id: default_route_id
-          rules:
-          - routes:
-            - routes
-            - routes
-            conditions:
-            - field: field
-              values:
-              - values
-              - values
-              operator: in
-            - field: field
-              values:
-              - values
-              - values
-              operator: in
-          - routes:
-            - routes
-            - routes
-            conditions:
-            - field: field
-              values:
-              - values
-              - values
-              operator: in
-            - field: field
-              values:
-              - values
-              - values
-              operator: in
-          resource_request:
-            min_replica: 0
-            max_replica: 6
-            memory_request: memory_request
-            cpu_request: cpu_request
-          ensembler:
-            standard_config:
-              experiment_mappings:
-              - treatment: treatment-1
-                route: route-1
-                experiment: experiment-1
-              - treatment: treatment-1
-                route: route-1
-                experiment: experiment-1
-            type: standard
-            docker_config:
-              service_account: secret-name-for-google-service-account
-              image: image
-              endpoint: endpoint
-              port: 5
-              resource_request:
-                min_replica: 0
-                max_replica: 6
-                memory_request: memory_request
-                cpu_request: cpu_request
-              env:
-              - name: name
-                value: value
-              - name: name
-                value: value
-              timeout: timeout
-          log_config:
-            bigquery_config:
-              table: table
-              service_account_secret: service_account_secret
-            kafka_config:
-              brokers: brokers
-              topic: topic
-              serialization_format: json
-          timeout: timeout
-          experiment_engine:
-            config: ""
-        environment_name: environment_name
-      properties:
-        environment_name:
-          type: string
-        name:
-          type: string
-        config:
-          $ref: '#/components/schemas/RouterConfig_config'
-      required:
-      - config
-      - environment_name
-      - name
       type: object
     TrafficRule:
       example:
@@ -2348,6 +2320,130 @@ components:
       - operator
       - values
       type: object
+    RouterConfig:
+      example:
+        name: name
+        config:
+          enricher:
+            service_account: secret-name-for-google-service-account
+            image: image
+            endpoint: endpoint
+            updated_at: 2000-01-23T04:56:07.000+00:00
+            port: 5
+            created_at: 2000-01-23T04:56:07.000+00:00
+            resource_request:
+              min_replica: 0
+              max_replica: 6
+              memory_request: memory_request
+              cpu_request: cpu_request
+            id: 1
+            env:
+            - name: name
+              value: value
+            - name: name
+              value: value
+            timeout: timeout
+          routes:
+          - endpoint: endpoint
+            annotations: '{}'
+            id: id
+            type: type
+            timeout: timeout
+          - endpoint: endpoint
+            annotations: '{}'
+            id: id
+            type: type
+            timeout: timeout
+          default_route_id: default_route_id
+          rules:
+          - routes:
+            - routes
+            - routes
+            conditions:
+            - field: field
+              values:
+              - values
+              - values
+              operator: in
+            - field: field
+              values:
+              - values
+              - values
+              operator: in
+          - routes:
+            - routes
+            - routes
+            conditions:
+            - field: field
+              values:
+              - values
+              - values
+              operator: in
+            - field: field
+              values:
+              - values
+              - values
+              operator: in
+          resource_request:
+            min_replica: 0
+            max_replica: 6
+            memory_request: memory_request
+            cpu_request: cpu_request
+          ensembler:
+            updated_at: 2000-01-23T04:56:07.000+00:00
+            standard_config:
+              experiment_mappings:
+              - treatment: treatment-1
+                route: route-1
+                experiment: experiment-1
+              - treatment: treatment-1
+                route: route-1
+                experiment: experiment-1
+            created_at: 2000-01-23T04:56:07.000+00:00
+            id: 5
+            type: standard
+            docker_config:
+              service_account: secret-name-for-google-service-account
+              image: image
+              endpoint: endpoint
+              port: 2
+              resource_request:
+                min_replica: 0
+                max_replica: 6
+                memory_request: memory_request
+                cpu_request: cpu_request
+              env:
+              - name: name
+                value: value
+              - name: name
+                value: value
+              timeout: timeout
+          log_config:
+            bigquery_config:
+              batch_load: true
+              table: table
+              service_account_secret: service_account_secret
+            kafka_config:
+              brokers: brokers
+              topic: topic
+              serialization_format: json
+          timeout: timeout
+          experiment_engine:
+            type: nop
+            config: '{}'
+        environment_name: environment_name
+      properties:
+        environment_name:
+          type: string
+        name:
+          type: string
+        config:
+          $ref: '#/components/schemas/RouterConfig_config'
+      required:
+      - config
+      - environment_name
+      - name
+      type: object
     Event:
       example:
         event_type: info
@@ -2359,7 +2455,7 @@ components:
         version: 6
       properties:
         id:
-          readOnly: true
+          format: int32
           type: integer
         created_at:
           format: date-time
@@ -2679,37 +2775,20 @@ components:
       type: object
     ExperimentConfig:
       example:
-        config: ""
+        type: nop
+        config: '{}'
       properties:
         type:
-          $ref: '#/components/schemas/ExperimentEngineType'
+          default: nop
+          type: string
         config:
-          oneOf:
-          - $ref: '#/components/schemas/StandardExperimentConfig'
-          - $ref: '#/components/schemas/CustomExperimentConfig'
+          type: object
       required:
       - type
       type: object
     ExperimentEngineType:
       default: nop
-      enum:
-      - nop
       type: string
-    StandardExperimentConfig:
-      properties:
-        client:
-          $ref: '#/components/schemas/ExperimentClient'
-        experiments:
-          items:
-            $ref: '#/components/schemas/Experiment'
-          type: array
-        variables:
-          $ref: '#/components/schemas/ExperimentVariables'
-      type: object
-    CustomExperimentConfig:
-      not:
-        $ref: '#/components/schemas/StandardExperimentConfig'
-      type: object
     FieldSource:
       enum:
       - header
@@ -2810,6 +2889,7 @@ components:
       example:
         custom_metrics_enabled: true
         bigquery_config:
+          batch_load: true
           table: table
           service_account_secret: service_account_secret
         kafka_config:
@@ -2860,6 +2940,7 @@ components:
     RouterConfig_config_log_config:
       example:
         bigquery_config:
+          batch_load: true
           table: table
           service_account_secret: service_account_secret
         kafka_config:
@@ -2880,12 +2961,15 @@ components:
           service_account: secret-name-for-google-service-account
           image: image
           endpoint: endpoint
-          port: 1
+          updated_at: 2000-01-23T04:56:07.000+00:00
+          port: 5
+          created_at: 2000-01-23T04:56:07.000+00:00
           resource_request:
             min_replica: 0
             max_replica: 6
             memory_request: memory_request
             cpu_request: cpu_request
+          id: 1
           env:
           - name: name
             value: value
@@ -2894,10 +2978,12 @@ components:
           timeout: timeout
         routes:
         - endpoint: endpoint
+          annotations: '{}'
           id: id
           type: type
           timeout: timeout
         - endpoint: endpoint
+          annotations: '{}'
           id: id
           type: type
           timeout: timeout
@@ -2937,6 +3023,7 @@ components:
           memory_request: memory_request
           cpu_request: cpu_request
         ensembler:
+          updated_at: 2000-01-23T04:56:07.000+00:00
           standard_config:
             experiment_mappings:
             - treatment: treatment-1
@@ -2945,12 +3032,14 @@ components:
             - treatment: treatment-1
               route: route-1
               experiment: experiment-1
+          created_at: 2000-01-23T04:56:07.000+00:00
+          id: 5
           type: standard
           docker_config:
             service_account: secret-name-for-google-service-account
             image: image
             endpoint: endpoint
-            port: 5
+            port: 2
             resource_request:
               min_replica: 0
               max_replica: 6
@@ -2964,6 +3053,7 @@ components:
             timeout: timeout
         log_config:
           bigquery_config:
+            batch_load: true
             table: table
             service_account_secret: service_account_secret
           kafka_config:
@@ -2972,7 +3062,8 @@ components:
             serialization_format: json
         timeout: timeout
         experiment_engine:
-          config: ""
+          type: nop
+          config: '{}'
       properties:
         routes:
           items:
@@ -2995,7 +3086,7 @@ components:
         enricher:
           $ref: '#/components/schemas/Enricher'
         ensembler:
-          $ref: '#/components/schemas/Ensembler_1'
+          $ref: '#/components/schemas/RouterEnsemblerConfig'
       required:
       - default_route_id
       - experiment_engine

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -343,8 +343,8 @@ type OpenapiConfig struct {
 	SpecFile string
 	// Config file to be used for serving swagger.
 	SwaggerUIConfig *SinglePageApplicationConfig
-	// Where the merged spec file yaml should be served.
-	YAMLServingPath string
+	// Where the merged spec file yaml should be saved.
+	MergedSpecFile string
 	// Optional. Overrides the file before running the Swagger UI.
 	SpecOverrideFile *string
 }
@@ -352,6 +352,16 @@ type OpenapiConfig struct {
 // SpecData returns a byte slice of the combined yaml files
 func (c *OpenapiConfig) SpecData() ([]byte, error) {
 	return utils.MergeTwoYamls(c.SpecFile, c.SpecOverrideFile)
+}
+
+// GenerateSpecFile gets the spec data and writes to a file
+func (c *OpenapiConfig) GenerateSpecFile() error {
+	b, err := c.SpecData()
+	if err != nil {
+		return err
+	}
+
+	return utils.WriteYAMLFile(b, c.MergedSpecFile)
 }
 
 // Load creates a Config object from default config values, config files and environment variables.
@@ -477,7 +487,7 @@ func setDefaultValues(v *viper.Viper) {
 	v.SetDefault("OpenapiConfig::SwaggerUIConfig::ServingPath", "/api-docs/")
 	v.SetDefault("OpenapiConfig::ValidationEnabled", "true")
 	v.SetDefault("OpenapiConfig::SpecFile", "api/openapi.bundle.yaml")
-	v.SetDefault("OpenapiConfig::YAMLServingPath", "/static/openapi.bundle.yaml")
+	v.SetDefault("OpenapiConfig::MergedSpecFile", "api/swagger-ui-dist/openapi.bundle.yaml")
 
 	v.SetDefault("Experiment", map[string]interface{}{})
 }

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -357,6 +359,11 @@ func (c *OpenapiConfig) SpecData() ([]byte, error) {
 // GenerateSpecFile gets the spec data and writes to a file
 func (c *OpenapiConfig) GenerateSpecFile() error {
 	b, err := c.SpecData()
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Dir(c.MergedSpecFile), 0755)
 	if err != nil {
 		return err
 	}

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -168,7 +168,7 @@ func TestLoad(t *testing.T) {
 				OpenapiConfig: &OpenapiConfig{
 					ValidationEnabled: true,
 					SpecFile:          "api/openapi.bundle.yaml",
-					YAMLServingPath:    "/static/openapi.bundle.yaml",
+					MergedSpecFile:    "api/swagger-ui-dist/openapi.bundle.yaml",
 					SwaggerUIConfig: &SinglePageApplicationConfig{
 						ServingDirectory: "",
 						ServingPath:      "/api-docs/",
@@ -249,7 +249,7 @@ func TestLoad(t *testing.T) {
 				OpenapiConfig: &OpenapiConfig{
 					ValidationEnabled: true,
 					SpecFile:          "api/openapi.bundle.yaml",
-					YAMLServingPath:    "/static/openapi.bundle.yaml",
+					MergedSpecFile:    "api/swagger-ui-dist/openapi.bundle.yaml",
 					SwaggerUIConfig: &SinglePageApplicationConfig{
 						ServingDirectory: "",
 						ServingPath:      "/api-docs/",
@@ -346,7 +346,7 @@ func TestLoad(t *testing.T) {
 				OpenapiConfig: &OpenapiConfig{
 					ValidationEnabled: true,
 					SpecFile:          "api/openapi.bundle.yaml",
-					YAMLServingPath:    "/static/openapi.bundle.yaml",
+					MergedSpecFile:    "api/swagger-ui-dist/openapi.bundle.yaml",
 					SwaggerUIConfig: &SinglePageApplicationConfig{
 						ServingDirectory: "",
 						ServingPath:      "/swagger-ui",
@@ -464,7 +464,7 @@ func TestLoad(t *testing.T) {
 				OpenapiConfig: &OpenapiConfig{
 					ValidationEnabled: true,
 					SpecFile:          "api/openapi.bundle.yaml",
-					YAMLServingPath:    "/static/openapi.bundle.yaml",
+					MergedSpecFile:    "api/swagger-ui-dist/openapi.bundle.yaml",
 					SwaggerUIConfig: &SinglePageApplicationConfig{
 						ServingDirectory: "static/swagger-ui",
 						ServingPath:      "/swagger-ui",

--- a/api/turing/server/application.go
+++ b/api/turing/server/application.go
@@ -117,11 +117,11 @@ func Run() {
 	// HealthCheck Handler
 	AddHealthCheckHandler(r, "/v1/internal", db)
 
-	openAPISpecBytes, err := cfg.OpenapiConfig.SpecData()
+	// Write to a file so that Swagger UI can use it
+	err = cfg.OpenapiConfig.GenerateSpecFile()
 	if err != nil {
-		log.Panicf("failed to merge openapi yamls: %s", err)
+		log.Panicf("failed to write openapi yaml file: %s", err)
 	}
-	ServeYAML(r, cfg.OpenapiConfig.YAMLServingPath, openAPISpecBytes)
 
 	// API Handler
 	err = AddAPIRoutesHandler(r, apiPathPrefix, appCtx, cfg)

--- a/api/turing/server/static.go
+++ b/api/turing/server/static.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	logger "github.com/gojek/turing/api/turing/log"
 	"github.com/gorilla/mux"
 )
 
@@ -81,19 +80,4 @@ func (h SPAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func ServeSinglePageApplication(r *mux.Router, path string, appDir string) {
 	r.PathPrefix(path).Handler(NewSinglePageApplicationHandler(path, appDir))
-}
-
-func serveByteArray(r *mux.Router, path string, bytes []byte, contentType string) {
-	r.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-type", contentType)
-		_, err := w.Write(bytes)
-		if err != nil {
-			logger.Errorf("error writing openapi yaml: %s", err)
-		}
-	})
-}
-
-// ServeYAML serves a yaml via http.
-func ServeYAML(r *mux.Router, path string, bytes []byte) {
-	serveByteArray(r, path, bytes, "application/x-yaml")
 }

--- a/api/turing/utils/merge.go
+++ b/api/turing/utils/merge.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v3"
 )
@@ -94,4 +95,24 @@ func readYAML(filepath string) (map[string]interface{}, error) {
 	}
 
 	return y, nil
+}
+
+// WriteYAMLFile takes a byte slice and writes to the path.
+func WriteYAMLFile(b []byte, path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening file for writing: %s", err)
+	}
+
+	_, err = f.Write(b)
+	if err != nil {
+		return fmt.Errorf("error writing bytes into file: %s", err)
+	}
+
+	err = f.Sync()
+	if err != nil {
+		return fmt.Errorf("error syncing file to disk: %s", err)
+	}
+
+	return nil
 }

--- a/scripts/swagger-ui-generator/swagger-ui-generator.sh
+++ b/scripts/swagger-ui-generator/swagger-ui-generator.sh
@@ -17,7 +17,7 @@ show_help() {
   cat <<EOF
 Usage: $(basename "$0") <options>
     -h, --help               Display help
-    -s, --spec-url           URL containing the API definition
+    -s, --spec-file          A file containing the API definition
     -o, --output             The output path for the generated Swagger UI files
     -v, --version            The Swagger-UI version to use (default: DEFAULT_SWAGGER_UI_VERSION)"
 EOF
@@ -66,12 +66,12 @@ parse_command_line() {
           exit 1
         fi
         ;;
-      -s | --spec-url)
+      -s | --spec-file)
         if [[ -n "${2:-}" ]]; then
-          spec_url="$2"
+          spec_file="$2"
           shift
         else
-          echo "ERROR: '-s|--spec-url' cannot be empty." >&2
+          echo "ERROR: '-s|--spec-file' cannot be empty." >&2
           show_help
           exit 1
         fi
@@ -84,8 +84,8 @@ parse_command_line() {
     shift
   done
 
-  if [[ -z "$spec_url" ]]; then
-    echo "ERROR: '-s|--spec-url' is required." >&2
+  if [[ -z "$spec_file" ]]; then
+    echo "ERROR: '-s|--spec-file' is required." >&2
     show_help
     exit 1
   fi
@@ -133,7 +133,7 @@ make_swagger_config(){
   echo "Generating Swagger UI configuration..."
   cat <<EOF > "$output/$SWAGGER_CONFIG_FILENAME"
 deepLinking: true
-url: "$spec_url"
+url: $(basename "$spec_file")
 EOF
 }
 


### PR DESCRIPTION
The main motivation for this PR is that whenever we deploy our application, swagger-ui is [referencing a fixed URL for openapi.bundle.yaml](https://github.com/gojek/turing/blob/1de5d8397d885d8342fc71b9a477a034c9d4a885/scripts/swagger-ui-generator/swagger-ui-generator.sh#L136), which does not allow for any URL rewrites when using a reverse proxy. Letting Swagger UI handle it based on file names allows the use of relative paths (which can be manipulated by a reverse proxy) rather than fixed static paths.