### PR TITLE
Fix batch ensembler Dockerfile

### DIFF
--- a/engines/batch-ensembler/Dockerfile
+++ b/engines/batch-ensembler/Dockerfile
@@ -31,7 +31,7 @@ RUN chmod 644 -R /etc/metrics/conf/*
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # Install wget and other libraries required by Miniconda3
-RUN apt-get update -q && \
+RUN apt-get update --allow-releaseinfo-change-suite -q && \
     apt-get install -q -y \
         bzip2 \
         ca-certificates \


### PR DESCRIPTION
### Context
The current batch ensembler Dockerfile uses Debian 10 (Buster), which has recently (14/8/2021) been superseded by Debian 11 (Bullseye). With Bullseye now becoming the new `stable` release, Buster has been relegated to `oldstable`. This forces the `apt-get update` command [here](https://github.com/gojek/turing/blob/main/engines/batch-ensembler/Dockerfile#L34) to require an explicit approval which terminates the Docker image building process.

This PR introduces an addition of a flag to ignore the `oldstable` release in the update command. This is only a temporary fix while support for Buster remains supported.

### Modifications
- `turing/engines/batch-ensembler/Dockerfile` - addition of a `--allow-releaseinfo-change-suite` flag to the `apt-get update` command 