### PR TITLE
Add wait for status update

### DIFF
--- a/sdk/turing/router/config/experiment_config.py
+++ b/sdk/turing/router/config/experiment_config.py
@@ -29,9 +29,9 @@ class ExperimentConfig:
 
     @config.setter
     def config(self, config: Dict):
-        if config is not None and 'project_id' in config:
-            config['project_id'] = int(config['project_id'])
         self._config = config
+        if self._config is not None and 'project_id' in self._config:
+            self.config['project_id'] = int(self._config['project_id'])
 
     def to_open_api(self) -> OpenApiModel:
         if self.config is None:

--- a/sdk/turing/router/config/router_ensembler_config.py
+++ b/sdk/turing/router/config/router_ensembler_config.py
@@ -59,11 +59,12 @@ class RouterEnsemblerConfig:
         if isinstance(standard_config, turing.generated.models.EnsemblerStandardConfig):
             self._standard_config = standard_config
         elif isinstance(standard_config, dict):
-            standard_config['experiment_mappings'] = [
+            openapi_standard_config = standard_config.copy()
+            openapi_standard_config['experiment_mappings'] = [
                 turing.generated.models.EnsemblerStandardConfigExperimentMappings(**mapping)
                 for mapping in standard_config['experiment_mappings']
             ]
-            self._standard_config = turing.generated.models.EnsemblerStandardConfig(**standard_config)
+            self._standard_config = turing.generated.models.EnsemblerStandardConfig(**openapi_standard_config)
         else:
             self._standard_config = standard_config
 
@@ -76,11 +77,12 @@ class RouterEnsemblerConfig:
         if isinstance(docker_config, turing.generated.models.EnsemblerDockerConfig):
             self._docker_config = docker_config
         elif isinstance(docker_config, dict):
-            docker_config['resource_request'] = \
-                turing.generated.models.ResourceRequest(**docker_config['resource_request'])
-            docker_config['env'] = [turing.generated.models.EnvVar(**env_var) for env_var in docker_config['env']]
+            openapi_docker_config = docker_config.copy()
+            openapi_docker_config['resource_request'] = \
+                turing.generated.models.ResourceRequest(**openapi_docker_config['resource_request'])
+            openapi_docker_config['env'] = [turing.generated.models.EnvVar(**env_var) for env_var in openapi_docker_config['env']]
             self._docker_config = turing.generated.models.EnsemblerDockerConfig(
-                **docker_config
+                **openapi_docker_config
             )
         else:
             self._docker_config = docker_config

--- a/sdk/turing/router/router.py
+++ b/sdk/turing/router/router.py
@@ -33,7 +33,6 @@ class Router(ApiObject):
                  environment_name: str,
                  monitoring_url: str,
                  status: str,
-                 version: int = None,
                  config: Dict = None,
                  endpoint: str = None,
                  **kwargs):
@@ -45,13 +44,7 @@ class Router(ApiObject):
         self._endpoint = endpoint
         self._monitoring_url = monitoring_url
         self._status = RouterStatus(status)
-
-        if config is not None:
-            self._config = RouterConfig(name=name, environment_name=environment_name, **config)
-            self._version = config.get('version')
-        else:
-            self._config = config
-            self._version = version
+        self._config = config
 
     @property
     def id(self) -> int:
@@ -83,11 +76,11 @@ class Router(ApiObject):
 
     @property
     def config(self) -> 'RouterConfig':
-        return self._config
+        return RouterConfig(name=self.name, environment_name=self.environment_name, **self._config)
 
     @property
     def version(self) -> int:
-        return self._version
+        return self._config.get('version') if self._config else None
 
     @classmethod
     def list(cls) -> List['Router']:
@@ -135,8 +128,7 @@ class Router(ApiObject):
         Update the current router with a new set of configs specified in the RouterConfig argument
 
         :param config: configuration of router
-        :return: instance of router (self); this router contains details of the currently deployed router; it contains
-            the details of the currently DEPLOYED router version
+        :return: instance of router (self); this router contains details of the router and its currently deployed version
         """
         self._config = config
         updated_router = Router.from_open_api(

--- a/sdk/turing/router/router.py
+++ b/sdk/turing/router/router.py
@@ -135,7 +135,8 @@ class Router(ApiObject):
         Update the current router with a new set of configs specified in the RouterConfig argument
 
         :param config: configuration of router
-        :return: instance of router updated (self)
+        :return: instance of router (self); this router contains details of the currently deployed router; it contains
+            the details of the currently DEPLOYED router version
         """
         self._config = config
         updated_router = Router.from_open_api(
@@ -208,11 +209,13 @@ class Router(ApiObject):
     def wait_for_status(self, status: RouterStatus, max_tries: int = 15, duration: float = 10.0):
         for i in range(1, max_tries + 1):
             logger.debug(f"Checking if router {self.id} is {status.value}...")
-            cur_status = Router.get(self.id).status
+            current_router = Router.get(self.id)
+            cur_status = current_router.status
             if cur_status == status:
                 # Wait for backend components to fully resolve
                 time.sleep(5)
                 logger.debug(f"Router {self.id} is finally {status.value}.")
+                self.__dict__ = current_router.__dict__
                 return
             else:
                 logger.debug(f"Router {self.id} is {cur_status.value}.")
@@ -224,11 +227,13 @@ class Router(ApiObject):
     def wait_for_version_status(self, status: RouterStatus, version: int, max_tries: int = 15, duration: float = 10.0):
         for i in range(1, max_tries + 1):
             logger.debug(f"Checking if router {self.id} with version {version} is {status.value}...")
-            cur_status = self.get_version(version).status
+            current_router = Router.get(self.id)
+            cur_status = current_router.status
             if cur_status == status:
                 # Wait for backend components to fully resolve
                 time.sleep(5)
                 logger.debug(f"Router {self.id} with version {version} is finally {status.value}.")
+                self.__dict__ = current_router.__dict__
                 return
             else:
                 logger.debug(f"Router {self.id} with version {version} is {cur_status.value}.")

--- a/sdk/turing/router/router.py
+++ b/sdk/turing/router/router.py
@@ -227,13 +227,11 @@ class Router(ApiObject):
     def wait_for_version_status(self, status: RouterStatus, version: int, max_tries: int = 15, duration: float = 10.0):
         for i in range(1, max_tries + 1):
             logger.debug(f"Checking if router {self.id} with version {version} is {status.value}...")
-            current_router = Router.get(self.id)
-            cur_status = current_router.status
+            cur_status = self.get_version(version).status
             if cur_status == status:
                 # Wait for backend components to fully resolve
                 time.sleep(5)
                 logger.debug(f"Router {self.id} with version {version} is finally {status.value}.")
-                self.__dict__ = current_router.__dict__
                 return
             else:
                 logger.debug(f"Router {self.id} with version {version} is {cur_status.value}.")

--- a/sdk/turing/router/router.py
+++ b/sdk/turing/router/router.py
@@ -33,6 +33,7 @@ class Router(ApiObject):
                  environment_name: str,
                  monitoring_url: str,
                  status: str,
+                 version: int = None,
                  config: Dict = None,
                  endpoint: str = None,
                  **kwargs):
@@ -47,8 +48,10 @@ class Router(ApiObject):
 
         if config is not None:
             self._config = RouterConfig(name=name, environment_name=environment_name, **config)
+            self._version = config.get('version')
         else:
-            self._config = None
+            self._config = config
+            self._version = version
 
     @property
     def id(self) -> int:
@@ -81,6 +84,10 @@ class Router(ApiObject):
     @property
     def config(self) -> 'RouterConfig':
         return self._config
+
+    @property
+    def version(self) -> int:
+        return self._version
 
     @classmethod
     def list(cls) -> List['Router']:


### PR DESCRIPTION
## Context
This update to the Turing SDK adds commits to the existing release of Turing SDK (`v0.2.0`), which serve to introduce a `version` attribute in the `Router` SDK. This `version` attribute (as well as a router's other attributes) gets updated when `wait_for_status` gets called on a `Router` instance. When `wait_for_status` returns successfully, the `version` attribute would be expected to contain the current router version number. 

This update is mainly targeted at scenarios when one updates a router - right after calling `update`, the existing router version that is deployed remains the same while the new version enters the `pending` state. Instead of having to query the status of the Router actively in order to retrieve the new router version id when it has finally been deployed successfully, the user can simply be assured that his/her `Router` instance has a newly updated version id when the waiting function has returned succesfully.