### PR TITLE
Update abstract PyFunc to utilise returned treatment_config

### DIFF
--- a/sdk/turing/ensembler.py
+++ b/sdk/turing/ensembler.py
@@ -57,8 +57,8 @@ class PyFunc(EnsemblerBase, mlflow.pyfunc.PythonModel, abc.ABC):
 
     def predict(self, context, model_input: pandas.DataFrame) -> \
             Union[numpy.ndarray, pandas.Series, pandas.DataFrame]:
-        prediction_columns = PyFunc._get_columns_with_header(model_input, PyFunc.PREDICTION_COLUMN_PREFIX)
-        treatment_config_columns = PyFunc._get_columns_with_header(model_input, PyFunc.TREATMENT_CONFIG_COLUMN_PREFIX)
+        prediction_columns = PyFunc._get_columns_with_prefix(model_input, PyFunc.PREDICTION_COLUMN_PREFIX)
+        treatment_config_columns = PyFunc._get_columns_with_prefix(model_input, PyFunc.TREATMENT_CONFIG_COLUMN_PREFIX)
 
         return model_input \
             .rename(columns=prediction_columns) \
@@ -71,10 +71,10 @@ class PyFunc(EnsemblerBase, mlflow.pyfunc.PythonModel, abc.ABC):
                    ), axis=1, result_type='expand')
 
     @staticmethod
-    def _get_columns_with_header(df: pandas.DataFrame, header: str):
+    def _get_columns_with_prefix(df: pandas.DataFrame, prefix: str):
         selected_columns = {
-            col: col[len(header):]
-            for col in df.columns if col.startswith(header)
+            col: col[len(prefix):]
+            for col in df.columns if col.startswith(prefix)
         }
         return selected_columns
 

--- a/sdk/turing/ensembler.py
+++ b/sdk/turing/ensembler.py
@@ -27,15 +27,8 @@ class EnsemblerBase(abc.ABC):
         :param predictions: pandas.Series, containing a single row with all models predictions
                 `predictions['model-a']` will contain prediction results from the model-a
         :param treatment_config: Optional[pandas.Series], representing the configuration of a
-                treatment, that should be applied to a given record/payload.
-
-                For batch experiments, the `treatment_config` can be `None`. If an attribute
-                representing a treatment plan of all the treatments and their respective
-                configuration is set using the `initialize` method, the `treatment_config`
-                for any treatment can be accessed during all calls made to `ensemble`.
-
-                For real-time experiments, the `treatment_config` is either a pandas.Series
-                object, or None, if the experiment engine is not configured.
+                treatment, that should be applied to a given record/payload. If the experiment
+                engine is not configured, then `treatment_config` will be `None`
 
         :returns ensembling result (one of str, int, float, double or array)
         """

--- a/sdk/turing/ensembler.py
+++ b/sdk/turing/ensembler.py
@@ -17,7 +17,7 @@ class EnsemblerBase(abc.ABC):
             self,
             features: pandas.Series,
             predictions: pandas.Series,
-            treatment_config: Optional[dict]) -> Any:
+            treatment_config: Optional[pandas.Series]) -> Any:
         """
         Ensembler should have an ensemble method, that implements the logic on how to
         ensemble final prediction results from individual model predictions and a treatment
@@ -26,9 +26,16 @@ class EnsemblerBase(abc.ABC):
         :param features: pandas.Series, containing a single row with input features
         :param predictions: pandas.Series, containing a single row with all models predictions
                 `predictions['model-a']` will contain prediction results from the model-a
-        :param treatment_config: dictionary, representing the configuration of a treatment,
-                that should be applied to a given record. If the experiment engine is not configured
-                for this Batch experiment, then `treatment_config` will be `None`
+        :param treatment_config: Optional[pandas.Series], representing the configuration of a
+                treatment, that should be applied to a given record/payload.
+
+                For batch experiments, the `treatment_config` can be `None`. If an attribute
+                representing a treatment plan of all the treatments and their respective
+                configuration is set using the `initialize` method, the `treatment_config`
+                for any treatment can be accessed during all calls made to `ensemble`.
+
+                For real-time experiments, the `treatment_config` is either a pandas.Series
+                object, or None, if the experiment engine is not configured.
 
         :returns ensembling result (one of str, int, float, double or array)
         """


### PR DESCRIPTION
### Context
Turing SDK offers an abstract class `PyFunc` from which the concrete `PyFuncEnsembler` is implemented. In particular, this `PyFunc` class implements the abstract method `predict` from its parent `mlflow.pyfunc.PythonModel`, which gets called whenever the `mlflow` model is used to generate predictions (or in this case, ensembling results).

This `predict` method partially implements the batch ensembling logic, i.e. it performs some simple `DataFrame` manipulations by separating a single input `DataFrame` into `DataFrames` corresponding to `features`, `predictions` and `treatment_config`, that subsequently get passed to a user-defined `ensemble` method, which contains the rest (and the crux) of the ensembling logic.

Previously, the `treatment_config` field has always been unused, since in batch ensembling, a treatment can equivalently be defined in the features columns, hence the `None` value being passed to `ensemble` when it gets called by `predict`.

However, as we are moving to implement real-time pyfunc ensemblers that ultimately use the same `PyFuncEnsembler` class (which would allow a user to use the very same ensembler in both batch and real-time ensembling, when the same batch columns/live payload naming convention is used), there is a need to handle any `treatment_config` that appears in a live-ensembling request. 

This PR thus aims to expose this `treatment_config` to the user in the `ensemble` method (which has previously always been a null object), allowing users to manipulate the payload from a live Turing router with a user defined ensembling method in a more intuitive manner.

### Extra Context
In batch ensembling, `predictions` are currently passed to `predict` through the `model_input` argument. These predictions are contained in columns with the `__predictions__` header, due to a tabular join operation upstream by other batch ensembling components. In order to not break the existing naming convention of columns in `model_input`, the future engine for the real-time ensembler will similarly pass `predictions` as well as `treatment_config` as columns in `model_input` with the same naming convention.

### Features
- Extraction of `treatment_config` data that gets passed to `predict` as part of the `model_input` argument into a separate `DataFrame`, which then gets passed to the `ensemble` method as the `treament_config` argument:
- Refactoring of a few lines of existing code used to extract column names with the `__[prefix_name]__` prefix into a static method:
```python
@staticmethod
def _get_columns_with_prefix(df: pandas.DataFrame, prefix: str):
    selected_columns = {
        col: col[len(prefix):]
        for col in df.columns if col.startswith(prefix)
    }
    return selected_columns
```

### Modifications
- `sdk/turing/ensembler.py` - addition of logic to consider `treatment_config` being passed to `predict` as part of the `model_input` argument