### PR TITLE
Update workflows to use Python 3.7 for ensembler engines and sdk

### DIFF
--- a/.github/workflows/pyfunc-ensembler-job.yaml
+++ b/.github/workflows/pyfunc-ensembler-job.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Setup Java
         uses: actions/setup-java@v2

--- a/.github/workflows/pyfunc-ensembler-service.yaml
+++ b/.github/workflows/pyfunc-ensembler-service.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Cache pip dependencies
         uses: actions/cache@v2
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Cache pip dependencies
         uses: actions/cache@v2

--- a/sdk/turing/router/router.py
+++ b/sdk/turing/router/router.py
@@ -1,7 +1,7 @@
 import time
 import logging
 
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 import turing.generated.models
 from turing._base_types import ApiObject, ApiObjectSpec
@@ -75,8 +75,11 @@ class Router(ApiObject):
         return self._status
 
     @property
-    def config(self) -> 'RouterConfig':
-        return RouterConfig(name=self.name, environment_name=self.environment_name, **self._config)
+    def config(self) -> Optional['RouterConfig']:
+        if self._config is not None:
+            return RouterConfig(name=self.name, environment_name=self.environment_name, **self._config)
+        else:
+            return None
 
     @property
     def version(self) -> int:

--- a/ui/src/components/config_section/index.scss
+++ b/ui/src/components/config_section/index.scss
@@ -11,7 +11,7 @@
 .euiPanel--configSection {
   .euiDescriptionList.euiDescriptionList--responsiveColumn {
     > * {
-      @include euiTextBreakWord;
+      @include euiTextTruncate;
 
       line-height: 2.1 !important;
       margin-top: 2px !important;

--- a/ui/src/components/config_section/index.scss
+++ b/ui/src/components/config_section/index.scss
@@ -11,7 +11,7 @@
 .euiPanel--configSection {
   .euiDescriptionList.euiDescriptionList--responsiveColumn {
     > * {
-      @include euiTextTruncate;
+      @include euiTextBreakWord;
 
       line-height: 2.1 !important;
       margin-top: 2px !important;

--- a/ui/src/router/components/configuration/components/docker_config_section/ContainerConfigTable.js
+++ b/ui/src/router/components/configuration/components/docker_config_section/ContainerConfigTable.js
@@ -7,7 +7,16 @@ export const ContainerConfigTable = ({
   const items = [
     {
       title: "Image",
-      description: image,
+      description: (
+        <span
+          style={{
+            wordBreak: "break-word",
+            textOverflow: "unset",
+            whiteSpace: "break-spaces",
+          }}>
+          {image}
+        </span>
+      ),
     },
     {
       title: "Endpoint",


### PR DESCRIPTION
### Context
With the PR #188, the Python versions for the Turing SDK as well as both ensembler engines have been fixed at `3.7.*`. While these changes have been made on these components, the workflows for these components have not been updated yet.

This PR serves to update these workflows to utilise Python 3.7 accordingly.

### Additional Fixes
- Tiny fix to the Turing SDK to handle cases whereby `RouterConfig` is not returned as part of a response body containing Routers
- Tiny fix to the Turing UI to allow for text wrapping when the docker image name is too long
