### PR TITLE
Fix cluster-local annonation, set knative svc defaults

### DIFF
--- a/api/turing/cluster/knative_service.go
+++ b/api/turing/cluster/knative_service.go
@@ -61,7 +61,7 @@ func (cfg *KnativeService) BuildKnativeServiceConfig() *knservingv1.Service {
 	if cfg.IsClusterLocal {
 		// Kservice should only be accessible from within the cluster
 		// https://knative.dev/v1.2-docs/serving/services/private-services/
-		kserviceLabels["serving.knative.dev/visibility"] = "cluster-local"
+		kserviceLabels["networking.knative.dev/visibility"] = "cluster-local"
 	}
 	kserviceObjectMeta := cfg.buildSvcObjectMeta(kserviceLabels)
 

--- a/api/turing/cluster/knative_service.go
+++ b/api/turing/cluster/knative_service.go
@@ -72,10 +72,9 @@ func (cfg *KnativeService) BuildKnativeServiceConfig() *knservingv1.Service {
 		ObjectMeta: *kserviceObjectMeta,
 		Spec:       *kserviceSpec,
 	}
-	// Call setDefaults on desired knative service here to avoid diffs generated because
-	// knative defaulter webhook is called when creating or updating the knative service.
-	// Ref: https://github.com/kserve/kserve/blob/v0.8.0/pkg/controller/v1beta1
-	// /inferenceservice/reconcilers/knative/ksvc_reconciler.go#L159
+	// Call setDefaults on desired knative service here to avoid diffs generated because knative defaulter webhook
+	// is called when creating or updating the knative service. Ref: https://github.com/kserve/kserve/blob/v0.8.0
+	// /pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go#L159
 	svc.SetDefaults(context.TODO())
 	return svc
 }

--- a/api/turing/cluster/knative_service.go
+++ b/api/turing/cluster/knative_service.go
@@ -61,7 +61,7 @@ func (cfg *KnativeService) BuildKnativeServiceConfig() *knservingv1.Service {
 	if cfg.IsClusterLocal {
 		// Kservice should only be accessible from within the cluster
 		// https://knative.dev/v1.2-docs/serving/services/private-services/
-		kserviceLabels["networking.knative.dev/visibility"] = "cluster-local"
+		kserviceLabels["serving.knative.dev/visibility"] = "cluster-local"
 	}
 	kserviceObjectMeta := cfg.buildSvcObjectMeta(kserviceLabels)
 

--- a/api/turing/cluster/knative_service_test.go
+++ b/api/turing/cluster/knative_service_test.go
@@ -85,7 +85,17 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 	}
 
 	// Expected specs
+	var defaultConcurrency, defaultTrafficPercent int64 = 0, 100
+	var defaultLatestRevision bool = true
 	var timeout int64 = 30
+	defaultRouteSpec := knservingv1.RouteSpec{
+		Traffic: []knservingv1.TrafficTarget{
+			{
+				LatestRevision: &defaultLatestRevision,
+				Percent:        &defaultTrafficPercent,
+			},
+		},
+	}
 	resources := corev1.ResourceRequirements{
 		Limits: map[corev1.ResourceName]resource.Quantity{
 			corev1.ResourceCPU:    resource.MustParse("600m"),
@@ -113,6 +123,7 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
+				Name:  "user-container",
 				Image: "asia.gcr.io/gcp-project-id/turing-router:latest",
 				Ports: []corev1.ContainerPort{
 					{
@@ -141,6 +152,7 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 					},
 					InitialDelaySeconds: 20,
 					PeriodSeconds:       10,
+					SuccessThreshold:    1,
 					TimeoutSeconds:      5,
 					FailureThreshold:    5,
 				},
@@ -171,8 +183,8 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 					Name:      "test-svc",
 					Namespace: "test-namespace",
 					Labels: map[string]string{
-						"labelKey":                       "labelVal",
-						"serving.knative.dev/visibility": "cluster-local",
+						"labelKey":                          "labelVal",
+						"networking.knative.dev/visibility": "cluster-local",
 					},
 				},
 				Spec: knservingv1.ServiceSpec{
@@ -192,11 +204,13 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 								},
 							},
 							Spec: knservingv1.RevisionSpec{
-								PodSpec:        podSpec,
-								TimeoutSeconds: &timeout,
+								PodSpec:              podSpec,
+								TimeoutSeconds:       &timeout,
+								ContainerConcurrency: &defaultConcurrency,
 							},
 						},
 					},
+					RouteSpec: defaultRouteSpec,
 				},
 			},
 		},
@@ -234,11 +248,13 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 								},
 							},
 							Spec: knservingv1.RevisionSpec{
-								PodSpec:        podSpec,
-								TimeoutSeconds: &timeout,
+								PodSpec:              podSpec,
+								TimeoutSeconds:       &timeout,
+								ContainerConcurrency: &defaultConcurrency,
 							},
 						},
 					},
+					RouteSpec: defaultRouteSpec,
 				},
 			},
 		},

--- a/api/turing/cluster/knative_service_test.go
+++ b/api/turing/cluster/knative_service_test.go
@@ -183,8 +183,8 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 					Name:      "test-svc",
 					Namespace: "test-namespace",
 					Labels: map[string]string{
-						"labelKey":                          "labelVal",
-						"networking.knative.dev/visibility": "cluster-local",
+						"labelKey":                       "labelVal",
+						"serving.knative.dev/visibility": "cluster-local",
 					},
 				},
 				Spec: knservingv1.ServiceSpec{

--- a/api/turing/cluster/knative_service_test.go
+++ b/api/turing/cluster/knative_service_test.go
@@ -183,8 +183,8 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 					Name:      "test-svc",
 					Namespace: "test-namespace",
 					Labels: map[string]string{
-						"labelKey":                       "labelVal",
-						"serving.knative.dev/visibility": "cluster-local",
+						"labelKey":                          "labelVal",
+						"networking.knative.dev/visibility": "cluster-local",
 					},
 				},
 				Spec: knservingv1.ServiceSpec{


### PR DESCRIPTION
In recent versions of Knative, the private resources must be created with the `networking.knative.dev/visibility=cluster-local` label which was previously `serving.knative.dev/visibility=cluster-local`. See:
* https://github.com/knative/serving/blob/knative-v1.0.1/config/core/configmaps/domain.yaml#L58
* https://knative.dev/v1.2-docs/serving/services/private-services/

Without the right label, the Enrichers and Ensemblers will have both sets of hosts mapped (cluster-local and external-ip).

### E2e Test Flakiness
In https://github.com/gojek/turing/pull/207, the Knative `net-istio` controller (used in e2e tests) was upgraded to `1.0.0`. The same version of the controller is used internally in Gojek, to run e2e tests against a GKE cluster. The tests were proving to be flaky with both the routers (accessed via the ingress gateway) and enrichers/ensemblers (accessed as cluster-local endpoints) intermittently returning 404. This was especially more commonly observed with the ensemblers used in the tests.

This PR corrects the service visibility label which seems to fix the intermittent issues. It's not clear (to me) why that is the case - from examining the logic for the `net-istio` controller ([here](https://github.com/knative-sandbox/net-istio/blob/knative-v1.0.0/pkg/reconciler/ingress/ingress.go#L221) and [here](https://github.com/knative-sandbox/net-istio/blob/knative-v1.0.0/vendor/knative.dev/networking/pkg/status/status.go#L444)) and observing its logs, the Kingress is marked as `LoadBalancerReady`, in the same fashion, having received no failed / unknown probe status for the relevant endpoints even in the scenarios where the tests fail (example screenshot below shows the first host for each rule in the Kservice being probed; no corresponding failure logs seen).

![scr](https://user-images.githubusercontent.com/23465343/173616727-15fc18c3-9c53-4dd7-a08e-1a8eb9814a88.png)

Nevertheless, the change from this PR has been tested numerous times on the internal CI and the e2e tests consistently pass.

### Service Defaults
Inspired by Kserve's implementation, this PR also adds a small change to set the defaults on the KService specs before submitting it for creation / update, to prevent some unnecessary detection of changes during processing.