### PR TITLE
Add Python 3.7 support

### DIFF
--- a/sdk/setup.py
+++ b/sdk/setup.py
@@ -29,5 +29,5 @@ setuptools.setup(
     extras_require={
         'dev': dev_requirements
     },
-    python_requires='>=3.8',
+    python_requires='>=3.7',
 )

--- a/sdk/turing/batch/config/config.py
+++ b/sdk/turing/batch/config/config.py
@@ -113,8 +113,13 @@ class EnsemblingJobConfig:
         )
 
     def infra_spec(self) -> turing.generated.models.EnsemblerInfraConfig:
+        if self.env_vars is None:
+            env_vars = []
+        else:
+            env_vars = [EnvVar(name=name, value=value) for name, value in self.env_vars.items()]\
+
         return turing.generated.models.EnsemblerInfraConfig(
             service_account_name=self.service_account,
             resources=self.resource_request,
-            env=[EnvVar(name=name, value=value) for name, value in self.env_vars.items()],
+            env=env_vars,
         )


### PR DESCRIPTION
### Context
Turing SDK currently supports Python 3.8 and above. In order to accommodate a larger variety of plugins/packages/libraries/etc., we're expanding support of Turing SDK to Python 3.7 and above.

### Fixes 
- `sdk/turing/batch/config/config.py` - add checks to ensure that `env` used to initialise a `EnsemblerInfraConfig` is an empty list if `env_vars` is returned as `None`

### Modifications
- `sdk/setup.py` - replace Python requirement from `>=3.8` to a more general `>=3.7`