### PR TITLE
Fix dynamic loading of Experiment Engine config

### DIFF
--- a/ui/src/components/experiments/ExperimentEngineLoaderComponent.js
+++ b/ui/src/components/experiments/ExperimentEngineLoaderComponent.js
@@ -17,7 +17,7 @@ const LoadDynamicScript = ({ url, setReady, setFailed }) => {
 };
 
 // Dynamic Script Loading component wrapper
-export const DynamicHookComponent = ({
+export const ExperimentEngineLoaderComponent = ({
   FallbackView,
   experimentEngine,
   children,
@@ -58,4 +58,4 @@ export const DynamicHookComponent = ({
   return children;
 };
 
-export default DynamicHookComponent;
+export default ExperimentEngineLoaderComponent;

--- a/ui/src/components/remote_component/DynamicHookComponent.js
+++ b/ui/src/components/remote_component/DynamicHookComponent.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from "react";
+
+import useDynamicScript from "../../hooks/useDynamicScript";
+
+// Renderless component wrapper
+const LoadDynamicScript = ({ url, setReady, setFailed }) => {
+  const { ready, failed } = useDynamicScript({
+    url: url,
+  });
+
+  useEffect(() => {
+    setReady(ready);
+    setFailed(failed);
+  }, [setReady, setFailed, ready, failed]);
+
+  return null;
+};
+
+// Dynamic Script Loading component wrapper
+export const DynamicHookComponent = ({
+  FallbackView,
+  experimentEngine,
+  children,
+}) => {
+  const [urlReady, setUrlReady] = useState(false);
+  const [urlFailed, setUrlFailed] = useState(false);
+  const [configReady, setConfigReady] = useState(false);
+  const [configFailed, setConfigFailed] = useState(false);
+
+  if (!!experimentEngine.url && !urlReady) {
+    return urlFailed ? (
+      <FallbackView text={"Failed to load Experiment Engine"} />
+    ) : (
+      <>
+        <LoadDynamicScript
+          setReady={setUrlReady}
+          setFailed={setUrlFailed}
+          url={experimentEngine.url}
+        />
+        <FallbackView text={"Loading Experiment Engine..."} />
+      </>
+    );
+  } else if (!!experimentEngine.config && !configReady) {
+    return configFailed ? (
+      <FallbackView text={"Failed to load Experiment Engine Config"} />
+    ) : (
+      <>
+        <LoadDynamicScript
+          setReady={setConfigReady}
+          setFailed={setConfigFailed}
+          url={experimentEngine.config}
+        />
+        <FallbackView text={"Loading Experiment Engine Config..."} />
+      </>
+    );
+  }
+
+  return children;
+};
+
+export default DynamicHookComponent;

--- a/ui/src/experiment/ExperimentsRouter.js
+++ b/ui/src/experiment/ExperimentsRouter.js
@@ -9,7 +9,7 @@ import {
 } from "@elastic/eui";
 import { PageTitle } from "../components/page/PageTitle";
 import { RemoteComponent } from "../components/remote_component/RemoteComponent";
-import { DynamicHookComponent } from "../components/remote_component/DynamicHookComponent";
+import { ExperimentEngineLoaderComponent } from "../components/experiments/ExperimentEngineLoaderComponent";
 
 import { useConfig } from "../config";
 
@@ -37,7 +37,7 @@ const RemoteRouter = ({ projectId }) => {
   return (
     <React.Suspense
       fallback={<FallbackView text="Loading Experiment Engine config" />}>
-      <DynamicHookComponent
+      <ExperimentEngineLoaderComponent
         FallbackView={FallbackView}
         experimentEngine={defaultExperimentEngine}>
         <RemoteComponent
@@ -46,7 +46,7 @@ const RemoteRouter = ({ projectId }) => {
           fallback={<FallbackView text="Loading Experiment Engine" />}
           projectId={projectId}
         />
-      </DynamicHookComponent>
+      </ExperimentEngineLoaderComponent>
     </React.Suspense>
   );
 };

--- a/ui/src/experiment/ExperimentsRouter.js
+++ b/ui/src/experiment/ExperimentsRouter.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   EuiPage,
   EuiPageBody,
@@ -9,7 +9,7 @@ import {
 } from "@elastic/eui";
 import { PageTitle } from "../components/page/PageTitle";
 import { RemoteComponent } from "../components/remote_component/RemoteComponent";
-import { LoadDynamicScript } from "../hooks/useDynamicScript";
+import { DynamicHookComponent } from "../components/remote_component/DynamicHookComponent";
 
 import { useConfig } from "../config";
 
@@ -32,50 +32,21 @@ const FallbackView = ({ text }) => (
 
 const RemoteRouter = ({ projectId }) => {
   const { defaultExperimentEngine } = useConfig();
-  const [urlReady, setUrlReady] = useState(false);
-  const [urlFailed, setUrlFailed] = useState(false);
-  const [configReady, setConfigReady] = useState(false);
-  const [configFailed, setConfigFailed] = useState(false);
-
-  // Retrieve script from host dynamically
-  if (!!defaultExperimentEngine.url && !urlReady) {
-    return urlFailed ? (
-      <FallbackView text={"Failed to load Experiment Engine"} />
-    ) : (
-      <>
-        <LoadDynamicScript
-          setReady={setUrlReady}
-          setFailed={setUrlFailed}
-          url={defaultExperimentEngine.url}
-        />
-        <FallbackView text={"Loading Experiment Engine..."} />
-      </>
-    );
-  } else if (!!defaultExperimentEngine.config && !configReady) {
-    return configFailed ? (
-      <FallbackView text={"Failed to load Experiment Engine Config"} />
-    ) : (
-      <>
-        <LoadDynamicScript
-          setReady={setConfigReady}
-          setFailed={setConfigFailed}
-          url={defaultExperimentEngine.config}
-        />
-        <FallbackView text={"Loading Experiment Engine Config..."} />
-      </>
-    );
-  }
 
   // Load component from remote host
   return (
     <React.Suspense
       fallback={<FallbackView text="Loading Experiment Engine config" />}>
-      <RemoteComponent
-        scope={defaultExperimentEngine.name}
-        name="./ExperimentsLandingPage"
-        fallback={<FallbackView text="Loading Experiment Engine" />}
-        projectId={projectId}
-      />
+      <DynamicHookComponent
+        FallbackView={FallbackView}
+        experimentEngine={defaultExperimentEngine}>
+        <RemoteComponent
+          scope={defaultExperimentEngine.name}
+          name="./ExperimentsLandingPage"
+          fallback={<FallbackView text="Loading Experiment Engine" />}
+          projectId={projectId}
+        />
+      </DynamicHookComponent>
     </React.Suspense>
   );
 };

--- a/ui/src/experiment/ExperimentsRouter.js
+++ b/ui/src/experiment/ExperimentsRouter.js
@@ -9,7 +9,7 @@ import {
 } from "@elastic/eui";
 import { PageTitle } from "../components/page/PageTitle";
 import { RemoteComponent } from "../components/remote_component/RemoteComponent";
-import useDynamicScript, { LoadDynamicScript } from "../hooks/useDynamicScript";
+import { LoadDynamicScript } from "../hooks/useDynamicScript";
 
 import { useConfig } from "../config";
 
@@ -32,19 +32,25 @@ const FallbackView = ({ text }) => (
 
 const RemoteRouter = ({ projectId }) => {
   const { defaultExperimentEngine } = useConfig();
+  const [urlReady, setUrlReady] = useState(false);
+  const [urlFailed, setUrlFailed] = useState(false);
   const [configReady, setConfigReady] = useState(false);
   const [configFailed, setConfigFailed] = useState(false);
 
   // Retrieve script from host dynamically
-  const { ready, failed } = useDynamicScript({
-    url: defaultExperimentEngine.url,
-  });
-
-  if (!ready || failed) {
-    const text = failed
-      ? "Failed to load Experiment Engine"
-      : "Loading Experiment Engine ...";
-    return <FallbackView text={text} />;
+  if (!!defaultExperimentEngine.url && !urlReady) {
+    return urlFailed ? (
+      <FallbackView text={"Failed to load Experiment Engine"} />
+    ) : (
+      <>
+        <LoadDynamicScript
+          setReady={setUrlReady}
+          setFailed={setUrlFailed}
+          url={defaultExperimentEngine.url}
+        />
+        <FallbackView text={"Loading Experiment Engine..."} />
+      </>
+    );
   } else if (!!defaultExperimentEngine.config && !configReady) {
     return configFailed ? (
       <FallbackView text={"Failed to load Experiment Engine Config"} />

--- a/ui/src/hooks/useDynamicScript.js
+++ b/ui/src/hooks/useDynamicScript.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 // Ref:
 // https://github.com/module-federation/module-federation-examples/blob/master/dynamic-system-host
@@ -38,20 +38,6 @@ const useDynamicScript = (args) => {
     ready,
     failed,
   };
-};
-
-// Renderless component wrapper
-export const LoadDynamicScript = ({ url, setReady, setFailed }) => {
-  const { ready, failed } = useDynamicScript({
-    url: url,
-  });
-
-  useEffect(() => {
-    setReady(ready);
-    setFailed(failed);
-  }, [setReady, setFailed, ready, failed]);
-
-  return null;
 };
 
 export default useDynamicScript;

--- a/ui/src/router/components/configuration/components/ExperimentConfigSection.js
+++ b/ui/src/router/components/configuration/components/ExperimentConfigSection.js
@@ -3,9 +3,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiPanel } from "@elastic/eui";
 
 import { ConfigSectionPanel } from "../../../../components/config_section";
 import { RemoteComponent } from "../../../../components/remote_component/RemoteComponent";
-import useDynamicScript, {
-  LoadDynamicScript,
-} from "../../../../hooks/useDynamicScript";
+import { LoadDynamicScript } from "../../../../hooks/useDynamicScript";
 import ExperimentEngineContext from "../../../../providers/experiments/context";
 
 import { StandardExperimentConfigGroup } from "./experiment_config_section/StandardExperimentConfigGroup";
@@ -27,19 +25,25 @@ const FallbackView = ({ text }) => (
 );
 
 const CustomExperimentConfigView = ({ projectId, remoteUi, config }) => {
+  const [urlReady, setUrlReady] = useState(false);
+  const [urlFailed, setUrlFailed] = useState(false);
   const [configReady, setConfigReady] = useState(false);
   const [configFailed, setConfigFailed] = useState(false);
 
   // Retrieve script from host dynamically
-  const { ready, failed } = useDynamicScript({
-    url: remoteUi.url,
-  });
-
-  if (!ready || failed) {
-    const text = failed
-      ? "Failed to load Experiment Engine"
-      : "Loading Experiment Engine ...";
-    return <FallbackView text={text} />;
+  if (!!remoteUi.url && !urlReady) {
+    return urlFailed ? (
+      <FallbackView text={"Failed to load Experiment Engine"} />
+    ) : (
+      <>
+        <LoadDynamicScript
+          setReady={setUrlReady}
+          setFailed={setUrlFailed}
+          url={remoteUi.url}
+        />
+        <FallbackView text={"Loading Experiment Engine..."} />
+      </>
+    );
   } else if (!!remoteUi.config && !configReady) {
     return configFailed ? (
       <FallbackView text={"Failed to load Experiment Engine Config"} />

--- a/ui/src/router/components/configuration/components/ExperimentConfigSection.js
+++ b/ui/src/router/components/configuration/components/ExperimentConfigSection.js
@@ -3,7 +3,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiPanel } from "@elastic/eui";
 
 import { ConfigSectionPanel } from "../../../../components/config_section";
 import { RemoteComponent } from "../../../../components/remote_component/RemoteComponent";
-import { DynamicHookComponent } from "../../../../components/remote_component/DynamicHookComponent";
+import { ExperimentEngineLoaderComponent } from "../../../../components/experiments/ExperimentEngineLoaderComponent";
 import ExperimentEngineContext from "../../../../providers/experiments/context";
 
 import { StandardExperimentConfigGroup } from "./experiment_config_section/StandardExperimentConfigGroup";
@@ -29,7 +29,7 @@ const CustomExperimentConfigView = ({ projectId, remoteUi, config }) => {
   return (
     <React.Suspense
       fallback={<FallbackView text="Loading Experiment Engine config" />}>
-      <DynamicHookComponent
+      <ExperimentEngineLoaderComponent
         FallbackView={FallbackView}
         experimentEngine={remoteUi}>
         <RemoteComponent
@@ -39,7 +39,7 @@ const CustomExperimentConfigView = ({ projectId, remoteUi, config }) => {
           projectId={projectId}
           config={config}
         />
-      </DynamicHookComponent>
+      </ExperimentEngineLoaderComponent>
     </React.Suspense>
   );
 };

--- a/ui/src/router/components/configuration/components/ExperimentConfigSection.js
+++ b/ui/src/router/components/configuration/components/ExperimentConfigSection.js
@@ -1,9 +1,9 @@
-import React, { Fragment, useContext, useState } from "react";
+import React, { Fragment, useContext } from "react";
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from "@elastic/eui";
 
 import { ConfigSectionPanel } from "../../../../components/config_section";
 import { RemoteComponent } from "../../../../components/remote_component/RemoteComponent";
-import { LoadDynamicScript } from "../../../../hooks/useDynamicScript";
+import { DynamicHookComponent } from "../../../../components/remote_component/DynamicHookComponent";
 import ExperimentEngineContext from "../../../../providers/experiments/context";
 
 import { StandardExperimentConfigGroup } from "./experiment_config_section/StandardExperimentConfigGroup";
@@ -25,51 +25,21 @@ const FallbackView = ({ text }) => (
 );
 
 const CustomExperimentConfigView = ({ projectId, remoteUi, config }) => {
-  const [urlReady, setUrlReady] = useState(false);
-  const [urlFailed, setUrlFailed] = useState(false);
-  const [configReady, setConfigReady] = useState(false);
-  const [configFailed, setConfigFailed] = useState(false);
-
-  // Retrieve script from host dynamically
-  if (!!remoteUi.url && !urlReady) {
-    return urlFailed ? (
-      <FallbackView text={"Failed to load Experiment Engine"} />
-    ) : (
-      <>
-        <LoadDynamicScript
-          setReady={setUrlReady}
-          setFailed={setUrlFailed}
-          url={remoteUi.url}
-        />
-        <FallbackView text={"Loading Experiment Engine..."} />
-      </>
-    );
-  } else if (!!remoteUi.config && !configReady) {
-    return configFailed ? (
-      <FallbackView text={"Failed to load Experiment Engine Config"} />
-    ) : (
-      <>
-        <LoadDynamicScript
-          setReady={setConfigReady}
-          setFailed={setConfigFailed}
-          url={remoteUi.config}
-        />
-        <FallbackView text={"Loading Experiment Engine Config..."} />
-      </>
-    );
-  }
-
   // Load component from remote host
   return (
     <React.Suspense
       fallback={<FallbackView text="Loading Experiment Engine config" />}>
-      <RemoteComponent
-        scope={remoteUi.name}
-        name="./ExperimentEngineConfigDetails"
-        fallback={<FallbackView text="Loading Experiment Engine config" />}
-        projectId={projectId}
-        config={config}
-      />
+      <DynamicHookComponent
+        FallbackView={FallbackView}
+        experimentEngine={remoteUi}>
+        <RemoteComponent
+          scope={remoteUi.name}
+          name="./ExperimentEngineConfigDetails"
+          fallback={<FallbackView text="Loading Experiment Engine config" />}
+          projectId={projectId}
+          config={config}
+        />
+      </DynamicHookComponent>
     </React.Suspense>
   );
 };

--- a/ui/src/router/components/configuration/components/ExperimentConfigSection.js
+++ b/ui/src/router/components/configuration/components/ExperimentConfigSection.js
@@ -1,9 +1,11 @@
-import React, { Fragment, useContext } from "react";
+import React, { Fragment, useContext, useState } from "react";
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from "@elastic/eui";
 
 import { ConfigSectionPanel } from "../../../../components/config_section";
 import { RemoteComponent } from "../../../../components/remote_component/RemoteComponent";
-import useDynamicScript from "../../../../hooks/useDynamicScript";
+import useDynamicScript, {
+  LoadDynamicScript,
+} from "../../../../hooks/useDynamicScript";
 import ExperimentEngineContext from "../../../../providers/experiments/context";
 
 import { StandardExperimentConfigGroup } from "./experiment_config_section/StandardExperimentConfigGroup";
@@ -25,6 +27,9 @@ const FallbackView = ({ text }) => (
 );
 
 const CustomExperimentConfigView = ({ projectId, remoteUi, config }) => {
+  const [configReady, setConfigReady] = useState(false);
+  const [configFailed, setConfigFailed] = useState(false);
+
   // Retrieve script from host dynamically
   const { ready, failed } = useDynamicScript({
     url: remoteUi.url,
@@ -35,6 +40,19 @@ const CustomExperimentConfigView = ({ projectId, remoteUi, config }) => {
       ? "Failed to load Experiment Engine"
       : "Loading Experiment Engine ...";
     return <FallbackView text={text} />;
+  } else if (!!remoteUi.config && !configReady) {
+    return configFailed ? (
+      <FallbackView text={"Failed to load Experiment Engine Config"} />
+    ) : (
+      <>
+        <LoadDynamicScript
+          setReady={setConfigReady}
+          setFailed={setConfigFailed}
+          url={remoteUi.config}
+        />
+        <FallbackView text={"Loading Experiment Engine Config..."} />
+      </>
+    );
   }
 
   // Load component from remote host

--- a/ui/src/router/components/form/components/experiment_config/ExperimentConfigPanel.js
+++ b/ui/src/router/components/form/components/experiment_config/ExperimentConfigPanel.js
@@ -1,9 +1,11 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { EuiFlexItem, EuiSpacer } from "@elastic/eui";
 
 import { RemoteComponent } from "../../../../../components/remote_component/RemoteComponent";
 import ExperimentEngineContext from "../../../../../providers/experiments/context";
-import useDynamicScript from "../../../../../hooks/useDynamicScript";
+import useDynamicScript, {
+  LoadDynamicScript,
+} from "../../../../../hooks/useDynamicScript";
 import { Panel } from "../Panel";
 
 import { StandardExperimentConfigGroup } from "./StandardExperimentConfigGroup";
@@ -24,6 +26,9 @@ const CustomExperimentEngineConfigGroup = ({
   onChangeHandler,
   errors,
 }) => {
+  const [configReady, setConfigReady] = useState(false);
+  const [configFailed, setConfigFailed] = useState(false);
+
   // Retrieve script from host dynamically
   const { ready, failed } = useDynamicScript({
     url: remoteUi.url,
@@ -34,6 +39,19 @@ const CustomExperimentEngineConfigGroup = ({
       ? "Failed to load Experiment Engine"
       : "Loading Experiment Engine ...";
     return <FallbackView text={text} />;
+  } else if (!!remoteUi.config && !configReady) {
+    return configFailed ? (
+      <FallbackView text={"Failed to load Experiment Engine Config"} />
+    ) : (
+      <>
+        <LoadDynamicScript
+          setReady={setConfigReady}
+          setFailed={setConfigFailed}
+          url={remoteUi.config}
+        />
+        <FallbackView text={"Loading Experiment Engine Config..."} />
+      </>
+    );
   }
 
   // Load component from remote host

--- a/ui/src/router/components/form/components/experiment_config/ExperimentConfigPanel.js
+++ b/ui/src/router/components/form/components/experiment_config/ExperimentConfigPanel.js
@@ -1,9 +1,9 @@
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { EuiFlexItem, EuiSpacer } from "@elastic/eui";
 
 import { RemoteComponent } from "../../../../../components/remote_component/RemoteComponent";
 import ExperimentEngineContext from "../../../../../providers/experiments/context";
-import { LoadDynamicScript } from "../../../../../hooks/useDynamicScript";
+import { DynamicHookComponent } from "../../../../../components/remote_component/DynamicHookComponent";
 import { Panel } from "../Panel";
 
 import { StandardExperimentConfigGroup } from "./StandardExperimentConfigGroup";
@@ -24,51 +24,24 @@ const CustomExperimentEngineConfigGroup = ({
   onChangeHandler,
   errors,
 }) => {
-  const [urlReady, setUrlReady] = useState(false);
-  const [urlFailed, setUrlFailed] = useState(false);
-  const [configReady, setConfigReady] = useState(false);
-  const [configFailed, setConfigFailed] = useState(false);
-
-  // Retrieve script from host dynamically
-  if (!!remoteUi.url && !urlReady) {
-    return urlFailed ? (
-      <FallbackView text={"Failed to load Experiment Engine"} />
-    ) : (
-      <>
-        <LoadDynamicScript
-          setReady={setUrlReady}
-          setFailed={setUrlFailed}
-          url={remoteUi.url}
-        />
-        <FallbackView text={"Loading Experiment Engine..."} />
-      </>
-    );
-  } else if (!!remoteUi.config && !configReady) {
-    return configFailed ? (
-      <FallbackView text={"Failed to load Experiment Engine Config"} />
-    ) : (
-      <>
-        <LoadDynamicScript
-          setReady={setConfigReady}
-          setFailed={setConfigFailed}
-          url={remoteUi.config}
-        />
-        <FallbackView text={"Loading Experiment Engine Config..."} />
-      </>
-    );
-  }
-
   // Load component from remote host
   return (
-    <RemoteComponent
-      scope={remoteUi.name}
-      name="./EditExperimentEngineConfig"
-      fallback={<FallbackView text="Loading Experiment Engine config" />}
-      projectId={projectId}
-      config={config}
-      onChangeHandler={onChangeHandler}
-      errors={errors}
-    />
+    <React.Suspense
+      fallback={<FallbackView text="Loading Experiment Engine config" />}>
+      <DynamicHookComponent
+        FallbackView={FallbackView}
+        experimentEngine={remoteUi}>
+        <RemoteComponent
+          scope={remoteUi.name}
+          name="./EditExperimentEngineConfig"
+          fallback={<FallbackView text="Loading Experiment Engine config" />}
+          projectId={projectId}
+          config={config}
+          onChangeHandler={onChangeHandler}
+          errors={errors}
+        />
+      </DynamicHookComponent>
+    </React.Suspense>
   );
 };
 

--- a/ui/src/router/components/form/components/experiment_config/ExperimentConfigPanel.js
+++ b/ui/src/router/components/form/components/experiment_config/ExperimentConfigPanel.js
@@ -3,7 +3,7 @@ import { EuiFlexItem, EuiSpacer } from "@elastic/eui";
 
 import { RemoteComponent } from "../../../../../components/remote_component/RemoteComponent";
 import ExperimentEngineContext from "../../../../../providers/experiments/context";
-import { DynamicHookComponent } from "../../../../../components/remote_component/DynamicHookComponent";
+import { ExperimentEngineLoaderComponent } from "../../../../../components/experiments/ExperimentEngineLoaderComponent";
 import { Panel } from "../Panel";
 
 import { StandardExperimentConfigGroup } from "./StandardExperimentConfigGroup";
@@ -28,7 +28,7 @@ const CustomExperimentEngineConfigGroup = ({
   return (
     <React.Suspense
       fallback={<FallbackView text="Loading Experiment Engine config" />}>
-      <DynamicHookComponent
+      <ExperimentEngineLoaderComponent
         FallbackView={FallbackView}
         experimentEngine={remoteUi}>
         <RemoteComponent
@@ -40,7 +40,7 @@ const CustomExperimentEngineConfigGroup = ({
           onChangeHandler={onChangeHandler}
           errors={errors}
         />
-      </DynamicHookComponent>
+      </ExperimentEngineLoaderComponent>
     </React.Suspense>
   );
 };

--- a/ui/src/router/components/form/components/experiment_config/ExperimentConfigPanel.js
+++ b/ui/src/router/components/form/components/experiment_config/ExperimentConfigPanel.js
@@ -3,9 +3,7 @@ import { EuiFlexItem, EuiSpacer } from "@elastic/eui";
 
 import { RemoteComponent } from "../../../../../components/remote_component/RemoteComponent";
 import ExperimentEngineContext from "../../../../../providers/experiments/context";
-import useDynamicScript, {
-  LoadDynamicScript,
-} from "../../../../../hooks/useDynamicScript";
+import { LoadDynamicScript } from "../../../../../hooks/useDynamicScript";
 import { Panel } from "../Panel";
 
 import { StandardExperimentConfigGroup } from "./StandardExperimentConfigGroup";
@@ -26,19 +24,25 @@ const CustomExperimentEngineConfigGroup = ({
   onChangeHandler,
   errors,
 }) => {
+  const [urlReady, setUrlReady] = useState(false);
+  const [urlFailed, setUrlFailed] = useState(false);
   const [configReady, setConfigReady] = useState(false);
   const [configFailed, setConfigFailed] = useState(false);
 
   // Retrieve script from host dynamically
-  const { ready, failed } = useDynamicScript({
-    url: remoteUi.url,
-  });
-
-  if (!ready || failed) {
-    const text = failed
-      ? "Failed to load Experiment Engine"
-      : "Loading Experiment Engine ...";
-    return <FallbackView text={text} />;
+  if (!!remoteUi.url && !urlReady) {
+    return urlFailed ? (
+      <FallbackView text={"Failed to load Experiment Engine"} />
+    ) : (
+      <>
+        <LoadDynamicScript
+          setReady={setUrlReady}
+          setFailed={setUrlFailed}
+          url={remoteUi.url}
+        />
+        <FallbackView text={"Loading Experiment Engine..."} />
+      </>
+    );
   } else if (!!remoteUi.config && !configReady) {
     return configFailed ? (
       <FallbackView text={"Failed to load Experiment Engine Config"} />


### PR DESCRIPTION
**What this PR does / why we need it:**
A previous related [PR](https://github.com/gojek/turing/pull/202) caused a bug which crashes Routers Details view. This view uses `ExperimentConfigSection` component which requires configured Experiment Engine information retrieved via global variables configured on the Experiment Engine UI. This resulted in runtime configs being NOT loaded into the index.html headers and hence, not available for use.

Logs show the following information:
```
TypeError: Cannot read properties of undefined (reading 'experimentEngineApiUrl')
...
```

This PR addresses the above issue for both `ExperimentConfigSection` and `StandardExperimentConfigGroup` components which load information from the remote Experiment Engine UI.

