### PR TITLE
Add steps to merge original request and enricher response headers

### DIFF
--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -91,6 +91,9 @@ func (h *httpHandler) getPrediction(
 
 	// Enrich
 	var resp mchttp.Response
+	// Creates a new map to represent the merged headers from the original request headers + enricher response headers
+	postEnrichmentResponseHeader := req.Header.Clone()
+
 	payload := requestBody
 	if h.IsEnricherEnabled() {
 		resp, httpErr := h.Enrich(ctx, req.Header, payload)
@@ -100,13 +103,17 @@ func (h *httpHandler) getPrediction(
 		if httpErr != nil {
 			return nil, httpErr
 		}
+		// Merge Enricher response headers with original request headers
+		for key, value := range resp.Header() {
+			postEnrichmentResponseHeader.Set(key, value[0])
+		}
 		// No error, copy response body
 		payload = resp.Body()
 	}
 
 	// Route
 	var expResp *experiment.Response
-	expResp, resp, httpErr := h.Route(ctx, req.Header, payload)
+	expResp, resp, httpErr := h.Route(ctx, postEnrichmentResponseHeader, payload)
 	if expResp != nil {
 		var expErr *errors.HTTPError
 		if expResp.Error != "" {

--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -104,8 +104,8 @@ func (h *httpHandler) getPrediction(
 			return nil, httpErr
 		}
 		// Merge Enricher response headers with original request headers
-		for key, value := range resp.Header() {
-			postEnrichmentResponseHeader.Set(key, value[0])
+		for key := range resp.Header() {
+			postEnrichmentResponseHeader.Set(key, resp.Header().Get(key))
 		}
 		// No error, copy response body
 		payload = resp.Body()


### PR DESCRIPTION
This PR introduces a minor change to merge the headers of the original request sent to Turing routers with that of the response returned from an enricher.

This in effect parses the enricher response headers for downstream traffic rules and experiment input, but *does not* parse them for ensembling.

# Modifications
- `engines/router/missionctl/handlers/http_handler.go` - Addition of a few lines of code to merge the headers of the original request and enricher response