### PR TITLE
Fix turing docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,36 @@
 ARG TURING_API_IMAGE
+FROM bash:alpine3.14 as swagger-ui
+
+WORKDIR /app
+
+ARG openapi_spec_file="/app/swagger-ui/openapi.bundle.yaml"
+
+# Build swagger ui deps
+COPY ./scripts/swagger-ui-generator /app/swagger-ui-generator
+
+RUN cd /app/swagger-ui-generator && ./swagger-ui-generator.sh \
+    --spec-file ${openapi_spec_file} \
+    --output /app/swagger-ui
+
 FROM ${TURING_API_IMAGE}
+
+ARG openapi_spec_file=/app/swagger-ui/openapi.bundle.yaml
+ARG turing_ui_dist_path=ui/build
 
 ARG TURING_USER=${TURING_USER:-turing}
 ARG TURING_USER_GROUP=${TURING_USER_GROUP:-app}
 
 ENV TURINGUICONFIG_SERVINGDIRECTORY "/app/turing-ui"
 
-USER root
-RUN apk add --no-cache bash
-
 # Override the swagger ui config
 ENV OPENAPICONFIG_SWAGGERUICONFIG_SERVINGDIRECTORY "/app/swagger-ui"
-ENV OPENAPICONFIG_MERGEDSPECFILE "/app/swagger-ui/openapi.bundle.yaml"
+ENV OPENAPICONFIG_MERGEDSPECFILE ${openapi_spec_file}
 
-# Build swagger ui deps
-COPY ./scripts/swagger-ui-generator /app/swagger-ui-generator
-RUN cd /app/swagger-ui-generator && ./swagger-ui-generator.sh \
-    --spec-file ${OPENAPICONFIG_MERGEDSPECFILE} \
-    --output ${OPENAPICONFIG_SWAGGERUICONFIG_SERVINGDIRECTORY}
-RUN rm -rf /app/swagger-ui-generator
-
-# Switch back to turing user
-USER ${TURING_USER}
-ARG TURING_UI_DIST_PATH=ui/build
-
-COPY --chown=${TURING_USER}:${TURING_USER_GROUP} ${TURING_UI_DIST_PATH} ${TURINGUICONFIG_SERVINGDIRECTORY}/
+COPY --chown=${TURING_USER}:${TURING_USER_GROUP} --from=swagger-ui /app/swagger-ui ${OPENAPICONFIG_SWAGGERUICONFIG_SERVINGDIRECTORY}/
+COPY --chown=${TURING_USER}:${TURING_USER_GROUP} ${turing_ui_dist_path} ${TURINGUICONFIG_SERVINGDIRECTORY}/
 
 COPY ./docker-entrypoint.sh ./
 
 ENV TURING_UI_DIST_DIR ${TURINGUICONFIG_SERVINGDIRECTORY}
-
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,16 @@ RUN cd /app/swagger-ui-generator && ./swagger-ui-generator.sh \
 
 FROM ${TURING_API_IMAGE}
 
-ARG openapi_spec_file=/app/swagger-ui/openapi.bundle.yaml
-ARG turing_ui_dist_path=ui/build
-
 ARG TURING_USER=${TURING_USER:-turing}
 ARG TURING_USER_GROUP=${TURING_USER_GROUP:-app}
+
+# Install bash
+USER root
+RUN apk add --no-cache bash
+USER ${TURING_USER}
+
+ARG openapi_spec_file=/app/swagger-ui/openapi.bundle.yaml
+ARG turing_ui_dist_path=ui/build
 
 ENV TURINGUICONFIG_SERVINGDIRECTORY "/app/turing-ui"
 

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ build-image: version
 	docker build . \
 		--tag ${IMAGE_TAG} \
 		--build-arg TURING_API_IMAGE \
-		--build-arg TURING_UI_DIST_PATH \
-		--build-arg SWAGGER_UI_DIST_PATH
+		--build-arg TURING_UI_DIST_PATH
 
 .PHONY: version
 version:


### PR DESCRIPTION
Cherry picked from @romanwozniak to fix the docker builds. Turing API was not able to write to the swagger ui folder because the permissions were tied to root rather than the turing user.

Since the CI doesn't cover this, I have built and tested the image locally.