### PR TITLE
[BUG] Fix End-to-End test suite 

### DIFF
--- a/api/e2e/test/01_create_router_test.go
+++ b/api/e2e/test/01_create_router_test.go
@@ -111,7 +111,7 @@ func TestCreateRouter(t *testing.T) {
 						}
 					},
 					{
-						"code": 200
+						"code": 200,
 						"data": {
 							"request": {
 								"client": {

--- a/api/e2e/test/01_create_router_test.go
+++ b/api/e2e/test/01_create_router_test.go
@@ -87,7 +87,7 @@ func TestCreateRouter(t *testing.T) {
 						"code": 200,
 						"data": {
 							"request": {
-								"customer": {
+								"client": {
 									"id": 4
 								}
 							},
@@ -114,7 +114,7 @@ func TestCreateRouter(t *testing.T) {
 						"code": 200
 						"data": {
 							"request": {
-								"customer": {
+								"client": {
 									"id": 7
 								}
 							},

--- a/api/e2e/test/01_create_router_test.go
+++ b/api/e2e/test/01_create_router_test.go
@@ -84,6 +84,7 @@ func TestCreateRouter(t *testing.T) {
 					t.Logf("Response Payload:\n%s", string(responsePayload))
 					expectedResponse := `[
 					{
+						"code": 200,
 						"data": {
 							"request": {
 								"customer": {
@@ -107,10 +108,10 @@ func TestCreateRouter(t *testing.T) {
 									}
 								]
 							},
-							"status_code": 200
 						}
 					},
 					{
+						"code": 200
 						"data": {
 							"request": {
 								"customer": {
@@ -133,8 +134,7 @@ func TestCreateRouter(t *testing.T) {
 										"route": "control"
 									}
 								]
-							},
-							"status_code": 200
+							}
 						}
 					}]`
 					assert.JSONEq(t, expectedResponse, string(responsePayload))

--- a/api/e2e/test/01_create_router_test.go
+++ b/api/e2e/test/01_create_router_test.go
@@ -83,60 +83,59 @@ func TestCreateRouter(t *testing.T) {
 						response.StatusCode, string(responsePayload))
 					t.Logf("Response Payload:\n%s", string(responsePayload))
 					expectedResponse := `[
-					{
-						"code": 200,
-						"data": {
-							"request": {
-								"client": {
-									"id": 4
-								}
-							},
-							"response": {
-								"experiment": {
-									"configuration": {
-										"foo": "bar"
+						{
+							"code": 200,
+							"data": {
+								"request": {
+									"client": {
+										"id": 4
 									}
 								},
-								"route_responses":
-								[
-									{
-										"data": {
-											"version": "control"
-										},
-										"is_default": true,
-										"route": "control"
-									}
-								]
-							},
-						}
-					},
-					{
-						"code": 200,
-						"data": {
-							"request": {
-								"client": {
-									"id": 7
+								"response": {
+									"experiment": {
+										"configuration": {
+											"foo": "bar"
+										}
+									},
+									"route_responses": [
+										{
+											"data": {
+												"version": "control"
+											},
+											"is_default": true,
+											"route": "control"
+										}
+									]
 								}
-							},
-							"response": {
-								"experiment": {
-									"configuration": {
-										"bar": "baz"
+							}
+						},
+						{
+							"code": 200,
+							"data": {
+								"request": {
+									"client": {
+										"id": 7
 									}
 								},
-								"route_responses":
-								[
-									{
-										"data": {
-											"version": "control"
-										},
-										"is_default": true,
-										"route": "control"
-									}
-								]
+								"response": {
+									"experiment": {
+										"configuration": {
+											"bar": "baz"
+										}
+									},
+									"route_responses": [
+										{
+											"data": {
+												"version": "control"
+											},
+											"is_default": true,
+											"route": "control"
+										}
+									]
+								}
 							}
 						}
-					}]`
+					]`
 					assert.JSONEq(t, expectedResponse, string(responsePayload))
 				})
 

--- a/api/e2e/test/01_create_router_test.go
+++ b/api/e2e/test/01_create_router_test.go
@@ -81,40 +81,63 @@ func TestCreateRouter(t *testing.T) {
 					assert.Equal(t, http.StatusOK, response.StatusCode,
 						"Unexpected response (code %d): %s",
 						response.StatusCode, string(responsePayload))
-					actualResponse := gjson.GetBytes(responsePayload, "#.data.response").String()
-					expectedResponse := `[{
-					  "experiment": {
-						"configuration": {
-							"foo":"bar"
+					t.Logf("Response Payload:\n%s", string(responsePayload))
+					expectedResponse := `[
+					{
+						"data": {
+							"request": {
+								"customer": {
+									"id": 4
+								}
+							},
+							"response": {
+								"experiment": {
+									"configuration": {
+										"foo": "bar"
+									}
+								},
+								"route_responses":
+								[
+									{
+										"data": {
+											"version": "control"
+										},
+										"is_default": true,
+										"route": "control"
+									}
+								]
+							},
+							"status_code": 200
 						}
-					  },
-					  "route_responses": [
-						{
-						  "data": {
-							"version": "control"
-						  },
-						  "is_default": true,
-						  "route": "control"
-						}
-					  ]
 					},
 					{
-					  "experiment": {
-						"configuration": {
-							"bar": "baz"
+						"data": {
+							"request": {
+								"customer": {
+									"id": 7
+								}
+							},
+							"response": {
+								"experiment": {
+									"configuration": {
+										"bar": "baz"
+									}
+								},
+								"route_responses":
+								[
+									{
+										"data": {
+											"version": "control"
+										},
+										"is_default": true,
+										"route": "control"
+									}
+								]
+							},
+							"status_code": 200
 						}
-					  },
-					  "route_responses": [
-						{
-						  "data": {
-							"version": "control"
-						  },
-						  "is_default": true,
-						  "route": "control"
-						}
-					  ]
 					}]`
-					assert.JSONEq(t, expectedResponse, actualResponse)
+					assert.JSONEq(t, expectedResponse, string(responsePayload))
 				})
 
 			t.Log("Test endpoints for router logs")

--- a/engines/experiment/examples/plugins/hardcoded/go.mod
+++ b/engines/experiment/examples/plugins/hardcoded/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/gojek/turing/engines/experiment v1.0.0
 	github.com/hashicorp/go-hclog v0.16.0
+	github.com/stretchr/testify v1.7.0
 )
 
 replace github.com/gojek/turing/engines/experiment => ../../../

--- a/engines/experiment/examples/plugins/hardcoded/runner_test.go
+++ b/engines/experiment/examples/plugins/hardcoded/runner_test.go
@@ -1,0 +1,78 @@
+package hardcoded
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/gojek/turing/engines/experiment/manager"
+	"github.com/gojek/turing/engines/experiment/pkg/request"
+	"github.com/gojek/turing/engines/experiment/runner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExperimentRunner_GetTreatmentForRequest(t *testing.T) {
+	suite := map[string]struct {
+		experiments []Experiment
+		header      http.Header
+		payload     json.RawMessage
+		expected    *runner.Treatment
+		err         string
+	}{
+		"success": {
+			experiments: []Experiment{
+				{
+					Experiment: manager.Experiment{
+						ID:   "001",
+						Name: "exp_1",
+						Variants: []manager.Variant{
+							{
+								Name: "control",
+							},
+							{
+								Name: "treatment-1",
+							},
+						},
+					},
+					SegmentationConfig: SegmenterConfig{
+						Name:            "customer_id",
+						SegmenterSource: request.PayloadFieldSource,
+						SegmenterValue:  "customer.id",
+					},
+					VariantsConfig: map[string]TreatmentConfig{
+						"control": {
+							Traffic: 0.85,
+							Data:    json.RawMessage(`{"foo": "bar"}`),
+						},
+						"treatment-1": {
+							Traffic: 0.15,
+							Data:    json.RawMessage(`{"bar": "baz"}`),
+						},
+					},
+				},
+			},
+			payload: json.RawMessage(`{"customer": {"id": 7}}`),
+			expected: &runner.Treatment{
+				ExperimentName: "exp_1",
+				Name:           "treatment-1",
+				Config:         json.RawMessage(`{"bar": "baz"}`),
+			},
+		},
+	}
+
+	for name, tt := range suite {
+		t.Run(name, func(t *testing.T) {
+			expRunner := ExperimentRunner{experiments: tt.experiments}
+
+			actual, err := expRunner.GetTreatmentForRequest(tt.header, tt.payload, runner.GetTreatmentOptions{})
+			if tt.err != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, actual)
+			}
+		})
+	}
+}

--- a/engines/experiment/examples/plugins/hardcoded/runner_test.go
+++ b/engines/experiment/examples/plugins/hardcoded/runner_test.go
@@ -13,6 +13,38 @@ import (
 )
 
 func TestExperimentRunner_GetTreatmentForRequest(t *testing.T) {
+	experiments := []Experiment{
+		{
+			Experiment: manager.Experiment{
+				ID:   "001",
+				Name: "exp_1",
+				Variants: []manager.Variant{
+					{
+						Name: "control",
+					},
+					{
+						Name: "treatment-1",
+					},
+				},
+			},
+			SegmentationConfig: SegmenterConfig{
+				Name:            "customer_id",
+				SegmenterSource: request.PayloadFieldSource,
+				SegmenterValue:  "client.id",
+			},
+			VariantsConfig: map[string]TreatmentConfig{
+				"control": {
+					Traffic: 0.85,
+					Data:    json.RawMessage(`{"foo": "bar"}`),
+				},
+				"treatment-1": {
+					Traffic: 0.15,
+					Data:    json.RawMessage(`{"bar": "baz"}`),
+				},
+			},
+		},
+	}
+
 	suite := map[string]struct {
 		experiments []Experiment
 		header      http.Header
@@ -20,44 +52,28 @@ func TestExperimentRunner_GetTreatmentForRequest(t *testing.T) {
 		expected    *runner.Treatment
 		err         string
 	}{
-		"success": {
-			experiments: []Experiment{
-				{
-					Experiment: manager.Experiment{
-						ID:   "001",
-						Name: "exp_1",
-						Variants: []manager.Variant{
-							{
-								Name: "control",
-							},
-							{
-								Name: "treatment-1",
-							},
-						},
-					},
-					SegmentationConfig: SegmenterConfig{
-						Name:            "customer_id",
-						SegmenterSource: request.PayloadFieldSource,
-						SegmenterValue:  "customer.id",
-					},
-					VariantsConfig: map[string]TreatmentConfig{
-						"control": {
-							Traffic: 0.85,
-							Data:    json.RawMessage(`{"foo": "bar"}`),
-						},
-						"treatment-1": {
-							Traffic: 0.15,
-							Data:    json.RawMessage(`{"bar": "baz"}`),
-						},
-					},
-				},
+		"success | client_id:4": {
+			experiments: experiments,
+			payload:     json.RawMessage(`{"client": {"id": 4}}`),
+			expected: &runner.Treatment{
+				ExperimentName: "exp_1",
+				Name:           "control",
+				Config:         json.RawMessage(`{"foo": "bar"}`),
 			},
-			payload: json.RawMessage(`{"customer": {"id": 7}}`),
+		},
+		"success | client_id:7": {
+			experiments: experiments,
+			payload:     json.RawMessage(`{"client": {"id": 7}}`),
 			expected: &runner.Treatment{
 				ExperimentName: "exp_1",
 				Name:           "treatment-1",
 				Config:         json.RawMessage(`{"bar": "baz"}`),
 			},
+		},
+		"failure": {
+			experiments: experiments,
+			payload:     json.RawMessage(`{}`),
+			err:         "no experiment configured for the unit",
 		},
 	}
 


### PR DESCRIPTION
# Context:
https://github.com/gojek/turing/pull/184 contained the updates to the e2e tests to cover the deployment of a Turing Router with the experiment engine plugin. It turned out, that one of the tests started failing intermittently because of the non-deterministic behavior (https://github.com/gojek/turing/pull/188#discussion_r835065627).

The problem occurs only with the test, that asserts the `/batch_predict` endpoint response. Previously, the request payload to the `/batch_predict` contained two equal prediction request payloads (the entire request was `[{}, {}]`), however, https://github.com/gojek/turing/pull/184 has changed this to verify that the experiment engine assigns treatments correctly to different requests. 

I'm not able to verify, that the experiment engine assigns treatments non-deterministically, so I assume that the problem was observed because of how the expected and actual responses were compared.

This PR adds a unit test for the test experiment engine's `ExperimentRunner. GetTreatmentForRequest` implementation and updates the e2e test part of the `/batch_predict` response assertion.