### PR TITLE
Standardize labels for kube objects

### DIFF
--- a/api/turing/batch/ensembling/controller.go
+++ b/api/turing/batch/ensembling/controller.go
@@ -203,7 +203,11 @@ func (c *ensemblingController) createSparkApplication(
 	return c.clusterController.CreateSparkApplication(jobRequest.Namespace, request)
 }
 
-func (c *ensemblingController) createJobConfigMap(ensemblingJob *models.EnsemblingJob, namespace string, labels map[string]string) error {
+func (c *ensemblingController) createJobConfigMap(
+	ensemblingJob *models.EnsemblingJob,
+	namespace string,
+	labels map[string]string,
+) error {
 	jobConfigJSON, err := json.Marshal(ensemblingJob.JobConfig)
 	if err != nil {
 		return err

--- a/api/turing/batch/ensembling/controller.go
+++ b/api/turing/batch/ensembling/controller.go
@@ -121,7 +121,7 @@ func (c *ensemblingController) Create(request *CreateEnsemblingJobRequest) error
 		return fmt.Errorf("failed creating namespace %s: %v", request.Namespace, err)
 	}
 
-	serviceAccount, err := c.createSparkDriverAuthorization(request.Namespace)
+	serviceAccount, err := c.createSparkDriverAuthorization(request.Namespace, request.Labels)
 	if err != nil {
 		return fmt.Errorf(
 			"failed creating spark driver authorization in namespace %s: %v",
@@ -239,6 +239,7 @@ func (c *ensemblingController) createSecret(request *CreateEnsemblingJobRequest,
 		Data: map[string]string{
 			cluster.ServiceAccountFileName: secretName,
 		},
+		Labels: request.Labels,
 	}
 	// I'm not sure why we need to pass in a context here but not other kubernetes cluster functions.
 	// Leaving a context.TODO() until we figure out what to do with this.
@@ -262,20 +263,38 @@ func (c *ensemblingController) cleanup(jobName string, namespace string) {
 	}
 }
 
-func (c *ensemblingController) createSparkDriverAuthorization(namespace string) (*apicorev1.ServiceAccount, error) {
+func (c *ensemblingController) createSparkDriverAuthorization(namespace string, labels map[string]string) (*apicorev1.ServiceAccount, error) {
 	serviceAccountName, roleName, roleBindingName := createAuthorizationResourceNames(namespace)
 
-	sa, err := c.clusterController.CreateServiceAccount(namespace, serviceAccountName)
+	saCfg := &cluster.ServiceAccount{
+		Name:      serviceAccountName,
+		Namespace: namespace,
+		Labels:    labels,
+	}
+	sa, err := c.clusterController.CreateServiceAccount(namespace, saCfg)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := c.clusterController.CreateRole(namespace, roleName, cluster.DefaultSparkDriverRoleRules)
+	roleCfg := &cluster.Role{
+		Name:        roleName,
+		Namespace:   namespace,
+		Labels:      labels,
+		PolicyRules: cluster.DefaultSparkDriverRoleRules,
+	}
+	r, err := c.clusterController.CreateRole(namespace, roleCfg)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = c.clusterController.CreateRoleBinding(namespace, roleBindingName, sa.Name, r.Name)
+	roleBindingCfg := &cluster.RoleBinding{
+		Name:               roleBindingName,
+		Namespace:          namespace,
+		Labels:             labels,
+		RoleName:           r.Name,
+		ServiceAccountName: sa.Name,
+	}
+	_, err = c.clusterController.CreateRoleBinding(namespace, roleBindingCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/api/turing/batch/ensembling/controller.go
+++ b/api/turing/batch/ensembling/controller.go
@@ -153,7 +153,7 @@ func (c *ensemblingController) Create(request *CreateEnsemblingJobRequest) error
 		)
 	}
 
-	err = c.createJobConfigMap(request.EnsemblingJob, request.Namespace)
+	err = c.createJobConfigMap(request.EnsemblingJob, request.Namespace, request.Labels)
 	if err != nil {
 		return fmt.Errorf(
 			"failed creating job specification configmap for job %s in namespace %s: %v",
@@ -203,7 +203,7 @@ func (c *ensemblingController) createSparkApplication(
 	return c.clusterController.CreateSparkApplication(jobRequest.Namespace, request)
 }
 
-func (c *ensemblingController) createJobConfigMap(ensemblingJob *models.EnsemblingJob, namespace string) error {
+func (c *ensemblingController) createJobConfigMap(ensemblingJob *models.EnsemblingJob, namespace string, labels map[string]string) error {
 	jobConfigJSON, err := json.Marshal(ensemblingJob.JobConfig)
 	if err != nil {
 		return err
@@ -218,6 +218,7 @@ func (c *ensemblingController) createJobConfigMap(ensemblingJob *models.Ensembli
 		Name:     ensemblingJob.Name,
 		FileName: batch.JobConfigFileName,
 		Data:     string(jobConfigYAML),
+		Labels:   labels,
 	}
 	err = c.clusterController.ApplyConfigMap(namespace, cm)
 	if err != nil {

--- a/api/turing/batch/ensembling/controller.go
+++ b/api/turing/batch/ensembling/controller.go
@@ -263,7 +263,10 @@ func (c *ensemblingController) cleanup(jobName string, namespace string) {
 	}
 }
 
-func (c *ensemblingController) createSparkDriverAuthorization(namespace string, labels map[string]string) (*apicorev1.ServiceAccount, error) {
+func (c *ensemblingController) createSparkDriverAuthorization(
+	namespace string,
+	labels map[string]string,
+) (*apicorev1.ServiceAccount, error) {
 	serviceAccountName, roleName, roleBindingName := createAuthorizationResourceNames(namespace)
 
 	saCfg := &cluster.ServiceAccount{

--- a/api/turing/cluster/controller.go
+++ b/api/turing/cluster/controller.go
@@ -218,6 +218,7 @@ func (c *controller) ApplyConfigMap(namespace string, configMap *ConfigMap) erro
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMap.Name,
 			Namespace: namespace,
+			Labels:    configMap.Labels,
 		},
 		Data: map[string]string{
 			configMap.FileName: configMap.Data,
@@ -491,7 +492,7 @@ func (c *controller) ApplyPersistentVolumeClaim(
 	return err
 }
 
-// ApplyPersistentVolumeClaim deletes the PVC in the given namespace.
+// DeletePersistentVolumeClaim deletes the PVC in the given namespace.
 func (c *controller) DeletePersistentVolumeClaim(pvcName string, namespace string) error {
 	pvcs := c.k8sCoreClient.PersistentVolumeClaims(namespace)
 	_, err := pvcs.Get(pvcName, metav1.GetOptions{})

--- a/api/turing/cluster/controller_test.go
+++ b/api/turing/cluster/controller_test.go
@@ -973,15 +973,18 @@ func TestCreateNamespace(t *testing.T) {
 
 func TestCreateConfigMap(t *testing.T) {
 	namespace := "namespace"
+	labels := map[string]string{"key": "value"}
 	cmap := ConfigMap{
 		Name:     "my-data",
 		FileName: "key",
 		Data:     "value",
+		Labels:   labels,
 	}
 	k8scmap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmap.Name,
 			Namespace: namespace,
+			Labels:    labels,
 		},
 		Data: map[string]string{
 			cmap.FileName: cmap.Data,

--- a/api/turing/cluster/controller_test.go
+++ b/api/turing/cluster/controller_test.go
@@ -626,6 +626,7 @@ func TestDeleteJob(t *testing.T) {
 func TestCreateServiceAccount(t *testing.T) {
 	namespace := "test-ns"
 	serviceAccountName := "bicycle"
+	labels := map[string]string{"key": "val"}
 	tests := map[string]struct {
 		reactors  []reactor
 		errNil    bool
@@ -677,7 +678,12 @@ func TestCreateServiceAccount(t *testing.T) {
 				k8sRBACClient:  cs.RbacV1(),
 				k8sCoreClient:  cs.CoreV1(),
 			}
-			svcAcc, err := c.CreateServiceAccount(namespace, serviceAccountName)
+			saCfg := &ServiceAccount{
+				Name:      serviceAccountName,
+				Namespace: namespace,
+				Labels:    labels,
+			}
+			svcAcc, err := c.CreateServiceAccount(namespace, saCfg)
 			assert.True(t, (err == nil) == tt.errNil)
 			assert.True(t, (svcAcc == nil) == tt.svcAccNil)
 		})
@@ -687,12 +693,13 @@ func TestCreateServiceAccount(t *testing.T) {
 func TestCreateRole(t *testing.T) {
 	namespace := "test-ns"
 	roleName := "bicycle"
+	labels := map[string]string{"key": "val"}
 	tests := map[string]struct {
 		reactors []reactor
 		errNil   bool
 		roleNil  bool
 	}{
-		"success | service account exists": {
+		"success | role exists": {
 			reactors: []reactor{
 				{
 					verb:     reactorVerbs.Get,
@@ -709,7 +716,7 @@ func TestCreateRole(t *testing.T) {
 			errNil:  true,
 			roleNil: false,
 		},
-		"success | service account created": {
+		"success | role created": {
 			reactors: []reactor{
 				{
 					verb:     reactorVerbs.Create,
@@ -738,7 +745,12 @@ func TestCreateRole(t *testing.T) {
 				k8sRBACClient:  cs.RbacV1(),
 				k8sCoreClient:  cs.CoreV1(),
 			}
-			role, err := c.CreateRole(namespace, roleName, DefaultSparkDriverRoleRules)
+			roleCfg := &Role{
+				Name:      roleName,
+				Namespace: namespace,
+				Labels:    labels,
+			}
+			role, err := c.CreateRole(namespace, roleCfg)
 			assert.True(t, (err == nil) == tt.errNil)
 			assert.True(t, (role == nil) == tt.roleNil)
 		})
@@ -750,6 +762,7 @@ func TestCreateRoleBinding(t *testing.T) {
 	roleName := "bicycle"
 	roleBindingName := "wd-40"
 	serviceAccountName := "bicycle-shop"
+	labels := map[string]string{"key": "val"}
 	tests := map[string]struct {
 		reactors []reactor
 		errNil   bool
@@ -801,7 +814,14 @@ func TestCreateRoleBinding(t *testing.T) {
 				k8sRBACClient:  cs.RbacV1(),
 				k8sCoreClient:  cs.CoreV1(),
 			}
-			role, err := c.CreateRoleBinding(namespace, roleBindingName, serviceAccountName, roleName)
+			roleBindingCfg := &RoleBinding{
+				Name:               roleBindingName,
+				Namespace:          namespace,
+				Labels:             labels,
+				RoleName:           roleName,
+				ServiceAccountName: serviceAccountName,
+			}
+			role, err := c.CreateRoleBinding(namespace, roleBindingCfg)
 			assert.True(t, (err == nil) == tt.errNil)
 			assert.True(t, (role == nil) == tt.roleNil)
 		})
@@ -1070,6 +1090,9 @@ func TestCreateSecret(t *testing.T) {
 		Name:      "secret",
 		Namespace: testNamespace,
 		Data: map[string]string{
+			"key": "value",
+		},
+		Labels: map[string]string{
 			"key": "value",
 		},
 	}

--- a/api/turing/cluster/mocks/controller.go
+++ b/api/turing/cluster/mocks/controller.go
@@ -106,13 +106,13 @@ func (_m *Controller) CreateNamespace(name string) error {
 	return r0
 }
 
-// CreateRole provides a mock function with given fields: namespace, roleName, policyRules
-func (_m *Controller) CreateRole(namespace string, roleName string, policyRules []rbacv1.PolicyRule) (*rbacv1.Role, error) {
-	ret := _m.Called(namespace, roleName, policyRules)
+// CreateRole provides a mock function with given fields: namespace, role
+func (_m *Controller) CreateRole(namespace string, role *cluster.Role) (*rbacv1.Role, error) {
+	ret := _m.Called(namespace, role)
 
 	var r0 *rbacv1.Role
-	if rf, ok := ret.Get(0).(func(string, string, []rbacv1.PolicyRule) *rbacv1.Role); ok {
-		r0 = rf(namespace, roleName, policyRules)
+	if rf, ok := ret.Get(0).(func(string, *cluster.Role) *rbacv1.Role); ok {
+		r0 = rf(namespace, role)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*rbacv1.Role)
@@ -120,8 +120,8 @@ func (_m *Controller) CreateRole(namespace string, roleName string, policyRules 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, []rbacv1.PolicyRule) error); ok {
-		r1 = rf(namespace, roleName, policyRules)
+	if rf, ok := ret.Get(1).(func(string, *cluster.Role) error); ok {
+		r1 = rf(namespace, role)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -129,13 +129,13 @@ func (_m *Controller) CreateRole(namespace string, roleName string, policyRules 
 	return r0, r1
 }
 
-// CreateRoleBinding provides a mock function with given fields: namespace, roleBindingName, serviceAccountName, roleName
-func (_m *Controller) CreateRoleBinding(namespace string, roleBindingName string, serviceAccountName string, roleName string) (*rbacv1.RoleBinding, error) {
-	ret := _m.Called(namespace, roleBindingName, serviceAccountName, roleName)
+// CreateRoleBinding provides a mock function with given fields: namespace, roleBinding
+func (_m *Controller) CreateRoleBinding(namespace string, roleBinding *cluster.RoleBinding) (*rbacv1.RoleBinding, error) {
+	ret := _m.Called(namespace, roleBinding)
 
 	var r0 *rbacv1.RoleBinding
-	if rf, ok := ret.Get(0).(func(string, string, string, string) *rbacv1.RoleBinding); ok {
-		r0 = rf(namespace, roleBindingName, serviceAccountName, roleName)
+	if rf, ok := ret.Get(0).(func(string, *cluster.RoleBinding) *rbacv1.RoleBinding); ok {
+		r0 = rf(namespace, roleBinding)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*rbacv1.RoleBinding)
@@ -143,8 +143,8 @@ func (_m *Controller) CreateRoleBinding(namespace string, roleBindingName string
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, string) error); ok {
-		r1 = rf(namespace, roleBindingName, serviceAccountName, roleName)
+	if rf, ok := ret.Get(1).(func(string, *cluster.RoleBinding) error); ok {
+		r1 = rf(namespace, roleBinding)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -166,13 +166,13 @@ func (_m *Controller) CreateSecret(ctx context.Context, secret *cluster.Secret) 
 	return r0
 }
 
-// CreateServiceAccount provides a mock function with given fields: namespace, serviceAccountName
-func (_m *Controller) CreateServiceAccount(namespace string, serviceAccountName string) (*corev1.ServiceAccount, error) {
-	ret := _m.Called(namespace, serviceAccountName)
+// CreateServiceAccount provides a mock function with given fields: namespace, serviceAccount
+func (_m *Controller) CreateServiceAccount(namespace string, serviceAccount *cluster.ServiceAccount) (*corev1.ServiceAccount, error) {
+	ret := _m.Called(namespace, serviceAccount)
 
 	var r0 *corev1.ServiceAccount
-	if rf, ok := ret.Get(0).(func(string, string) *corev1.ServiceAccount); ok {
-		r0 = rf(namespace, serviceAccountName)
+	if rf, ok := ret.Get(0).(func(string, *cluster.ServiceAccount) *corev1.ServiceAccount); ok {
+		r0 = rf(namespace, serviceAccount)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*corev1.ServiceAccount)
@@ -180,8 +180,8 @@ func (_m *Controller) CreateServiceAccount(namespace string, serviceAccountName 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(namespace, serviceAccountName)
+	if rf, ok := ret.Get(1).(func(string, *cluster.ServiceAccount) error); ok {
+		r1 = rf(namespace, serviceAccount)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/api/turing/cluster/models.go
+++ b/api/turing/cluster/models.go
@@ -124,9 +124,10 @@ type Port struct {
 
 // ConfigMap contains information to create a config map
 type ConfigMap struct {
-	Name     string `json:"name"`
-	FileName string `json:"file_name"`
-	Data     string `json:"data"`
+	Name     string            `json:"name"`
+	FileName string            `json:"file_name"`
+	Data     string            `json:"data"`
+	Labels   map[string]string `json:"labels"`
 }
 
 // Ref:

--- a/api/turing/cluster/pvc.go
+++ b/api/turing/cluster/pvc.go
@@ -12,6 +12,7 @@ type PersistentVolumeClaim struct {
 	Namespace   string            `json:"namespace"`
 	AccessModes []string          `json:"access_modes"`
 	Size        resource.Quantity `json:"size"`
+	Labels      map[string]string `json:"labels"`
 }
 
 func (pvc *PersistentVolumeClaim) BuildPersistentVolumeClaim() *corev1.PersistentVolumeClaim {
@@ -24,6 +25,7 @@ func (pvc *PersistentVolumeClaim) BuildPersistentVolumeClaim() *corev1.Persisten
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvc.Name,
 			Namespace: pvc.Namespace,
+			Labels:    pvc.Labels,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: accessModes,

--- a/api/turing/cluster/pvc_test.go
+++ b/api/turing/cluster/pvc_test.go
@@ -13,17 +13,20 @@ func TestBuildPVC(t *testing.T) {
 	qty, err := resource.ParseQuantity("2Gi")
 	assert.NoError(t, err)
 	testNamespace := "namespace"
+	labels := map[string]string{"key": "value"}
 	pvcCfg := PersistentVolumeClaim{
 		Name:        "cache-volume",
 		Namespace:   testNamespace,
 		AccessModes: []string{"ReadWriteOnce"},
 		Size:        qty,
+		Labels:      labels,
 	}
 	volumeMode := corev1.PersistentVolumeFilesystem
 	expected := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cache-volume",
 			Namespace: testNamespace,
+			Labels:    labels,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{

--- a/api/turing/cluster/role.go
+++ b/api/turing/cluster/role.go
@@ -1,0 +1,25 @@
+package cluster
+
+import (
+	apirbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Role contains the information to build a role
+type Role struct {
+	Name        string                 `json:"name"`
+	Namespace   string                 `json:"namespace"`
+	Labels      map[string]string      `json:"labels"`
+	PolicyRules []apirbacv1.PolicyRule `json:"rules"`
+}
+
+func (r *Role) BuildRole() *apirbacv1.Role {
+	return &apirbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.Name,
+			Namespace: r.Namespace,
+			Labels:    r.Labels,
+		},
+		Rules: r.PolicyRules,
+	}
+}

--- a/api/turing/cluster/role_binding.go
+++ b/api/turing/cluster/role_binding.go
@@ -1,0 +1,37 @@
+package cluster
+
+import (
+	apirbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RoleBinding contains the information to build a role binding
+type RoleBinding struct {
+	Name               string            `json:"name"`
+	Namespace          string            `json:"namespace"`
+	Labels             map[string]string `json:"labels"`
+	RoleName           string            `json:"role_name"`
+	ServiceAccountName string            `json:"service_account_name"`
+}
+
+func (r *RoleBinding) BuildRoleBinding() *apirbacv1.RoleBinding {
+	return &apirbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.Name,
+			Namespace: r.Namespace,
+			Labels:    r.Labels,
+		},
+		Subjects: []apirbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Namespace: r.Namespace,
+				Name:      r.ServiceAccountName,
+			},
+		},
+		RoleRef: apirbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     r.RoleName,
+		},
+	}
+}

--- a/api/turing/cluster/role_binding_test.go
+++ b/api/turing/cluster/role_binding_test.go
@@ -1,0 +1,44 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apirbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildRoleBinding(t *testing.T) {
+	testNamespace := "namespace"
+	serviceAccountName := "service-account-name"
+	roleName := "role-name"
+	roleBindingName := "role-binding-name"
+	roleBindingCfg := RoleBinding{
+		Name:               roleBindingName,
+		Namespace:          testNamespace,
+		Labels:             labels,
+		RoleName:           roleName,
+		ServiceAccountName: serviceAccountName,
+	}
+	expected := apirbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleBindingName,
+			Namespace: testNamespace,
+			Labels:    labels,
+		},
+		Subjects: []apirbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Namespace: testNamespace,
+				Name:      serviceAccountName,
+			},
+		},
+		RoleRef: apirbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     roleName,
+		},
+	}
+	got := roleBindingCfg.BuildRoleBinding()
+	assert.Equal(t, expected, *got)
+}

--- a/api/turing/cluster/role_test.go
+++ b/api/turing/cluster/role_test.go
@@ -1,0 +1,27 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apirbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildRole(t *testing.T) {
+	testNamespace := "namespace"
+	roleCfg := Role{
+		Name:      "role-name",
+		Namespace: testNamespace,
+		Labels:    labels,
+	}
+	expected := apirbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "role-name",
+			Namespace: testNamespace,
+			Labels:    labels,
+		},
+	}
+	got := roleCfg.BuildRole()
+	assert.Equal(t, expected, *got)
+}

--- a/api/turing/cluster/secret.go
+++ b/api/turing/cluster/secret.go
@@ -10,6 +10,7 @@ type Secret struct {
 	Name      string
 	Namespace string
 	Data      map[string]string
+	Labels    map[string]string
 }
 
 // BuildSecret builds a kubernetes secret from the given config.
@@ -22,6 +23,7 @@ func (cfg *Secret) BuildSecret() *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cfg.Name,
 			Namespace: cfg.Namespace,
+			Labels:    cfg.Labels,
 		},
 		Data: data,
 		Type: corev1.SecretTypeOpaque,

--- a/api/turing/cluster/secret_test.go
+++ b/api/turing/cluster/secret_test.go
@@ -16,11 +16,17 @@ func TestBuildSecret(t *testing.T) {
 		Data: map[string]string{
 			"key.json": "asdf",
 		},
+		Labels: map[string]string{
+			"key": "val",
+		},
 	}
 	expected := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "svc-account",
 			Namespace: "test-project",
+			Labels: map[string]string{
+				"key": "val",
+			},
 		},
 		Data: map[string][]byte{
 			"key.json": []byte("asdf"),

--- a/api/turing/cluster/service_account.go
+++ b/api/turing/cluster/service_account.go
@@ -1,0 +1,23 @@
+package cluster
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ServiceAccount contains the information to build a service account
+type ServiceAccount struct {
+	Name      string            `json:"name"`
+	Namespace string            `json:"namespace"`
+	Labels    map[string]string `json:"labels"`
+}
+
+func (sa *ServiceAccount) BuildServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sa.Name,
+			Namespace: sa.Namespace,
+			Labels:    sa.Labels,
+		},
+	}
+}

--- a/api/turing/cluster/service_account_test.go
+++ b/api/turing/cluster/service_account_test.go
@@ -1,0 +1,27 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildServiceAccount(t *testing.T) {
+	testNamespace := "namespace"
+	saCfg := ServiceAccount{
+		Name:      "sa-name",
+		Namespace: testNamespace,
+		Labels:    labels,
+	}
+	expected := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sa-name",
+			Namespace: testNamespace,
+			Labels:    labels,
+		},
+	}
+	got := saCfg.BuildServiceAccount()
+	assert.Equal(t, expected, *got)
+}

--- a/api/turing/cluster/servicebuilder/fluentd.go
+++ b/api/turing/cluster/servicebuilder/fluentd.go
@@ -7,7 +7,6 @@ import (
 
 	mlp "github.com/gojek/mlp/api/client"
 	"github.com/gojek/turing/api/turing/cluster"
-	"github.com/gojek/turing/api/turing/cluster/labeller"
 	"github.com/gojek/turing/api/turing/config"
 	"github.com/gojek/turing/api/turing/models"
 	corev1 "k8s.io/api/core/v1"
@@ -53,13 +52,7 @@ func (sb *clusterSvcBuilder) NewFluentdService(
 		Namespace:   project.Name,
 		AccessModes: []string{"ReadWriteOnce"},
 		Size:        resource.MustParse(cacheVolumeSize),
-		Labels: labeller.BuildLabels(
-			labeller.KubernetesLabelsRequest{
-				Stream: project.Stream,
-				Team:   project.Team,
-				App:    pvcName,
-			},
-		),
+		Labels:      buildLabels(project, envType, routerVersion.Router),
 	}
 	volumes, volumeMounts := buildFluentdVolumes(serviceAccountSecretName, persistentVolumeClaim.Name)
 

--- a/api/turing/cluster/servicebuilder/fluentd.go
+++ b/api/turing/cluster/servicebuilder/fluentd.go
@@ -26,7 +26,6 @@ const (
 func (sb *clusterSvcBuilder) NewFluentdService(
 	routerVersion *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 	serviceAccountSecretName string,
 	fluentdConfig *config.FluentdConfig,
 ) *cluster.KubernetesService {

--- a/api/turing/cluster/servicebuilder/fluentd.go
+++ b/api/turing/cluster/servicebuilder/fluentd.go
@@ -52,7 +52,7 @@ func (sb *clusterSvcBuilder) NewFluentdService(
 		Namespace:   project.Name,
 		AccessModes: []string{"ReadWriteOnce"},
 		Size:        resource.MustParse(cacheVolumeSize),
-		Labels:      buildLabels(project, envType, routerVersion.Router),
+		Labels:      buildLabels(project, routerVersion.Router),
 	}
 	volumes, volumeMounts := buildFluentdVolumes(serviceAccountSecretName, persistentVolumeClaim.Name)
 
@@ -70,7 +70,7 @@ func (sb *clusterSvcBuilder) NewFluentdService(
 			LivenessHTTPGetPath:   fluentdHealthCheckPath,
 			ReadinessHTTPGetPath:  fluentdHealthCheckPath,
 			ProbeInitDelaySeconds: 10,
-			Labels:                buildLabels(project, envType, routerVersion.Router),
+			Labels:                buildLabels(project, routerVersion.Router),
 			Envs:                  envs,
 			PersistentVolumeClaim: persistentVolumeClaim,
 			Volumes:               volumes,

--- a/api/turing/cluster/servicebuilder/fluentd_test.go
+++ b/api/turing/cluster/servicebuilder/fluentd_test.go
@@ -53,7 +53,9 @@ func TestNewFluentdService(t *testing.T) {
 			ProbeInitDelaySeconds: 10,
 			ProbePort:             9880,
 			Labels: map[string]string{
-				"app":          "test-svc",
+				"app": "test-svc",
+				// environment is empty string because its value will only be injected
+				// when Singleton is initialized from turing/api/turing/cluster/labeller/labeller.go
 				"environment":  "",
 				"orchestrator": "turing",
 				"stream":       "test-stream",
@@ -138,6 +140,6 @@ func TestNewFluentdService(t *testing.T) {
 		},
 	}
 
-	actual := sb.NewFluentdService(routerVersion, project, "test-env", "service-account", &fluentdConfig)
+	actual := sb.NewFluentdService(routerVersion, project, "service-account", &fluentdConfig)
 	assert.Equal(t, expected, actual)
 }

--- a/api/turing/cluster/servicebuilder/fluentd_test.go
+++ b/api/turing/cluster/servicebuilder/fluentd_test.go
@@ -76,7 +76,7 @@ func TestNewFluentdService(t *testing.T) {
 				AccessModes: []string{"ReadWriteOnce"},
 				Size:        volSize,
 				Labels: map[string]string{
-					"app":          "test-svc-turing-cache-volume-1",
+					"app":          "test-svc",
 					"environment":  "",
 					"orchestrator": "turing",
 					"stream":       "test-stream",

--- a/api/turing/cluster/servicebuilder/fluentd_test.go
+++ b/api/turing/cluster/servicebuilder/fluentd_test.go
@@ -75,6 +75,13 @@ func TestNewFluentdService(t *testing.T) {
 				Namespace:   project.Name,
 				AccessModes: []string{"ReadWriteOnce"},
 				Size:        volSize,
+				Labels: map[string]string{
+					"app":          "test-svc-turing-cache-volume-1",
+					"environment":  "",
+					"orchestrator": "turing",
+					"stream":       "test-stream",
+					"team":         "test-team",
+				},
 			},
 			Volumes: []corev1.Volume{
 				{

--- a/api/turing/cluster/servicebuilder/plugins_server.go
+++ b/api/turing/cluster/servicebuilder/plugins_server.go
@@ -34,7 +34,6 @@ var (
 func (sb *clusterSvcBuilder) NewPluginsServerService(
 	routerVersion *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 ) *cluster.KubernetesService {
 	return &cluster.KubernetesService{
 		BaseService: &cluster.BaseService{

--- a/api/turing/cluster/servicebuilder/plugins_server.go
+++ b/api/turing/cluster/servicebuilder/plugins_server.go
@@ -41,7 +41,7 @@ func (sb *clusterSvcBuilder) NewPluginsServerService(
 			Name:                  GetComponentName(routerVersion, ComponentTypes.PluginsServer),
 			Namespace:             project.Name,
 			Image:                 nginxImage,
-			Labels:                buildLabels(project, envType, routerVersion.Router),
+			Labels:                buildLabels(project, routerVersion.Router),
 			ProbePort:             80,
 			LivenessHTTPGetPath:   "/",
 			ReadinessHTTPGetPath:  "/",

--- a/api/turing/cluster/servicebuilder/plugins_server_test.go
+++ b/api/turing/cluster/servicebuilder/plugins_server_test.go
@@ -44,7 +44,6 @@ func TestClusterSvcBuilder_NewPluginsServerService(t *testing.T) {
 					ProbeInitDelaySeconds: 5,
 					Labels: buildLabels(
 						&mlp.Project{Name: "integration-test"},
-						"test",
 						&models.Router{Name: "router-1"}),
 					Volumes: []v1.Volume{
 						pluginsVolume,

--- a/api/turing/cluster/servicebuilder/plugins_server_test.go
+++ b/api/turing/cluster/servicebuilder/plugins_server_test.go
@@ -16,7 +16,6 @@ func TestClusterSvcBuilder_NewPluginsServerService(t *testing.T) {
 	tests := map[string]struct {
 		version  *models.RouterVersion
 		project  *mlp.Project
-		envType  string
 		expected *cluster.KubernetesService
 		panics   bool
 	}{
@@ -32,7 +31,6 @@ func TestClusterSvcBuilder_NewPluginsServerService(t *testing.T) {
 				},
 			},
 			project: &mlp.Project{Name: "integration-test"},
-			envType: "test",
 			expected: &cluster.KubernetesService{
 				BaseService: &cluster.BaseService{
 					Name:                  "router-1-turing-plugins-server-42",
@@ -102,9 +100,9 @@ func TestClusterSvcBuilder_NewPluginsServerService(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			if tt.panics {
-				assert.Panics(t, func() { sb.NewPluginsServerService(tt.version, tt.project, tt.envType) })
+				assert.Panics(t, func() { sb.NewPluginsServerService(tt.version, tt.project) })
 			} else {
-				actual := sb.NewPluginsServerService(tt.version, tt.project, tt.envType)
+				actual := sb.NewPluginsServerService(tt.version, tt.project)
 				assert.Equal(t, tt.expected, actual)
 			}
 

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -12,6 +12,7 @@ import (
 	fiberconfig "github.com/gojek/fiber/config"
 	mlp "github.com/gojek/mlp/api/client"
 	"github.com/gojek/turing/api/turing/cluster"
+	"github.com/gojek/turing/api/turing/cluster/labeller"
 	"github.com/gojek/turing/api/turing/config"
 	"github.com/gojek/turing/api/turing/models"
 	"github.com/gojek/turing/api/turing/utils"
@@ -524,10 +525,18 @@ func buildFiberConfigMap(
 		return nil, err
 	}
 
+	name := GetComponentName(ver, ComponentTypes.FiberConfig)
 	return &cluster.ConfigMap{
-		Name:     GetComponentName(ver, ComponentTypes.FiberConfig),
+		Name:     name,
 		FileName: routerConfigFileName,
 		Data:     string(configMapData),
+		Labels: labeller.BuildLabels(
+			labeller.KubernetesLabelsRequest{
+				Stream: project.Stream,
+				Team:   project.Team,
+				App:    name,
+			},
+		),
 	}, nil
 }
 

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -98,7 +98,7 @@ func (sb *clusterSvcBuilder) NewRouterService(
 	// Namespace is the name of the project
 	namespace := GetNamespace(project)
 
-	configMap, err := buildFiberConfigMap(routerVersion, project, experimentConfig, envType)
+	configMap, err := buildFiberConfigMap(routerVersion, project, experimentConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -462,7 +462,6 @@ func buildFiberConfigMap(
 	ver *models.RouterVersion,
 	project *mlp.Project,
 	experimentCfg json.RawMessage,
-	envType string,
 ) (*cluster.ConfigMap, error) {
 	// Create the properties map for fiber's routing strategy or fanIn
 	propsMap := map[string]interface{}{

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -121,7 +121,7 @@ func (sb *clusterSvcBuilder) NewRouterService(
 			LivenessHTTPGetPath:  routerLivenessPath,
 			ReadinessHTTPGetPath: routerReadinessPath,
 			Envs:                 envs,
-			Labels:               buildLabels(project, envType, routerVersion.Router),
+			Labels:               buildLabels(project, routerVersion.Router),
 			ConfigMap:            configMap,
 			Volumes:              volumes,
 			VolumeMounts:         volumeMounts,
@@ -143,7 +143,7 @@ func (sb *clusterSvcBuilder) NewRouterEndpoint(
 	envType string,
 	versionEndpoint string,
 ) (*cluster.VirtualService, error) {
-	labels := buildLabels(project, envType, routerVersion.Router)
+	labels := buildLabels(project, routerVersion.Router)
 	routerName := GetComponentName(routerVersion, ComponentTypes.Router)
 
 	veURL, err := url.Parse(versionEndpoint)
@@ -529,7 +529,7 @@ func buildFiberConfigMap(
 		Name:     GetComponentName(ver, ComponentTypes.FiberConfig),
 		FileName: routerConfigFileName,
 		Data:     string(configMapData),
-		Labels:   buildLabels(project, envType, ver.Router),
+		Labels:   buildLabels(project, ver.Router),
 	}, nil
 }
 

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -12,7 +12,6 @@ import (
 	fiberconfig "github.com/gojek/fiber/config"
 	mlp "github.com/gojek/mlp/api/client"
 	"github.com/gojek/turing/api/turing/cluster"
-	"github.com/gojek/turing/api/turing/cluster/labeller"
 	"github.com/gojek/turing/api/turing/config"
 	"github.com/gojek/turing/api/turing/models"
 	"github.com/gojek/turing/api/turing/utils"
@@ -99,7 +98,7 @@ func (sb *clusterSvcBuilder) NewRouterService(
 	// Namespace is the name of the project
 	namespace := GetNamespace(project)
 
-	configMap, err := buildFiberConfigMap(routerVersion, project, experimentConfig)
+	configMap, err := buildFiberConfigMap(routerVersion, project, experimentConfig, envType)
 	if err != nil {
 		return nil, err
 	}
@@ -463,6 +462,7 @@ func buildFiberConfigMap(
 	ver *models.RouterVersion,
 	project *mlp.Project,
 	experimentCfg json.RawMessage,
+	envType string,
 ) (*cluster.ConfigMap, error) {
 	// Create the properties map for fiber's routing strategy or fanIn
 	propsMap := map[string]interface{}{
@@ -525,18 +525,11 @@ func buildFiberConfigMap(
 		return nil, err
 	}
 
-	name := GetComponentName(ver, ComponentTypes.FiberConfig)
 	return &cluster.ConfigMap{
-		Name:     name,
+		Name:     GetComponentName(ver, ComponentTypes.FiberConfig),
 		FileName: routerConfigFileName,
 		Data:     string(configMapData),
-		Labels: labeller.BuildLabels(
-			labeller.KubernetesLabelsRequest{
-				Stream: project.Stream,
-				Team:   project.Team,
-				App:    name,
-			},
-		),
+		Labels:   buildLabels(project, envType, ver.Router),
 	}, nil
 }
 

--- a/api/turing/cluster/servicebuilder/router_test.go
+++ b/api/turing/cluster/servicebuilder/router_test.go
@@ -71,6 +71,13 @@ func TestNewRouterService(t *testing.T) {
 						Name:     "test-svc-turing-fiber-config-1",
 						FileName: "fiber.yml",
 						Data:     string(cfgmapDefault),
+						Labels: map[string]string{
+							"app":          "test-svc-turing-fiber-config-1",
+							"environment":  "",
+							"orchestrator": "turing",
+							"stream":       "test-stream",
+							"team":         "test-team",
+						},
 					},
 					Envs: []corev1.EnvVar{
 						{Name: "APP_NAME", Value: "test-svc-1.test-project"},
@@ -159,6 +166,13 @@ func TestNewRouterService(t *testing.T) {
 						Name:     "test-svc-turing-fiber-config-1",
 						FileName: "fiber.yml",
 						Data:     string(cfgmapEnsembling),
+						Labels: map[string]string{
+							"app":          "test-svc-turing-fiber-config-1",
+							"environment":  "",
+							"orchestrator": "turing",
+							"stream":       "test-stream",
+							"team":         "test-team",
+						},
 					},
 					Envs: []corev1.EnvVar{
 						{Name: "APP_NAME", Value: "test-svc-1.test-project"},
@@ -255,6 +269,13 @@ func TestNewRouterService(t *testing.T) {
 						Name:     "test-svc-turing-fiber-config-1",
 						FileName: "fiber.yml",
 						Data:     string(cfgmapStandardEnsemble),
+						Labels: map[string]string{
+							"app":          "test-svc-turing-fiber-config-1",
+							"environment":  "",
+							"orchestrator": "turing",
+							"stream":       "test-stream",
+							"team":         "test-team",
+						},
 					},
 					Envs: []corev1.EnvVar{
 						{Name: "APP_NAME", Value: "test-svc-1.test-project"},
@@ -343,6 +364,13 @@ func TestNewRouterService(t *testing.T) {
 						Name:     "test-svc-turing-fiber-config-1",
 						FileName: "fiber.yml",
 						Data:     string(cfgmapTrafficSplitting),
+						Labels: map[string]string{
+							"app":          "test-svc-turing-fiber-config-1",
+							"environment":  "",
+							"orchestrator": "turing",
+							"stream":       "test-stream",
+							"team":         "test-team",
+						},
 					},
 					Envs: []corev1.EnvVar{
 						{Name: "APP_NAME", Value: "test-svc-1.test-project"},
@@ -431,6 +459,13 @@ func TestNewRouterService(t *testing.T) {
 						Name:     "router-with-exp-engine-turing-fiber-config-1",
 						FileName: "fiber.yml",
 						Data:     string(cfgmapExpEngine),
+						Labels: map[string]string{
+							"app":          "router-with-exp-engine-turing-fiber-config-1",
+							"environment":  "",
+							"orchestrator": "turing",
+							"stream":       "test-stream",
+							"team":         "test-team",
+						},
 					},
 					Envs: []corev1.EnvVar{
 						{Name: "APP_NAME", Value: "router-with-exp-engine-1.test-project"},

--- a/api/turing/cluster/servicebuilder/router_test.go
+++ b/api/turing/cluster/servicebuilder/router_test.go
@@ -72,7 +72,7 @@ func TestNewRouterService(t *testing.T) {
 						FileName: "fiber.yml",
 						Data:     string(cfgmapDefault),
 						Labels: map[string]string{
-							"app":          "test-svc-turing-fiber-config-1",
+							"app":          "test-svc",
 							"environment":  "",
 							"orchestrator": "turing",
 							"stream":       "test-stream",
@@ -167,7 +167,7 @@ func TestNewRouterService(t *testing.T) {
 						FileName: "fiber.yml",
 						Data:     string(cfgmapEnsembling),
 						Labels: map[string]string{
-							"app":          "test-svc-turing-fiber-config-1",
+							"app":          "test-svc",
 							"environment":  "",
 							"orchestrator": "turing",
 							"stream":       "test-stream",
@@ -270,7 +270,7 @@ func TestNewRouterService(t *testing.T) {
 						FileName: "fiber.yml",
 						Data:     string(cfgmapStandardEnsemble),
 						Labels: map[string]string{
-							"app":          "test-svc-turing-fiber-config-1",
+							"app":          "test-svc",
 							"environment":  "",
 							"orchestrator": "turing",
 							"stream":       "test-stream",
@@ -365,7 +365,7 @@ func TestNewRouterService(t *testing.T) {
 						FileName: "fiber.yml",
 						Data:     string(cfgmapTrafficSplitting),
 						Labels: map[string]string{
-							"app":          "test-svc-turing-fiber-config-1",
+							"app":          "test-svc",
 							"environment":  "",
 							"orchestrator": "turing",
 							"stream":       "test-stream",
@@ -460,7 +460,7 @@ func TestNewRouterService(t *testing.T) {
 						FileName: "fiber.yml",
 						Data:     string(cfgmapExpEngine),
 						Labels: map[string]string{
-							"app":          "router-with-exp-engine-turing-fiber-config-1",
+							"app":          "router-with-exp-engine",
 							"environment":  "",
 							"orchestrator": "turing",
 							"stream":       "test-stream",

--- a/api/turing/cluster/servicebuilder/service_builder.go
+++ b/api/turing/cluster/servicebuilder/service_builder.go
@@ -193,7 +193,7 @@ func (sb *clusterSvcBuilder) NewEnricherService(
 			CPURequests:    enricher.ResourceRequest.CPURequest,
 			MemoryRequests: enricher.ResourceRequest.MemoryRequest,
 			Envs:           enricher.Env.ToKubernetesEnvVars(),
-			Labels:         buildLabels(project, envType, routerVersion.Router),
+			Labels:         buildLabels(project, routerVersion.Router),
 			Volumes:        volumes,
 			VolumeMounts:   volumeMounts,
 		},
@@ -273,7 +273,7 @@ func (sb *clusterSvcBuilder) NewEnsemblerService(
 			CPURequests:    docker.ResourceRequest.CPURequest,
 			MemoryRequests: docker.ResourceRequest.MemoryRequest,
 			Envs:           docker.Env.ToKubernetesEnvVars(),
-			Labels:         buildLabels(project, envType, routerVersion.Router),
+			Labels:         buildLabels(project, routerVersion.Router),
 			Volumes:        volumes,
 			VolumeMounts:   volumeMounts,
 		},
@@ -312,7 +312,7 @@ func (sb *clusterSvcBuilder) NewSecret(
 		),
 		Namespace: project.Name,
 		Data:      data,
-		Labels:    buildLabels(project, envType, routerVersion.Router),
+		Labels:    buildLabels(project, routerVersion.Router),
 	}
 }
 
@@ -338,7 +338,6 @@ func GetNamespace(project *mlp.Project) string {
 
 func buildLabels(
 	project *mlp.Project,
-	envType string,
 	router *models.Router,
 ) map[string]string {
 	r := labeller.KubernetesLabelsRequest{

--- a/api/turing/cluster/servicebuilder/service_builder.go
+++ b/api/turing/cluster/servicebuilder/service_builder.go
@@ -85,14 +85,12 @@ type ClusterServiceBuilder interface {
 	NewFluentdService(
 		routerVersion *models.RouterVersion,
 		project *mlp.Project,
-		envType string,
 		secretName string,
 		fluentdConfig *config.FluentdConfig,
 	) *cluster.KubernetesService
 	NewPluginsServerService(
 		routerVersion *models.RouterVersion,
 		project *mlp.Project,
-		envType string,
 	) *cluster.KubernetesService
 	NewRouterEndpoint(
 		routerVersion *models.RouterVersion,
@@ -103,7 +101,6 @@ type ClusterServiceBuilder interface {
 	NewSecret(
 		routerVersion *models.RouterVersion,
 		project *mlp.Project,
-		envType string,
 		routerServiceAccountKey string,
 		enricherServiceAccountKey string,
 		ensemblerServiceAccountKey string,
@@ -293,7 +290,6 @@ func (sb *clusterSvcBuilder) NewEnsemblerService(
 func (sb *clusterSvcBuilder) NewSecret(
 	routerVersion *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 	routerServiceAccountKey string,
 	enricherServiceAccountKey string,
 	ensemblerServiceAccountKey string,

--- a/api/turing/cluster/servicebuilder/service_builder.go
+++ b/api/turing/cluster/servicebuilder/service_builder.go
@@ -103,6 +103,7 @@ type ClusterServiceBuilder interface {
 	NewSecret(
 		routerVersion *models.RouterVersion,
 		project *mlp.Project,
+		envType string,
 		routerServiceAccountKey string,
 		enricherServiceAccountKey string,
 		ensemblerServiceAccountKey string,
@@ -292,6 +293,7 @@ func (sb *clusterSvcBuilder) NewEnsemblerService(
 func (sb *clusterSvcBuilder) NewSecret(
 	routerVersion *models.RouterVersion,
 	project *mlp.Project,
+	envType string,
 	routerServiceAccountKey string,
 	enricherServiceAccountKey string,
 	ensemblerServiceAccountKey string,
@@ -310,6 +312,7 @@ func (sb *clusterSvcBuilder) NewSecret(
 		),
 		Namespace: project.Name,
 		Data:      data,
+		Labels:    buildLabels(project, envType, routerVersion.Router),
 	}
 }
 

--- a/api/turing/cluster/servicebuilder/service_builder_test.go
+++ b/api/turing/cluster/servicebuilder/service_builder_test.go
@@ -210,6 +210,7 @@ func TestNewSecret(t *testing.T) {
 	tests := map[string]struct {
 		version         *models.RouterVersion
 		project         *mlp.Project
+		envType         string
 		routerSvcKey    string
 		enricherSvcKey  string
 		ensemblerSvcKey string
@@ -224,6 +225,7 @@ func TestNewSecret(t *testing.T) {
 				},
 			},
 			project:         &mlp.Project{Name: "test-project"},
+			envType:         "test",
 			routerSvcKey:    "router-key",
 			enricherSvcKey:  "enricher-key",
 			ensemblerSvcKey: "ensembler-key",
@@ -235,13 +237,20 @@ func TestNewSecret(t *testing.T) {
 					"enricher-service-account.json":  "enricher-key",
 					"ensembler-service-account.json": "ensembler-key",
 				},
+				Labels: map[string]string{
+					"app":          "test-router",
+					"environment":  "",
+					"orchestrator": "turing",
+					"stream":       "",
+					"team":         "",
+				},
 			},
 		},
 	}
 	sb := &clusterSvcBuilder{}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			secret := sb.NewSecret(tt.version, tt.project, tt.routerSvcKey, tt.enricherSvcKey, tt.ensemblerSvcKey)
+			secret := sb.NewSecret(tt.version, tt.project, tt.envType, tt.routerSvcKey, tt.enricherSvcKey, tt.ensemblerSvcKey)
 			assert.Equal(t, tt.expected, secret)
 		})
 	}

--- a/api/turing/cluster/servicebuilder/service_builder_test.go
+++ b/api/turing/cluster/servicebuilder/service_builder_test.go
@@ -250,7 +250,7 @@ func TestNewSecret(t *testing.T) {
 	sb := &clusterSvcBuilder{}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			secret := sb.NewSecret(tt.version, tt.project, tt.envType, tt.routerSvcKey, tt.enricherSvcKey, tt.ensemblerSvcKey)
+			secret := sb.NewSecret(tt.version, tt.project, tt.routerSvcKey, tt.enricherSvcKey, tt.ensemblerSvcKey)
 			assert.Equal(t, tt.expected, secret)
 		})
 	}

--- a/api/turing/service/router_deployment_service.go
+++ b/api/turing/service/router_deployment_service.go
@@ -78,7 +78,6 @@ func NewDeploymentService(
 	sb := servicebuilder.NewClusterServiceBuilder(
 		resource.Quantity(cfg.DeployConfig.MaxCPU),
 		resource.Quantity(cfg.DeployConfig.MaxMemory),
-		cfg.DeployConfig.EnvironmentType,
 	)
 
 	return &deploymentService{

--- a/api/turing/service/router_deployment_service.go
+++ b/api/turing/service/router_deployment_service.go
@@ -78,6 +78,7 @@ func NewDeploymentService(
 	sb := servicebuilder.NewClusterServiceBuilder(
 		resource.Quantity(cfg.DeployConfig.MaxCPU),
 		resource.Quantity(cfg.DeployConfig.MaxMemory),
+		cfg.DeployConfig.EnvironmentType,
 	)
 
 	return &deploymentService{
@@ -138,6 +139,7 @@ func (ds *deploymentService) DeployRouterVersion(
 	secret := ds.svcBuilder.NewSecret(
 		routerVersion,
 		project,
+		ds.environmentType,
 		routerServiceAccountKey,
 		enricherServiceAccountKey,
 		ensemblerServiceAccountKey,
@@ -254,7 +256,7 @@ func (ds *deploymentService) UndeployRouterVersion(
 
 	// Delete secret
 	eventsCh.Write(models.NewInfoEvent(models.EventStageDeletingDependencies, "deleting secrets"))
-	secret := ds.svcBuilder.NewSecret(routerVersion, project, "", "", "")
+	secret := ds.svcBuilder.NewSecret(routerVersion, project, ds.environmentType, "", "", "")
 	err = deleteSecret(controller, secret)
 	if err != nil {
 		errs = append(errs, err.Error())

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -48,7 +48,6 @@ func (msb *mockClusterServiceBuilder) NewRouterEndpoint(
 func (msb *mockClusterServiceBuilder) NewSecret(
 	routerVersion *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 	routerServiceAccountKey string,
 	enricherServiceAccountKey string,
 	ensemblerServiceAccountKey string,
@@ -160,7 +159,6 @@ func (msb *mockClusterServiceBuilder) NewRouterService(
 func (msb *mockClusterServiceBuilder) NewPluginsServerService(
 	rv *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 ) *cluster.KubernetesService {
 	return nil
 }
@@ -168,7 +166,6 @@ func (msb *mockClusterServiceBuilder) NewPluginsServerService(
 func (msb *mockClusterServiceBuilder) NewFluentdService(
 	rv *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 	serviceAccountSecretName string,
 	cfg *config.FluentdConfig,
 ) *cluster.KubernetesService {

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -48,6 +48,7 @@ func (msb *mockClusterServiceBuilder) NewRouterEndpoint(
 func (msb *mockClusterServiceBuilder) NewSecret(
 	routerVersion *models.RouterVersion,
 	project *mlp.Project,
+	envType string,
 	routerServiceAccountKey string,
 	enricherServiceAccountKey string,
 	ensemblerServiceAccountKey string,

--- a/infra/charts/turing/Chart.yaml
+++ b/infra/charts/turing/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.2.5
+version: 0.2.6
 appVersion: v1.0.0

--- a/infra/charts/turing/templates/_helpers.tpl
+++ b/infra/charts/turing/templates/_helpers.tpl
@@ -11,6 +11,9 @@ app: {{ include "turing.fullname" . }}
 chart: {{ include "turing.chart" . }}
 release: {{ .Release.Name }}
 heritage: {{ .Release.Service }}
+{{- if .Values.turing.labels }}
+{{ toYaml .Values.turing.labels -}}
+{{- end }}
 {{- end -}}
 
 {{- define "turing.fullname" -}}

--- a/infra/charts/turing/templates/_helpers.tpl
+++ b/infra/charts/turing/templates/_helpers.tpl
@@ -6,6 +6,13 @@
 {{- printf "%s-%s" .Chart.Name .Chart.Version -}}
 {{- end -}}
 
+{{- define "turing.labels" -}}
+app: {{ include "turing.fullname" . }}
+chart: {{ include "turing.chart" . }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- end -}}
+
 {{- define "turing.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}

--- a/infra/charts/turing/templates/cluster-role-binding.yaml
+++ b/infra/charts/turing/templates/cluster-role-binding.yaml
@@ -4,10 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "turing.serviceAccount.name" . }}-role-binding
   labels:
-    app: {{ template "turing.fullname" . }}
-    chart: {{ template "turing.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "turing.labels" . | indent 4 }}
 {{- if .Values.turing.labels }}
 {{ toYaml .Values.turing.labels | indent 4 -}}
 {{- end }}

--- a/infra/charts/turing/templates/cluster-role-binding.yaml
+++ b/infra/charts/turing/templates/cluster-role-binding.yaml
@@ -3,6 +3,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "turing.serviceAccount.name" . }}-role-binding
+  labels:
+    app: {{ template "turing.fullname" . }}
+    chart: {{ template "turing.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.turing.labels }}
+{{ toYaml .Values.turing.labels | indent 4 -}}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/infra/charts/turing/templates/cluster-role-binding.yaml
+++ b/infra/charts/turing/templates/cluster-role-binding.yaml
@@ -5,9 +5,6 @@ metadata:
   name: {{ template "turing.serviceAccount.name" . }}-role-binding
   labels:
 {{ include "turing.labels" . | indent 4 }}
-{{- if .Values.turing.labels }}
-{{ toYaml .Values.turing.labels | indent 4 -}}
-{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/infra/charts/turing/templates/cluster-role.yaml
+++ b/infra/charts/turing/templates/cluster-role.yaml
@@ -3,6 +3,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "turing.serviceAccount.name" . }}-cluster-role
+  labels:
+    app: {{ template "turing.fullname" . }}
+    chart: {{ template "turing.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.turing.labels }}
+{{ toYaml .Values.turing.labels | indent 4 -}}
+{{- end }}
 rules:
 - apiGroups: [""]
   resources:

--- a/infra/charts/turing/templates/cluster-role.yaml
+++ b/infra/charts/turing/templates/cluster-role.yaml
@@ -5,9 +5,6 @@ metadata:
   name: {{ template "turing.serviceAccount.name" . }}-cluster-role
   labels:
 {{ include "turing.labels" . | indent 4 }}
-{{- if .Values.turing.labels }}
-{{ toYaml .Values.turing.labels | indent 4 -}}
-{{- end }}
 rules:
 - apiGroups: [""]
   resources:

--- a/infra/charts/turing/templates/cluster-role.yaml
+++ b/infra/charts/turing/templates/cluster-role.yaml
@@ -4,10 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "turing.serviceAccount.name" . }}-cluster-role
   labels:
-    app: {{ template "turing.fullname" . }}
-    chart: {{ template "turing.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "turing.labels" . | indent 4 }}
 {{- if .Values.turing.labels }}
 {{ toYaml .Values.turing.labels | indent 4 -}}
 {{- end }}

--- a/infra/charts/turing/templates/deployment.yaml
+++ b/infra/charts/turing/templates/deployment.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "turing.labels" . | indent 4 }}
-{{- if .Values.turing.labels }}
-{{ toYaml .Values.turing.labels | indent 4 -}}
-{{- end }}
 spec:
   replicas: {{ .Values.turing.replicaCount }}
   selector:

--- a/infra/charts/turing/templates/deployment.yaml
+++ b/infra/charts/turing/templates/deployment.yaml
@@ -4,10 +4,7 @@ metadata:
   name: {{ template "turing.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "turing.fullname" . }}
-    chart: {{ template "turing.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "turing.labels" . | indent 4 }}
 {{- if .Values.turing.labels }}
 {{ toYaml .Values.turing.labels | indent 4 -}}
 {{- end }}

--- a/infra/charts/turing/templates/ingress.yaml
+++ b/infra/charts/turing/templates/ingress.yaml
@@ -6,16 +6,10 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "{{ .Values.turing.ingress.class }}"
   labels:
-    app: {{ include "turing.name" . }}
-    chart: {{ include "turing.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
     app.kubernetes.io/name: {{ include "turing.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- if .Values.turing.labels }}
-{{ toYaml .Values.turing.labels | indent 4 -}}
-{{- end }}
+{{ include "turing.labels" . | indent 4 }}
 {{- if .Values.turing.ingress.useV1Beta1 }}
 apiVersion: networking.k8s.io/v1beta1
 spec:

--- a/infra/charts/turing/templates/ingress.yaml
+++ b/infra/charts/turing/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     app.kubernetes.io/name: {{ include "turing.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.turing.labels }}
+{{ toYaml .Values.turing.labels | indent 4 -}}
+{{- end }}
 {{- if .Values.turing.ingress.useV1Beta1 }}
 apiVersion: networking.k8s.io/v1beta1
 spec:

--- a/infra/charts/turing/templates/openapi-override-configmap.yaml
+++ b/infra/charts/turing/templates/openapi-override-configmap.yaml
@@ -5,10 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "turing.fullname" . }}-openapi
   labels:
-    app: {{ template "turing.fullname" . }}
-    chart: {{ template "turing.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "turing.labels" . | indent 4 }}
 {{- if .Values.turing.labels }}
 {{ toYaml .Values.turing.labels | indent 4 -}}
 {{- end }}

--- a/infra/charts/turing/templates/openapi-override-configmap.yaml
+++ b/infra/charts/turing/templates/openapi-override-configmap.yaml
@@ -4,6 +4,14 @@ kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "turing.fullname" . }}-openapi
+  labels:
+    app: {{ template "turing.fullname" . }}
+    chart: {{ template "turing.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.turing.labels }}
+{{ toYaml .Values.turing.labels | indent 4 -}}
+{{- end }}
 data:
   override.yaml: |
     {{- toYaml .Values.turing.openApiSpecOverrides | nindent 4 -}}

--- a/infra/charts/turing/templates/openapi-override-configmap.yaml
+++ b/infra/charts/turing/templates/openapi-override-configmap.yaml
@@ -6,9 +6,6 @@ metadata:
   name: {{ template "turing.fullname" . }}-openapi
   labels:
 {{ include "turing.labels" . | indent 4 }}
-{{- if .Values.turing.labels }}
-{{ toYaml .Values.turing.labels | indent 4 -}}
-{{- end }}
 data:
   override.yaml: |
     {{- toYaml .Values.turing.openApiSpecOverrides | nindent 4 -}}

--- a/infra/charts/turing/templates/secrets.yaml
+++ b/infra/charts/turing/templates/secrets.yaml
@@ -5,9 +5,6 @@ metadata:
   name: {{ template "turing.fullname" . }}-api-config
   labels:
 {{ include "turing.labels" . | indent 4 }}
-{{- if .Values.turing.labels }}
-{{ toYaml .Values.turing.labels | indent 4 -}}
-{{- end }}
 stringData:
   config.yaml: |
     {{- include "turing.config" . | nindent 4 -}}

--- a/infra/charts/turing/templates/secrets.yaml
+++ b/infra/charts/turing/templates/secrets.yaml
@@ -4,10 +4,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "turing.fullname" . }}-api-config
   labels:
-    app: {{ template "turing.fullname" . }}
-    chart: {{ template "turing.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "turing.labels" . | indent 4 }}
 {{- if .Values.turing.labels }}
 {{ toYaml .Values.turing.labels | indent 4 -}}
 {{- end }}

--- a/infra/charts/turing/templates/secrets.yaml
+++ b/infra/charts/turing/templates/secrets.yaml
@@ -3,6 +3,14 @@ kind: Secret
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "turing.fullname" . }}-api-config
+  labels:
+    app: {{ template "turing.fullname" . }}
+    chart: {{ template "turing.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.turing.labels }}
+{{ toYaml .Values.turing.labels | indent 4 -}}
+{{- end }}
 stringData:
   config.yaml: |
     {{- include "turing.config" . | nindent 4 -}}

--- a/infra/charts/turing/templates/service-account.yaml
+++ b/infra/charts/turing/templates/service-account.yaml
@@ -5,7 +5,4 @@ metadata:
   name: {{ template "turing.serviceAccount.name" . }}
   labels:
 {{ include "turing.labels" . | indent 4 }}
-{{- if .Values.turing.labels }}
-{{ toYaml .Values.turing.labels | indent 4 -}}
-{{- end }}
 {{- end -}}

--- a/infra/charts/turing/templates/service-account.yaml
+++ b/infra/charts/turing/templates/service-account.yaml
@@ -4,10 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "turing.serviceAccount.name" . }}
   labels:
-    app: {{ template "turing.fullname" . }}
-    chart: {{ template "turing.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "turing.labels" . | indent 4 }}
 {{- if .Values.turing.labels }}
 {{ toYaml .Values.turing.labels | indent 4 -}}
 {{- end }}

--- a/infra/charts/turing/templates/service-account.yaml
+++ b/infra/charts/turing/templates/service-account.yaml
@@ -3,4 +3,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "turing.serviceAccount.name" . }}
+  labels:
+    app: {{ template "turing.fullname" . }}
+    chart: {{ template "turing.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.turing.labels }}
+{{ toYaml .Values.turing.labels | indent 4 -}}
+{{- end }}
 {{- end -}}

--- a/infra/charts/turing/templates/virtualservice-mlp.yaml
+++ b/infra/charts/turing/templates/virtualservice-mlp.yaml
@@ -4,10 +4,7 @@ kind: Gateway
 metadata:
   name: {{ template "turing.fullname" . }}-gateway
   labels:
-    app: {{ template "turing.fullname" . }}
-    chart: {{ template "turing.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "turing.labels" . | indent 4 }}
 {{- if .Values.turing.labels }}
 {{ toYaml .Values.turing.labels | indent 4 -}}
 {{- end }}
@@ -28,10 +25,7 @@ kind: VirtualService
 metadata:
   name: {{ template "turing.fullname" . }}-virtual-service
   labels:
-    app: {{ template "turing.fullname" . }}
-    chart: {{ template "turing.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "turing.labels" . | indent 4 }}
 {{- if .Values.turing.labels }}
 {{ toYaml .Values.turing.labels | indent 4 -}}
 {{- end }}

--- a/infra/charts/turing/templates/virtualservice-mlp.yaml
+++ b/infra/charts/turing/templates/virtualservice-mlp.yaml
@@ -3,6 +3,14 @@ apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: {{ template "turing.fullname" . }}-gateway
+  labels:
+    app: {{ template "turing.fullname" . }}
+    chart: {{ template "turing.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.turing.labels }}
+{{ toYaml .Values.turing.labels | indent 4 -}}
+{{- end }}
 spec:
   selector:
     istio: ingressgateway
@@ -19,6 +27,14 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: {{ template "turing.fullname" . }}-virtual-service
+  labels:
+    app: {{ template "turing.fullname" . }}
+    chart: {{ template "turing.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.turing.labels }}
+{{ toYaml .Values.turing.labels | indent 4 -}}
+{{- end }}
 spec:
   hosts:
     - "*"

--- a/infra/charts/turing/templates/virtualservice-mlp.yaml
+++ b/infra/charts/turing/templates/virtualservice-mlp.yaml
@@ -5,9 +5,6 @@ metadata:
   name: {{ template "turing.fullname" . }}-gateway
   labels:
 {{ include "turing.labels" . | indent 4 }}
-{{- if .Values.turing.labels }}
-{{ toYaml .Values.turing.labels | indent 4 -}}
-{{- end }}
 spec:
   selector:
     istio: ingressgateway
@@ -26,9 +23,6 @@ metadata:
   name: {{ template "turing.fullname" . }}-virtual-service
   labels:
 {{ include "turing.labels" . | indent 4 }}
-{{- if .Values.turing.labels }}
-{{ toYaml .Values.turing.labels | indent 4 -}}
-{{- end }}
 spec:
   hosts:
     - "*"


### PR DESCRIPTION
### Context

Some of the Kubernetes objects created via Turing API workflows do not contain labels. This PR standardizes the labels for all objects that are required, which would help in cost management and searching of resources in a cluster.

The standardization of labels touches 2 places:
- Turing's helm chart
- Turing's API workflows which creates Kubernetes objects