### PR TITLE
Set kafka message size and compression as configurable

### DIFF
--- a/api/turing/api/request/request.go
+++ b/api/turing/api/request/request.go
@@ -162,6 +162,8 @@ func (r CreateOrUpdateRouterRequest) BuildRouterVersion(
 			Brokers:             r.Config.LogConfig.KafkaConfig.Brokers,
 			Topic:               r.Config.LogConfig.KafkaConfig.Topic,
 			SerializationFormat: r.Config.LogConfig.KafkaConfig.SerializationFormat,
+			MaxMessageBytes:     defaults.KafkaConfig.MaxMessageBytes,
+			CompressionType:     defaults.KafkaConfig.CompressionType,
 		}
 	}
 	if rv.ExperimentEngine.Type != models.ExperimentEngineTypeNop {

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -254,8 +254,8 @@ func (sb *clusterSvcBuilder) buildRouterEnvs(
 			{Name: envKafkaBrokers, Value: logConfig.KafkaConfig.Brokers},
 			{Name: envKafkaTopic, Value: logConfig.KafkaConfig.Topic},
 			{Name: envKafkaSerializationFormat, Value: string(logConfig.KafkaConfig.SerializationFormat)},
-			{Name: envKafkaMaxMessageBytes, Value: logConfig.KafkaConfig.Topic},
-			{Name: envKafkaCompressionType, Value: string(logConfig.KafkaConfig.SerializationFormat)},
+			{Name: envKafkaMaxMessageBytes, Value: strconv.Itoa(logConfig.KafkaConfig.MaxMessageBytes)},
+			{Name: envKafkaCompressionType, Value: string(logConfig.KafkaConfig.CompressionType)},
 		}...)
 	}
 

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -45,6 +45,8 @@ const (
 	envKafkaBrokers                 = "APP_KAFKA_BROKERS"
 	envKafkaTopic                   = "APP_KAFKA_TOPIC"
 	envKafkaSerializationFormat     = "APP_KAFKA_SERIALIZATION_FORMAT"
+	envKafkaMaxMessageBytes         = "APP_KAFKA_MAX_MESSAGE_BYTES"
+	envKafkaCompressionType         = "APP_KAFKA_COMPRESSION_TYPE"
 	envRouterConfigFile             = "ROUTER_CONFIG_FILE"
 	envGoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
 )
@@ -252,6 +254,8 @@ func (sb *clusterSvcBuilder) buildRouterEnvs(
 			{Name: envKafkaBrokers, Value: logConfig.KafkaConfig.Brokers},
 			{Name: envKafkaTopic, Value: logConfig.KafkaConfig.Topic},
 			{Name: envKafkaSerializationFormat, Value: string(logConfig.KafkaConfig.SerializationFormat)},
+			{Name: envKafkaMaxMessageBytes, Value: logConfig.KafkaConfig.Topic},
+			{Name: envKafkaCompressionType, Value: string(logConfig.KafkaConfig.SerializationFormat)},
 		}...)
 	}
 

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -255,7 +255,7 @@ func (sb *clusterSvcBuilder) buildRouterEnvs(
 			{Name: envKafkaTopic, Value: logConfig.KafkaConfig.Topic},
 			{Name: envKafkaSerializationFormat, Value: string(logConfig.KafkaConfig.SerializationFormat)},
 			{Name: envKafkaMaxMessageBytes, Value: strconv.Itoa(logConfig.KafkaConfig.MaxMessageBytes)},
-			{Name: envKafkaCompressionType, Value: string(logConfig.KafkaConfig.CompressionType)},
+			{Name: envKafkaCompressionType, Value: logConfig.KafkaConfig.CompressionType},
 		}...)
 	}
 

--- a/api/turing/cluster/servicebuilder/router_test.go
+++ b/api/turing/cluster/servicebuilder/router_test.go
@@ -554,7 +554,7 @@ func TestNewRouterEndpoint(t *testing.T) {
 	assert.Equal(t, expected, got)
 }
 
-func Test_clusterSvcBuilder_buildRouterEnvs_resultlogger(t *testing.T) {
+func TestBuildRouterEnvsResultLogger(t *testing.T) {
 	type args struct {
 		namespace               string
 		environmentType         string

--- a/api/turing/cluster/servicebuilder/router_test.go
+++ b/api/turing/cluster/servicebuilder/router_test.go
@@ -503,6 +503,7 @@ func TestNewRouterService(t *testing.T) {
 			}
 			svc, err := sb.NewRouterService(&routerVersion, project, "test-env", "service-account",
 				data.expRawConfig, "fluentd-tag", "jaeger-endpoint", true, "sentry-dsn", 1, 20, 1.5)
+
 			if data.err == "" {
 				require.NoError(t, err)
 				assert.Equal(t, data.expected, svc)

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -275,6 +275,8 @@ type RouterDefaults struct {
 	// 	blue-exp-engine:
 	//	  Image: ghcr.io/myproject/blue-exp-engine-plugin:v0.0.1
 	ExperimentEnginePlugins map[string]*ExperimentEnginePluginConfig `validate:"dive"`
+	// Kafka Configuration. If result logging is using Kafka
+	KafkaConfig *KafkaConfig
 }
 
 // FluentdConfig captures the defaults used by the Turing Router when Fluentd is enabled
@@ -285,6 +287,14 @@ type FluentdConfig struct {
 	Tag string
 	// Flush interval seconds - value determined by load job frequency to BQ
 	FlushIntervalSeconds int
+}
+
+// KafkaConfig captures the defaults used by Turing Router when result logger is set to kafka
+type KafkaConfig struct {
+	// Producer Config - Max message byte to send to broker
+	MaxMessageBytes int
+	// Producer Config - Compression Type of message
+	CompressionType string
 }
 
 // AuthorizationConfig captures the config for auth using mlp authz
@@ -469,6 +479,8 @@ func setDefaultValues(v *viper.Viper) {
 	v.SetDefault("RouterDefaults::FluentdConfig::Tag", "turing-result.log")
 	v.SetDefault("RouterDefaults::FluentdConfig::FlushIntervalSeconds", "90")
 	v.SetDefault("RouterDefaults::Experiment", map[string]interface{}{})
+	v.SetDefault("RouterDefaults::KafkaConfig::MaxMessageBytes", "1048588")
+	v.SetDefault("RouterDefaults::KafkaConfig::CompressionType", "none")
 
 	v.SetDefault("Sentry::Enabled", "false")
 	v.SetDefault("Sentry::DSN", "")

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -146,6 +146,10 @@ func TestLoad(t *testing.T) {
 						Tag:                  "turing-result.log",
 						FlushIntervalSeconds: 90,
 					},
+					KafkaConfig: &config.KafkaConfig{
+						MaxMessageBytes: 1048588,
+						CompressionType: "none",
+					},
 				},
 				Sentry: sentry.Config{},
 				ClusterConfig: config.ClusterConfig{
@@ -207,6 +211,10 @@ func TestLoad(t *testing.T) {
 					FluentdConfig: &config.FluentdConfig{
 						Tag:                  "turing-result.log",
 						FlushIntervalSeconds: 60,
+					},
+					KafkaConfig: &config.KafkaConfig{
+						MaxMessageBytes: 1048588,
+						CompressionType: "none",
 					},
 				},
 				Sentry: sentry.Config{
@@ -293,6 +301,10 @@ func TestLoad(t *testing.T) {
 					ExperimentEnginePlugins: map[string]*config.ExperimentEnginePluginConfig{
 						"red":  {Image: "ghcr.io/myproject/red-exp-engine-plugin:v0.0.1"},
 						"blue": {Image: "ghcr.io/myproject/blue-exp-engine-plugin:latest"},
+					},
+					KafkaConfig: &config.KafkaConfig{
+						MaxMessageBytes: 1234567,
+						CompressionType: "snappy",
 					},
 				},
 				Sentry: sentry.Config{
@@ -399,6 +411,10 @@ func TestLoad(t *testing.T) {
 					ExperimentEnginePlugins: map[string]*config.ExperimentEnginePluginConfig{
 						"red":  {Image: "ghcr.io/myproject/red-exp-engine-plugin:v0.0.1"},
 						"blue": {Image: "ghcr.io/myproject/blue-exp-engine-plugin:latest"},
+					},
+					KafkaConfig: &config.KafkaConfig{
+						MaxMessageBytes: 1234567,
+						CompressionType: "snappy",
 					},
 				},
 				Sentry: sentry.Config{

--- a/api/turing/config/testdata/config-2.yaml
+++ b/api/turing/config/testdata/config-2.yaml
@@ -16,6 +16,9 @@ RouterDefaults:
       Image: ghcr.io/myproject/red-exp-engine-plugin:v0.0.1
     blue:
       Image: ghcr.io/myproject/blue-exp-engine-plugin:latest
+  KafkaConfig:
+    MaxMessageBytes: 1234567
+    CompressionType: snappy
 Experiment:
     qux:
       quxkey1: quxval1-override

--- a/api/turing/models/log_config.go
+++ b/api/turing/models/log_config.go
@@ -52,6 +52,10 @@ type KafkaConfig struct {
 	Topic string `json:"topic"`
 	// Serialization Format used for the messages
 	SerializationFormat SerializationFormat `json:"serialization_format"`
+	// Producer Config - Max message byte to send to broker
+	MaxMessageBytes int `json:"max_message_bytes"`
+	// Producer Config - Compression Type of message
+	CompressionType string `json:"compression_type"`
 }
 
 // LogConfig contains all log configuration necessary for a deployment

--- a/api/turing/models/log_config_test.go
+++ b/api/turing/models/log_config_test.go
@@ -59,6 +59,8 @@ func TestLogConfigValue(t *testing.T) {
 					Brokers:             "test-brokers",
 					Topic:               "test-topic",
 					SerializationFormat: "test-serialization",
+					MaxMessageBytes:     10000,
+					CompressionType:     "none",
 				},
 			},
 			expected: string(`{
@@ -70,7 +72,9 @@ func TestLogConfigValue(t *testing.T) {
 				"kafka_config": {
 					"brokers": "test-brokers",
 					"topic": "test-topic",
-					"serialization_format": "test-serialization"
+					"serialization_format": "test-serialization",
+					"max_message_bytes" : 10000,
+					"compression_type" : "none"
 				}
 			}`),
 		},

--- a/engines/router/missionctl/config/config.go
+++ b/engines/router/missionctl/config/config.go
@@ -95,6 +95,8 @@ type KafkaConfig struct {
 	Brokers             string
 	Topic               string
 	SerializationFormat SerializationFormat `split_words:"true"`
+	MaxMessageBytes     int                 `split_words:"true" default:"1048588"`
+	CompressionType     string              `split_words:"true" default:"none"`
 }
 
 // JaegerConfig captures the settings for tracing using Jaeger client

--- a/engines/router/missionctl/config/config_test.go
+++ b/engines/router/missionctl/config/config_test.go
@@ -110,6 +110,8 @@ func TestInitConfigDefaultEnvs(t *testing.T) {
 				Brokers:             "",
 				Topic:               "",
 				SerializationFormat: SerializationFormat(""),
+				MaxMessageBytes:     1048588,
+				CompressionType:     "none",
 			},
 			CustomMetrics: false,
 			Jaeger: &JaegerConfig{

--- a/engines/router/missionctl/config/config_test.go
+++ b/engines/router/missionctl/config/config_test.go
@@ -174,6 +174,8 @@ func TestInitConfigEnv(t *testing.T) {
 				Brokers:             "localhost:9000",
 				Topic:               "kafka_topic",
 				SerializationFormat: JSONSerializationFormat,
+				MaxMessageBytes:     1048588,
+				CompressionType:     "none",
 			},
 			CustomMetrics: true,
 			Jaeger: &JaegerConfig{

--- a/engines/router/missionctl/log/resultlog/kafka.go
+++ b/engines/router/missionctl/log/resultlog/kafka.go
@@ -53,7 +53,11 @@ func newKafkaLogger(cfg *config.KafkaConfig) (*KafkaLogger, error) {
 }
 
 func newKafkaProducer(cfg *config.KafkaConfig) (kafkaProducer, error) {
-	producer, err := kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": cfg.Brokers, "message.max.bytes": 10485760})
+	producer, err := kafka.NewProducer(
+		&kafka.ConfigMap{
+			"bootstrap.servers": cfg.Brokers,
+			"message.max.bytes": cfg.MaxMessageBytes,
+			"compression.type":  cfg.CompressionType})
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error initializing Kafka Producer")
 	}


### PR DESCRIPTION
# Overview
This MR is a follow up from the [previous](https://github.com/gojek/turing/pull/172), it allows
`max.request.size` and `compression.type` of the Kafka producer configuration to be set in helm values when deploying Turing Server.

# Modification
`api/turing/api/request/request.go` - Appended `MaxMessageBytes` and `CompressionType` during building of new router version when logger type is kafka.
`api/turing/cluster/servicebuilder/router.go` - Creating router with env var `APP_KAFKA_MAX_MESSAGE_BYTES` and `APP_KAFKA_COMPRESSION_TYPE`
`engines/router/missionctl/log/resultlog/kafka.go` - Router's logger to init with config, which are read from env var during initialisation.

# Testing
Setting router default in Turing Server helms value
![image](https://user-images.githubusercontent.com/30390872/156917447-f8ec3157-a385-4a19-a830-310b9808dc96.png)

Router container env var set with the global values
![image](https://user-images.githubusercontent.com/30390872/156917486-99142e31-a77f-43d4-8028-944cd423f60e.png)
