### PR TITLE
Fix experiment engine dynamic config load

### DIFF
--- a/ui/src/components/experiments/ExperimentEngineLoaderComponent.js
+++ b/ui/src/components/experiments/ExperimentEngineLoaderComponent.js
@@ -27,35 +27,31 @@ export const ExperimentEngineLoaderComponent = ({
   const [configReady, setConfigReady] = useState(false);
   const [configFailed, setConfigFailed] = useState(false);
 
-  if (!!experimentEngine.url && !urlReady) {
-    return urlFailed ? (
-      <FallbackView text={"Failed to load Experiment Engine"} />
-    ) : (
-      <>
+  return urlFailed ? (
+    <FallbackView text={"Failed to load Experiment Engine"} />
+  ) : configFailed ? (
+    <FallbackView text={"Failed to load Experiment Engine Config"} />
+  ) : !urlReady || !configReady ? (
+    <>
+      {!!experimentEngine.url && !urlReady && (
         <LoadDynamicScript
           setReady={setUrlReady}
           setFailed={setUrlFailed}
           url={experimentEngine.url}
         />
-        <FallbackView text={"Loading Experiment Engine..."} />
-      </>
-    );
-  } else if (!!experimentEngine.config && !configReady) {
-    return configFailed ? (
-      <FallbackView text={"Failed to load Experiment Engine Config"} />
-    ) : (
-      <>
+      )}
+      {!!experimentEngine.config && !configReady && (
         <LoadDynamicScript
           setReady={setConfigReady}
           setFailed={setConfigFailed}
           url={experimentEngine.config}
         />
-        <FallbackView text={"Loading Experiment Engine Config..."} />
-      </>
-    );
-  }
-
-  return children;
+      )}
+      <FallbackView text={"Loading Experiment Engine..."} />
+    </>
+  ) : (
+    children
+  );
 };
 
 export default ExperimentEngineLoaderComponent;


### PR DESCRIPTION
### Bug
When a custom experiment engine's remote UI must be loaded, the current implementation of the `ExperimentEngineLoaderComponent` loads the remote entry file first and then the dynamic config, if any, sequentially. If both succeed, the children of the component (which would attempt to load the specific remote components from the remote engine UI) will be returned. Intermittently, the config loader fails to be mounted with the following warning:

<img width="739" alt="Screenshot 2022-07-10 at 11 37 37 AM" src="https://user-images.githubusercontent.com/23465343/178138526-d3facff8-5343-4ccd-8738-78e0b695bb56.png">

As a result, the experiment engine's dynamic configs are not loaded which causes unexpected behaviours in the respective views - this can only be reset with a hard refresh. As an example, we see the below error with the [turing-experiments](https://github.com/gojek/turing-experiments) engine, when viewing a router (the API host, which was supposed to have been retrieved from the dynamic configs is missing, and the dummy [default value](https://github.com/gojek/turing-experiments/blob/main/ui/.env#L8) that's compiled into the UI build is taken).

<img width="1680" alt="Screenshot 2022-07-10 at 11 26 54 AM" src="https://user-images.githubusercontent.com/23465343/178138998-d77dafb1-1813-4786-b773-fd5a91e23f89.png">

<img width="1512" alt="Screenshot 2022-07-10 at 3 04 08 PM" src="https://user-images.githubusercontent.com/23465343/178138650-7bc20a41-6d69-4230-930f-175710f2b562.png">

### Fix
The fix refactors the `ExperimentEngineLoaderComponent` so that the remote entry file as well as the config file of the custom experiment engine will be loaded using the same parent component which is also responsible for returning the `children` - this fixes the warning (and the subsequent error) and also has the advantage of parallel retrieval of the script files.