### PR TITLE
Add dynamic loading of Experiment Engine config

### DIFF
--- a/ui/.env
+++ b/ui/.env
@@ -28,7 +28,7 @@ REACT_APP_MAX_ALLOWED_REPLICA=10
 REACT_APP_SENTRY_DSN=
 
 # Default Experiment Engine Remote UI settings.
-REACT_APP_DEFAULT_EXPERIMENT_ENGINE={"name":"","url":""}
+REACT_APP_DEFAULT_EXPERIMENT_ENGINE={"name":"","url":"","config":""}
 
 # JSON string map, key being the (unroutable) path used by the remote app for API calls,
 # and value being the URL to proxy to. Used only in local development mode, to bypass CORS.

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -80,6 +80,13 @@ const alertConfig = {
     appConfig.environment === "dev" ? "development" : appConfig.environment,
 };
 
+/**
+ * Default Experiment Engine setting
+ *
+ * name: Name of Experiment Engine
+ * url: URL Path to load Experiment Engine
+ * config: URL Path to load Experiment Engine Config
+ */
 const defaultExperimentEngine = process.env.REACT_APP_DEFAULT_EXPERIMENT_ENGINE
   ? JSON.parse(process.env.REACT_APP_DEFAULT_EXPERIMENT_ENGINE)
   : {};

--- a/ui/src/experiment/ExperimentsRouter.js
+++ b/ui/src/experiment/ExperimentsRouter.js
@@ -45,26 +45,25 @@ const RemoteRouter = ({ projectId }) => {
       ? "Failed to load Experiment Engine"
       : "Loading Experiment Engine ...";
     return <FallbackView text={text} />;
-  } else if (!configReady && !configFailed) {
-    // Config has not loaded - Do nothing
-  } else if (!configReady || configFailed) {
-    const text = configFailed
-      ? "Failed to load Experiment Engine Config"
-      : "Loading Experiment Engine Config...";
-    return <FallbackView text={text} />;
+  } else if (!!defaultExperimentEngine.config && !configReady) {
+    return configFailed ? (
+      <FallbackView text={"Failed to load Experiment Engine Config"} />
+    ) : (
+      <>
+        <LoadDynamicScript
+          setReady={setConfigReady}
+          setFailed={setConfigFailed}
+          url={defaultExperimentEngine.config}
+        />
+        <FallbackView text={"Loading Experiment Engine Config..."} />
+      </>
+    );
   }
 
   // Load component from remote host
   return (
     <React.Suspense
       fallback={<FallbackView text="Loading Experiment Engine config" />}>
-      {!!defaultExperimentEngine.config && (
-        <LoadDynamicScript
-          setConfigReady={setConfigReady}
-          setConfigFailed={setConfigFailed}
-          url={defaultExperimentEngine.config}
-        />
-      )}
       <RemoteComponent
         scope={defaultExperimentEngine.name}
         name="./ExperimentsLandingPage"

--- a/ui/src/experiment/ExperimentsRouter.js
+++ b/ui/src/experiment/ExperimentsRouter.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   EuiPage,
   EuiPageBody,
@@ -39,6 +39,13 @@ const RemoteRouter = ({ projectId }) => {
   // Retrieve script from host dynamically
   const { ready, failed } = useDynamicScript({
     url: defaultExperimentEngine.url,
+  });
+
+  // Re-render to get updated config loading status
+  useEffect(() => {
+    return () => {
+      setConfigStatusLoaded(false);
+    };
   });
 
   if (!ready || failed) {

--- a/ui/src/experiment/ExperimentsRouter.js
+++ b/ui/src/experiment/ExperimentsRouter.js
@@ -38,10 +38,21 @@ const RemoteRouter = ({ projectId }) => {
     url: defaultExperimentEngine.url,
   });
 
+  const { ready: readyConfig, failed: failedConfig } = useDynamicScript({
+    url: defaultExperimentEngine.config,
+  });
+
   if (!ready || failed) {
     const text = failed
       ? "Failed to load Experiment Engine"
       : "Loading Experiment Engine ...";
+    return <FallbackView text={text} />;
+  }
+
+  if (!readyConfig || failedConfig) {
+    const text = failedConfig
+      ? "Failed to load Experiment Engine Config"
+      : "Loading Experiment Engine Config...";
     return <FallbackView text={text} />;
   }
 

--- a/ui/src/hooks/useDynamicScript.js
+++ b/ui/src/hooks/useDynamicScript.js
@@ -41,15 +41,15 @@ const useDynamicScript = (args) => {
 };
 
 // Renderless component wrapper
-export const LoadDynamicScript = ({ url, setConfigReady, setConfigFailed }) => {
+export const LoadDynamicScript = ({ url, setReady, setFailed }) => {
   const { ready, failed } = useDynamicScript({
     url: url,
   });
 
   useEffect(() => {
-    setConfigReady(ready);
-    setConfigFailed(failed);
-  }, [setConfigReady, setConfigFailed, ready, failed]);
+    setReady(ready);
+    setFailed(failed);
+  }, [setReady, setFailed, ready, failed]);
 
   return null;
 };

--- a/ui/src/hooks/useDynamicScript.js
+++ b/ui/src/hooks/useDynamicScript.js
@@ -41,18 +41,15 @@ const useDynamicScript = (args) => {
 };
 
 // Renderless component wrapper
-export const LoadDynamicScript = (props) => {
+export const LoadDynamicScript = ({ url, setConfigReady, setConfigFailed }) => {
   const { ready, failed } = useDynamicScript({
-    url: props.url,
+    url: url,
   });
 
   useEffect(() => {
-    if (props.url) {
-      props.setConfigStatusReady(ready);
-      props.setConfigStatusFailed(failed);
-      props.setConfigStatusLoaded(true);
-    }
-  }, [props, ready, failed]);
+    setConfigReady(ready);
+    setConfigFailed(failed);
+  }, [setConfigReady, setConfigFailed, ready, failed]);
 
   return null;
 };

--- a/ui/src/hooks/useDynamicScript.js
+++ b/ui/src/hooks/useDynamicScript.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 // Ref:
 // https://github.com/module-federation/module-federation-examples/blob/master/dynamic-system-host
@@ -38,6 +38,23 @@ const useDynamicScript = (args) => {
     ready,
     failed,
   };
+};
+
+// Renderless component wrapper
+export const LoadDynamicScript = (props) => {
+  const { ready, failed } = useDynamicScript({
+    url: props.url,
+  });
+
+  useEffect(() => {
+    if (props.url) {
+      props.setConfigStatusReady(ready);
+      props.setConfigStatusFailed(failed);
+      props.setConfigStatusLoaded(true);
+    }
+  }, [props, ready, failed]);
+
+  return null;
 };
 
 export default useDynamicScript;


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR is required to dynamically load any global variables from configured Experiment Engine UI via script tag in Turing's index.html file. This can be done through providing the url of the config, similar to how the url of the UI is provided currently.

**Which issue(s) this PR fixes:**

`NONE`