### PR TITLE
Fixes #166 [router] Return all response headers unmodified

### DIFF
--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -177,7 +177,9 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	payload := resp.Body()
 
 	// Write the json response to the writer
-	rw.Header().Set("Content-Type", resp.Header().Get("Content-Type"))
+	for key := range resp.Header() {
+		rw.Header().Set(key, resp.Header().Get(key))
+	}
 	rw.Header().Set(turingReqIDHeaderKey, turingReqID)
 	rw.WriteHeader(http.StatusOK)
 	contentLength, err := rw.Write(payload)


### PR DESCRIPTION
### Context:
Issue: https://github.com/gojek/turing/issues/166

### Summary:
* Knative adds the `Accept-Encoding: gzip` header  to each proxied request in all versions before 0.21.x (this behaviour was changed in v0.21: https://github.com/knative/serving/pull/10691)
* Becasue if this, even if a client has sent a request without asking to compress the response, the requests to all internal components (such as routes, enricher, ensembler) will be made with `Accept-Encoding: gzip`, and if any of these components supports compression – the response will be gzipped
* Before sending the response back to the client, Knative looks if the request is compressed (response headers contain `Content-Encoding: gzip`) and decodes it accordingly
* But Turing router doesn't propagate headers from the ensembler, hence `Content-Encoding: gzip` is missing in the response that the router sends back to Knative's queue-proxy. And subsequently, Knative sends the response back to the client unmodified (i.e. compressed)

### Solution:
In order to avoid such an unexpected behavior as returning a compressed response when the client doesn't request it, Turing router needs to let `queue-proxy` know if the response is compressed (i.e. propagate `Content-Encoding` header), so `queue-proxy` can handle it accordingly and decode the response before sending it to the client. 
Currently, Turing router strips all of the response headers except `Content-Type`. This PR fixes this by propagating all of the responses back to the `queue-proxy` (and subsequently – the client).

