### PR TITLE
Set EUI spacer to small

### DIFF
--- a/ui/src/router/components/form/components/pyfunc_config/PyFuncDeploymentPanel.js
+++ b/ui/src/router/components/form/components/pyfunc_config/PyFuncDeploymentPanel.js
@@ -80,7 +80,7 @@ export const PyFuncDeploymentPanel = ({
           </EuiFlexItem>
         </EuiFlexGroup>
 
-        <EuiSpacer size="l" />
+        <EuiSpacer size="s" />
       </EuiForm>
     </Panel>
   );


### PR DESCRIPTION
### Context
This PR introduces a tiny fix to the UI to correct the size of the pyfunc ensembler deployment panel from large to small.