### PR TITLE
Bugfix: Show Configure Alerts button when router is deployed

### DIFF
--- a/ui/src/router/alerts/details/RouterAlertDetails.js
+++ b/ui/src/router/alerts/details/RouterAlertDetails.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo, useRef } from "react";
+import React, { Fragment, useRef } from "react";
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,13 +18,14 @@ import { supportedAlerts } from "../config";
 
 export const RouterAlertDetails = ({ alertsData, routerStatus, ...props }) => {
   const alertDetailsRef = useRef();
-  const status = useMemo(() => Status.fromValue(routerStatus), [routerStatus]);
 
   return (
     <div ref={alertDetailsRef}>
-      {[Status.UNDEPLOYED, Status.PENDING].includes(status) && (
+      {[Status.UNDEPLOYED, Status.PENDING].includes(routerStatus) && (
         <OverlayMask parentRef={alertDetailsRef} opacity={0.4}>
-          {status === Status.PENDING && <EuiLoadingChart size="xl" mono />}
+          {routerStatus === Status.PENDING && (
+            <EuiLoadingChart size="xl" mono />
+          )}
         </OverlayMask>
       )}
       <EuiFlexGroup alignItems="baseline">
@@ -41,7 +42,7 @@ export const RouterAlertDetails = ({ alertsData, routerStatus, ...props }) => {
           <EuiButton
             size="s"
             onClick={() => props.navigate("./edit")}
-            disabled={status !== Status.DEPLOYED}>
+            disabled={routerStatus !== Status.DEPLOYED}>
             Configure Alerts
           </EuiButton>
         </EuiFlexItem>


### PR DESCRIPTION
This PR is a small fix for a regression introduced by https://github.com/gojek/turing/pull/192, which introduced conversion of the API router / router version response to `TuringRouter` and `RouterVersion` objects, respectively, before passing down to the views. Thus, the conversion of the status string to the `Status` object would have also happened ahead of time and there is no need to do `Status.fromValue` within the `RouterAlertDetails` component. This was missed in the original PR.

![Screenshot 2022-06-10 at 11 05 20 AM](https://user-images.githubusercontent.com/23465343/172982296-8920d27a-553f-4fcc-8446-4eaa38714d78.png)