### PR TITLE
[BUGFIX] Fix experiment engine plugins in routers with the traffic rules 

### DIFF
--- a/engines/experiment/config/config.go
+++ b/engines/experiment/config/config.go
@@ -1,4 +1,6 @@
-package experiment
+package config
+
+import "encoding/json"
 
 // EngineConfig is a struct used to decode engine's configuration into
 // It consists of an optional PluginBinary (if the experiment engine is implemented
@@ -8,4 +10,12 @@ type EngineConfig struct {
 	PluginBinary        string                 `mapstructure:"plugin_binary"`
 	PluginURL           string                 `mapstructure:"plugin_url"`
 	EngineConfiguration map[string]interface{} `mapstructure:",remain"`
+}
+
+func (c EngineConfig) IsPlugin() bool {
+	return c.PluginBinary != "" || c.PluginURL != ""
+}
+
+func (c EngineConfig) RawEngineConfig() (json.RawMessage, error) {
+	return json.Marshal(c.EngineConfiguration)
 }

--- a/engines/experiment/config/config_test.go
+++ b/engines/experiment/config/config_test.go
@@ -1,9 +1,10 @@
-package experiment_test
+package config_test
 
 import (
 	"testing"
 
-	"github.com/gojek/turing/engines/experiment"
+	"github.com/gojek/turing/engines/experiment/config"
+
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 )
@@ -11,14 +12,14 @@ import (
 func Test_EngineConfigDecoding(t *testing.T) {
 	var suite = map[string]struct {
 		cfg      interface{}
-		expected experiment.EngineConfig
+		expected config.EngineConfig
 		err      string
 	}{
 		"success | plugin": {
 			cfg: map[string]interface{}{
 				"plugin_binary": "path/to/binary",
 			},
-			expected: experiment.EngineConfig{
+			expected: config.EngineConfig{
 				PluginBinary:        "path/to/binary",
 				EngineConfiguration: nil,
 			},
@@ -31,7 +32,7 @@ func Test_EngineConfigDecoding(t *testing.T) {
 					"Key2-1": "Value2-1",
 				},
 			},
-			expected: experiment.EngineConfig{
+			expected: config.EngineConfig{
 				PluginBinary: "path/to/binary",
 				EngineConfiguration: map[string]interface{}{
 					"Key1": "Value1",
@@ -45,7 +46,7 @@ func Test_EngineConfigDecoding(t *testing.T) {
 			cfg: map[string]interface{}{
 				"Key1": "Value1",
 			},
-			expected: experiment.EngineConfig{
+			expected: config.EngineConfig{
 				EngineConfiguration: map[string]interface{}{
 					"Key1": "Value1",
 				},
@@ -64,7 +65,7 @@ func Test_EngineConfigDecoding(t *testing.T) {
 
 	for name, tt := range suite {
 		t.Run(name, func(t *testing.T) {
-			var actual experiment.EngineConfig
+			var actual config.EngineConfig
 			err := mapstructure.Decode(tt.cfg, &actual)
 
 			if tt.err != "" {
@@ -73,6 +74,44 @@ func Test_EngineConfigDecoding(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, actual)
 			}
+		})
+	}
+}
+
+func TestEngineConfig_IsPlugin(t *testing.T) {
+	var suite = map[string]struct {
+		cfg      config.EngineConfig
+		expected bool
+	}{
+		"success | binary path provided": {
+			cfg: config.EngineConfig{
+				PluginBinary: "/app/plugins/my_plugin",
+			},
+			expected: true,
+		},
+		"success | download url provided": {
+			cfg: config.EngineConfig{
+				PluginURL: "http://localhost:8080/plugins/my_plugin",
+			},
+			expected: true,
+		},
+		"success | binary path and download url provided": {
+			cfg: config.EngineConfig{
+				PluginBinary: "/app/plugins/my_plugin",
+				PluginURL:    "http://localhost:8080/plugins/my_plugin",
+			},
+			expected: true,
+		},
+		"success | not provided": {
+			cfg:      config.EngineConfig{},
+			expected: false,
+		},
+	}
+
+	for name, tt := range suite {
+		t.Run(name, func(t *testing.T) {
+			actual := tt.cfg.IsPlugin()
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/engines/experiment/factory_test.go
+++ b/engines/experiment/factory_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gojek/turing/engines/experiment/config"
+
 	"bou.ke/monkey"
 	"github.com/gojek/turing/engines/experiment"
 	"github.com/gojek/turing/engines/experiment/plugin/inproc"
@@ -41,7 +43,7 @@ func Test_NewEngineFactory(t *testing.T) {
 			},
 			withPatch: func(expected experiment.EngineFactory, fn func()) {
 				monkey.Patch(rpc.NewFactory,
-					func(string, json.RawMessage, *zap.SugaredLogger) (*rpc.EngineFactory, error) {
+					func(string, config.EngineConfig, *zap.SugaredLogger) (*rpc.EngineFactory, error) {
 						return expected.(*rpc.EngineFactory), nil
 					},
 				)

--- a/engines/experiment/go.mod
+++ b/engines/experiment/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/go-hclog v0.16.0
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/engines/experiment/go.sum
+++ b/engines/experiment/go.sum
@@ -59,6 +59,8 @@ github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW1
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/engines/experiment/plugin/inproc/factory.go
+++ b/engines/experiment/plugin/inproc/factory.go
@@ -3,6 +3,8 @@ package inproc
 import (
 	"encoding/json"
 
+	"github.com/gojek/turing/engines/experiment/config"
+
 	"github.com/gojek/turing/engines/experiment/manager"
 	managerPlugin "github.com/gojek/turing/engines/experiment/plugin/inproc/manager"
 	runnerPlugin "github.com/gojek/turing/engines/experiment/plugin/inproc/runner"
@@ -24,9 +26,13 @@ func (f *EngineFactory) GetExperimentRunner() (runner.ExperimentRunner, error) {
 	return runnerPlugin.Get(f.EngineName, f.EngineConfig)
 }
 
-func NewEngineFactory(name string, cfg json.RawMessage) (*EngineFactory, error) {
+func NewEngineFactory(name string, cfg config.EngineConfig) (*EngineFactory, error) {
+	engineCfg, err := cfg.RawEngineConfig()
+	if err != nil {
+		return nil, err
+	}
 	return &EngineFactory{
 		EngineName:   name,
-		EngineConfig: cfg,
+		EngineConfig: engineCfg,
 	}, nil
 }

--- a/engines/experiment/plugin/rpc/factory.go
+++ b/engines/experiment/plugin/rpc/factory.go
@@ -86,7 +86,7 @@ func NewFactory(name string, cfg config.EngineConfig, logger *zap.SugaredLogger)
 	factoriesmu.Lock()
 	defer factoriesmu.Unlock()
 
-	// get a hash of the engine's configuration and use it as a fingerprint
+	// get a hash of the engine's configuration and use it as a configuration's fingerprint
 	cfgHash, err := hashstructure.Hash(cfg, hashstructure.FormatV2, nil)
 	if err != nil {
 		return nil, err

--- a/engines/experiment/plugin/rpc/factory_test.go
+++ b/engines/experiment/plugin/rpc/factory_test.go
@@ -34,8 +34,9 @@ func withPatchedConnect(client goPlugin.ClientProtocol, err string, fn func()) {
 
 func TestNewFactory(t *testing.T) {
 	suite := map[string]struct {
-		cfg json.RawMessage
-		err string
+		name string
+		cfg  json.RawMessage
+		err  string
 	}{
 		"success": {
 			cfg: json.RawMessage("{\"key_1\": \"value_1\"}"),
@@ -51,7 +52,7 @@ func TestNewFactory(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			withPatchedConnect(mockClient, tt.err, func() {
-				actual, err := rpc.NewFactory("path/to/plugin", tt.cfg, logger.Sugar())
+				actual, err := rpc.NewFactoryFromBinary("path/to/plugin", tt.cfg, logger.Sugar())
 				if tt.err != "" {
 					assert.EqualError(t, err, tt.err)
 					assert.Nil(t, actual)
@@ -130,7 +131,7 @@ func TestEngineFactory_GetExperimentManager(t *testing.T) {
 				).Once()
 
 			withPatchedConnect(mockClient, "", func() {
-				factory, _ := rpc.NewFactory("path/to/plugin", tt.cfg, logger.Sugar())
+				factory, _ := rpc.NewFactoryFromBinary("path/to/plugin", tt.cfg, logger.Sugar())
 				actual, err := factory.GetExperimentManager()
 
 				if tt.err != "" {

--- a/engines/router/Makefile
+++ b/engines/router/Makefile
@@ -82,12 +82,12 @@ build-image: vendor version
 	@echo "Building docker image: ${IMAGE_TAG}"
 	docker build \
 		--tag ${IMAGE_TAG} \
-		--build-arg BIN_NAME \
-		--build-arg VERSION \
-		--build-arg USER \
-		--build-arg HOST \
-		--build-arg BRANCH \
-		--build-arg NOW \
+		--build-arg BIN_NAME=$(BIN_NAME) \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg USER=$(USER) \
+		--build-arg HOST=$(HOST) \
+		--build-arg BRANCH=$(BRANCH) \
+		--build-arg NOW=$(NOW) \
 		.
 
 .PHONY: swagger-ui

--- a/engines/router/go.sum
+++ b/engines/router/go.sum
@@ -431,6 +431,8 @@ github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=


### PR DESCRIPTION
### Context: 
Turing supports [Traffic Rules](https://github.com/gojek/turing/blob/main/docs/how-to/create-a-router/configure-traffic-rules.md) via Fiber's [LazyRouter](https://github.com/gojek/fiber/blob/main/lazy_router.go), where each route in this LazyRouter is another Fiber component (either [EagerRouter](https://github.com/gojek/fiber/blob/main/eager_router.go) (when standard or no ensembler is used) or [Combiner](https://github.com/gojek/fiber/blob/main/combiner.go) (when Docker ensembler is used)). The configuration of each route contains all the information that this traffic rule's route requires, including the routes activated when this traffic rule is matched and the configuration of the experiment engine, if it's configured on the router. The entire configuration could look something like this:

```yaml
id: my-router
routes:
  - id: traffic-split-default
    routes:
      - endpoint: https://run.mocky.io/v3/5a431baf-95e8-4e45-a3e4-c5018a0ec107
        id: control
        timeout: 2s
        type: PROXY
    strategy:
      properties:
        default_route_id: control
        experiment_engine: my-engine
        experiment_engine_properties:         
          plugin_url: http://plugins-server:8080/plugins/my-engine
          timeout: 1s
      type: fiber.DefaultTuringRoutingStrategy
    type: EAGER_ROUTER
  - id: traffic-split-0
    routes:
      - endpoint: https://run.mocky.io/v3/5a431baf-95e8-4e45-a3e4-c5018a0ec107
        id: control
        timeout: 2s
        type: PROXY
      - endpoint: https://run.mocky.io/v3/fb120af8-0127-4fde-8e42-288958b37ad4
        id: route-a
        timeout: 1.5s
        type: PROXY
    strategy:
      properties:
        default_route_id: control
        experiment_engine: my-engine
        experiment_engine_properties:         
          plugin_url: http://plugins-server:8080/plugins/my-engine
          timeout: 1s
      type: fiber.DefaultTuringRoutingStrategy
    type: EAGER_ROUTER  
strategy:
  properties:
    default_route_id: traffic-split-default
    rules:
      - conditions:
          - field: X-Route
            field_source: header
            operator: in
            values: ["A"]
        route_id: traffic-split-0
  type: fiber.TrafficSplittingStrategy
type: LAZY_ROUTER
```  

### Problem:
From the example above, it's seen, that `routes.0.strategy` == `routes.1.strategy` which is expected because the experiment configuration is common for each traffic rule within the same router. The problem, however, happens when the router is using an RPC plugin to interact with the experiment engine. 

In this case, each traffic rule will launch the same RPC plugin in a separate process, which isn't really necessary. Also, when the router is configured to download the plugin from a remote URL (see. `routes.0.strategy.properties.experiment_engine_properties.plugin_url`), in certain cases, it fails to initialize the ExperimentRunner, because, during the initialization of multiple traffic rule, each route's Fiber component tries to download the plugin binary into the same location which may leave the binary in a broken state.

### Fix:
This PR fixes the described issue by keeping track of the experiment engines factories that have already been initialized and preventing new factories from being created when the same factory already exists in the turing-router process. This is achieved by storing the references to the initialized factory objects in the local key-value registry.
