### PR TITLE
Minor fixes for experiment engine configs in the helm chart

### DIFF
--- a/infra/charts/turing/Chart.yaml
+++ b/infra/charts/turing/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.2.7
+version: 0.2.8
 appVersion: v1.0.0

--- a/infra/charts/turing/README.md
+++ b/infra/charts/turing/README.md
@@ -88,7 +88,7 @@ The following table lists the configurable parameters of the Turing chart and th
 | tags.mlp | bool | `true` | Specifies if the necessary MLP components needs to be installed together with Turing |
 | turing.clusterConfig.useInClusterConfig | bool | `false` | (bool) Configuration to tell Turing API how it should authenticate with deployment k8s cluster By default, Turing API expects to use a remote k8s cluster for deployment and to do so, it requires cluster credentials to be stored in Vault's KV Secrets store. |
 | turing.config | object | computed value | Turing API server configuration. Please refer to https://github.com/gojek/turing/blob/main/api/turing/config/example.yaml for the detailed explanation on Turing API config options |
-| turing.experimentEngines | object | `{}` | Turing Experiment Engines configuration |
+| turing.experimentEngines | list | `[]` | Turing Experiment Engines configuration |
 | turing.extraArgs | list | `[]` | List of string containing additional Turing API server arguments. For example, multiple "-config" can be specified to use multiple config files |
 | turing.extraContainers | list | `[]` | List of sidecar containers to attach to the Pod. For example, you can attach sidecar container that forward logs or dynamically update some  configuration files. |
 | turing.extraEnvs | list | `[]` | List of extra environment variables to add to Turing API server container |

--- a/infra/charts/turing/templates/_helpers.tpl
+++ b/infra/charts/turing/templates/_helpers.tpl
@@ -188,7 +188,9 @@ Sentry:
 Experiment:
 {{ range $expEngine := .Values.turing.experimentEngines }}
   {{ $expEngine.name }}:
+{{ if $expEngine.options }}
 {{ toYaml $expEngine.options | indent 4 }}
+{{ end }}
 {{ if eq (toString $expEngine.type) "rpc-plugin" }}
     plugin_binary: {{ include "turing.plugins.directory" . }}/{{ $expEngine.name }}
 {{ end }}

--- a/infra/charts/turing/values.yaml
+++ b/infra/charts/turing/values.yaml
@@ -101,7 +101,7 @@ turing:
     useInClusterConfig: false
 
   # -- Turing Experiment Engines configuration
-  experimentEngines: {}
+  experimentEngines: []
   # Example:
   # - name: my-exp-engine
   #   type: rpc-plugin


### PR DESCRIPTION
This PR makes the following 2 minor fixes to the helm chart:
* `infra/charts/turing/values.yaml` - The default value for the `experimentEngines` should be a map rather than a list, as it is processed so. Having `{}` as the default would cause the following warnings during a helm install:
```
coalesce.go:200: warning: cannot overwrite table with non table for experimentEngines (map[])
```
* `infra/charts/turing/templates/_helpers.tpl` - When an experiment engine is registered but the `options` are unset (either the key does not exist or the value is an empty map `{}`), the `{{ toYaml $expEngine.options | indent 4 }}` causes problems with the indentation of other lines:
```
Error: 'error converting YAML to JSON: yaml: line 32: mapping values are not allowed
      in this context'
```
This is simply handled by adding a check for empty options. 

The chart version has been bumped up.