### PR TITLE
Add missing config field to RemoteUI struct

### DIFF
--- a/engines/experiment/manager/types.go
+++ b/engines/experiment/manager/types.go
@@ -29,7 +29,8 @@ type RemoteUI struct {
 	Name string `json:"name"`
 	// URL is the Host + Remote Entry file at which the remote UI can be found
 	URL string `json:"url"`
-	// Config is an optional Experiment Engine's Remote Entry file where any shared state can be dynamically loaded during runtime
+	// Config is an optional URL that will be loaded at run-time, to provide the experiment engine
+	// configs dynamically
 	Config string `json:"config,omitempty"`
 }
 

--- a/engines/experiment/manager/types.go
+++ b/engines/experiment/manager/types.go
@@ -29,6 +29,8 @@ type RemoteUI struct {
 	Name string `json:"name"`
 	// URL is the Host + Remote Entry file at which the remote UI can be found
 	URL string `json:"url"`
+	// Config is an optional Experiment Engine's Remote Entry file where any shared state can be dynamically loaded during runtime
+	Config string `json:"config,omitempty"`
 }
 
 type CustomExperimentManagerConfig struct {


### PR DESCRIPTION
**What this PR does / why we need it:**
In relation to previous [PR](https://github.com/gojek/turing/pull/205), `config` field is now optionally used by the UI to dynamically load shared state via a remote entry file and this is required on RemoteUI struct for Experiment Engine plugin as well to be used.
