### PR TITLE
Use background context rather than cancelled context

### DIFF
--- a/api/turing/cluster/controller.go
+++ b/api/turing/cluster/controller.go
@@ -719,7 +719,7 @@ func (c *controller) waitKnativeServiceReady(
 	for {
 		select {
 		case <-ctx.Done():
-			terminationMessage := c.getKnativePodTerminationMessage(ctx, svcName, namespace)
+			terminationMessage := c.getKnativePodTerminationMessage(context.Background(), svcName, namespace)
 			if terminationMessage == "" {
 				// Pod was not created (as with invalid image names), get status messages from the knative service.
 				svc, err := services.Get(ctx, svcName, metav1.GetOptions{})

--- a/api/turing/cluster/controller.go
+++ b/api/turing/cluster/controller.go
@@ -64,16 +64,13 @@ type clusterConfig struct {
 // Controller defines the operations supported by the cluster controller
 type Controller interface {
 	DeployKnativeService(ctx context.Context, svc *KnativeService) error
-	DeleteKnativeService(ctx context.Context, svcName string,
-		namespace string, timeout time.Duration, ignoreNotFound bool) error
+	DeleteKnativeService(ctx context.Context, svcName string, namespace string, ignoreNotFound bool) error
 	GetKnativeServiceURL(ctx context.Context, svcName string, namespace string) string
 	ApplyIstioVirtualService(ctx context.Context, routerEndpoint *VirtualService) error
-	DeleteIstioVirtualService(ctx context.Context, svcName string, namespace string, timeout time.Duration) error
+	DeleteIstioVirtualService(ctx context.Context, svcName string, namespace string) error
 	DeployKubernetesService(ctx context.Context, svc *KubernetesService) error
-	DeleteKubernetesDeployment(ctx context.Context, name string,
-		namespace string, timeout time.Duration, ignoreNotFound bool) error
-	DeleteKubernetesService(ctx context.Context, svcName string,
-		namespace string, timeout time.Duration, ignoreNotFound bool) error
+	DeleteKubernetesDeployment(ctx context.Context, name string, namespace string, ignoreNotFound bool) error
+	DeleteKubernetesService(ctx context.Context, svcName string, namespace string, ignoreNotFound bool) error
 	CreateNamespace(ctx context.Context, name string) error
 	ApplyConfigMap(ctx context.Context, namespace string, configMap *ConfigMap) error
 	DeleteConfigMap(ctx context.Context, name string, namespace string, ignoreNotFound bool) error
@@ -305,7 +302,6 @@ func (c *controller) DeleteKnativeService(
 	ctx context.Context,
 	svcName string,
 	namespace string,
-	timeout time.Duration,
 	ignoreNotFound bool,
 ) error {
 	// Init knative ServicesGetter
@@ -321,12 +317,7 @@ func (c *controller) DeleteKnativeService(
 	}
 
 	// Delete the service
-	gracePeriod := int64(timeout.Seconds())
-	delOptions := metav1.DeleteOptions{
-		GracePeriodSeconds: &gracePeriod,
-	}
-
-	return services.Delete(ctx, svcName, delOptions)
+	return services.Delete(ctx, svcName, metav1.DeleteOptions{})
 }
 
 // DeployKubernetesService deploys a kubernetes service and deployment
@@ -396,14 +387,8 @@ func (c *controller) DeleteKubernetesDeployment(
 	ctx context.Context,
 	name string,
 	namespace string,
-	timeout time.Duration,
 	ignoreNotFound bool,
 ) error {
-	gracePeriod := int64(timeout.Seconds())
-	delOptions := metav1.DeleteOptions{
-		GracePeriodSeconds: &gracePeriod,
-	}
-
 	deployments := c.k8sAppsClient.Deployments(namespace)
 	_, err := deployments.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
@@ -412,7 +397,7 @@ func (c *controller) DeleteKubernetesDeployment(
 		}
 		return err
 	}
-	return deployments.Delete(ctx, name, delOptions)
+	return deployments.Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 // DeleteKubernetesService deletes a kubernetes service
@@ -420,14 +405,8 @@ func (c *controller) DeleteKubernetesService(
 	ctx context.Context,
 	svcName string,
 	namespace string,
-	timeout time.Duration,
 	ignoreNotFound bool,
 ) error {
-	gracePeriod := int64(timeout.Seconds())
-	delOptions := metav1.DeleteOptions{
-		GracePeriodSeconds: &gracePeriod,
-	}
-
 	services := c.k8sCoreClient.Services(namespace)
 	_, err := services.Get(ctx, svcName, metav1.GetOptions{})
 	if err != nil {
@@ -436,7 +415,7 @@ func (c *controller) DeleteKubernetesService(
 		}
 		return err
 	}
-	return services.Delete(ctx, svcName, delOptions)
+	return services.Delete(ctx, svcName, metav1.DeleteOptions{})
 }
 
 // ApplyIstioVirtualService creates a virtual service if not exists, if exists, updates the
@@ -459,18 +438,13 @@ func (c *controller) DeleteIstioVirtualService(
 	ctx context.Context,
 	svcName string,
 	namespace string,
-	timeout time.Duration,
 ) error {
 	vservices := c.istioClient.VirtualServices(namespace)
 	_, err := vservices.Get(ctx, svcName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to retrieve virtual service %s: %s", svcName, err.Error())
 	}
-	gracePeriod := int64(timeout.Seconds())
-	delOptions := metav1.DeleteOptions{
-		GracePeriodSeconds: &gracePeriod,
-	}
-	return vservices.Delete(ctx, svcName, delOptions)
+	return vservices.Delete(ctx, svcName, metav1.DeleteOptions{})
 }
 
 // CreateSecret creates a secret. If the secret already exists, the existing secret will be updated.

--- a/api/turing/cluster/controller_test.go
+++ b/api/turing/cluster/controller_test.go
@@ -475,7 +475,7 @@ func TestDeleteKnativeService(t *testing.T) {
 			// Create test controller
 			c := createTestKnController(cs, tc.reactors)
 			// Run test
-			err := c.DeleteKnativeService(ctx, testName, testNamespace, time.Second*5, tc.ignoreNotFound)
+			err := c.DeleteKnativeService(ctx, testName, testNamespace, tc.ignoreNotFound)
 			// Validate no error
 			assert.Equal(t, err != nil, tc.hasErr)
 		})
@@ -568,7 +568,7 @@ func TestDeleteKubernetesDeployment(t *testing.T) {
 			// Create test controller
 			c := createTestK8sController(cs, tc.reactors)
 			// Run test
-			err := c.DeleteKubernetesDeployment(ctx, testName, testNamespace, time.Second*5, tc.ignoreNotFound)
+			err := c.DeleteKubernetesDeployment(ctx, testName, testNamespace, tc.ignoreNotFound)
 			// Validate no error
 			assert.Equal(t, err != nil, tc.hasErr)
 		})
@@ -660,7 +660,7 @@ func TestDeleteKubernetesService(t *testing.T) {
 			// Create test controller
 			c := createTestK8sController(cs, tc.reactors)
 			// Run test
-			err := c.DeleteKubernetesService(ctx, testName, testNamespace, time.Second*5, tc.ignoreNotFound)
+			err := c.DeleteKubernetesService(ctx, testName, testNamespace, tc.ignoreNotFound)
 			// Validate no error
 			assert.Equal(t, err != nil, tc.hasErr)
 		})
@@ -1840,7 +1840,7 @@ func TestDeleteIstioVirtualService(t *testing.T) {
 	defer cancel()
 
 	// Run test
-	err := c.DeleteIstioVirtualService(ctx, vsConf.Name, testNamespace, time.Second*5)
+	err := c.DeleteIstioVirtualService(ctx, vsConf.Name, testNamespace)
 	// Validate no error
 	assert.NoError(t, err)
 }

--- a/api/turing/cluster/mocks/controller.go
+++ b/api/turing/cluster/mocks/controller.go
@@ -15,8 +15,6 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 
-	time "time"
-
 	v1 "k8s.io/api/batch/v1"
 
 	v1beta2 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
@@ -226,13 +224,13 @@ func (_m *Controller) DeleteConfigMap(ctx context.Context, name string, namespac
 	return r0
 }
 
-// DeleteIstioVirtualService provides a mock function with given fields: ctx, svcName, namespace, timeout
-func (_m *Controller) DeleteIstioVirtualService(ctx context.Context, svcName string, namespace string, timeout time.Duration) error {
-	ret := _m.Called(ctx, svcName, namespace, timeout)
+// DeleteIstioVirtualService provides a mock function with given fields: ctx, svcName, namespace
+func (_m *Controller) DeleteIstioVirtualService(ctx context.Context, svcName string, namespace string) error {
+	ret := _m.Called(ctx, svcName, namespace)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, time.Duration) error); ok {
-		r0 = rf(ctx, svcName, namespace, timeout)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, svcName, namespace)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -254,13 +252,13 @@ func (_m *Controller) DeleteJob(ctx context.Context, namespace string, jobName s
 	return r0
 }
 
-// DeleteKnativeService provides a mock function with given fields: ctx, svcName, namespace, timeout, ignoreNotFound
-func (_m *Controller) DeleteKnativeService(ctx context.Context, svcName string, namespace string, timeout time.Duration, ignoreNotFound bool) error {
-	ret := _m.Called(ctx, svcName, namespace, timeout, ignoreNotFound)
+// DeleteKnativeService provides a mock function with given fields: ctx, svcName, namespace, ignoreNotFound
+func (_m *Controller) DeleteKnativeService(ctx context.Context, svcName string, namespace string, ignoreNotFound bool) error {
+	ret := _m.Called(ctx, svcName, namespace, ignoreNotFound)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, time.Duration, bool) error); ok {
-		r0 = rf(ctx, svcName, namespace, timeout, ignoreNotFound)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) error); ok {
+		r0 = rf(ctx, svcName, namespace, ignoreNotFound)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -268,13 +266,13 @@ func (_m *Controller) DeleteKnativeService(ctx context.Context, svcName string, 
 	return r0
 }
 
-// DeleteKubernetesDeployment provides a mock function with given fields: ctx, name, namespace, timeout, ignoreNotFound
-func (_m *Controller) DeleteKubernetesDeployment(ctx context.Context, name string, namespace string, timeout time.Duration, ignoreNotFound bool) error {
-	ret := _m.Called(ctx, name, namespace, timeout, ignoreNotFound)
+// DeleteKubernetesDeployment provides a mock function with given fields: ctx, name, namespace, ignoreNotFound
+func (_m *Controller) DeleteKubernetesDeployment(ctx context.Context, name string, namespace string, ignoreNotFound bool) error {
+	ret := _m.Called(ctx, name, namespace, ignoreNotFound)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, time.Duration, bool) error); ok {
-		r0 = rf(ctx, name, namespace, timeout, ignoreNotFound)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) error); ok {
+		r0 = rf(ctx, name, namespace, ignoreNotFound)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -282,13 +280,13 @@ func (_m *Controller) DeleteKubernetesDeployment(ctx context.Context, name strin
 	return r0
 }
 
-// DeleteKubernetesService provides a mock function with given fields: ctx, svcName, namespace, timeout, ignoreNotFound
-func (_m *Controller) DeleteKubernetesService(ctx context.Context, svcName string, namespace string, timeout time.Duration, ignoreNotFound bool) error {
-	ret := _m.Called(ctx, svcName, namespace, timeout, ignoreNotFound)
+// DeleteKubernetesService provides a mock function with given fields: ctx, svcName, namespace, ignoreNotFound
+func (_m *Controller) DeleteKubernetesService(ctx context.Context, svcName string, namespace string, ignoreNotFound bool) error {
+	ret := _m.Called(ctx, svcName, namespace, ignoreNotFound)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, time.Duration, bool) error); ok {
-		r0 = rf(ctx, svcName, namespace, timeout, ignoreNotFound)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) error); ok {
+		r0 = rf(ctx, svcName, namespace, ignoreNotFound)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -353,11 +353,11 @@ func TestDeleteEndpoint(t *testing.T) {
 	// Create mock controller
 	controller := &mocks.Controller{}
 	controller.On("DeleteKnativeService", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, false).Return(nil)
+		mock.Anything, false).Return(nil)
 	controller.On("DeleteKubernetesDeployment", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, false).Return(nil)
+		mock.Anything, false).Return(nil)
 	controller.On("DeleteKubernetesService", mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, false).Return(nil)
+		mock.Anything, false).Return(nil)
 	controller.On("DeleteSecret", mock.Anything, mock.Anything, mock.Anything, false).Return(nil)
 	controller.On("DeleteConfigMap", mock.Anything, mock.Anything, mock.Anything, false).Return(nil)
 	controller.On("DeletePersistentVolumeClaim", mock.Anything, mock.Anything, mock.Anything, false).Return(nil)
@@ -410,11 +410,11 @@ func TestDeleteEndpoint(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	controller.AssertCalled(t, "DeleteKubernetesService",
-		mock.Anything, "test-svc-fluentd-logger-1", testNs, timeout, false)
+		mock.Anything, "test-svc-fluentd-logger-1", testNs, false)
 	controller.AssertCalled(t, "DeleteConfigMap", mock.Anything, "test-svc-fiber-config-1", testNs, false)
-	controller.AssertCalled(t, "DeleteKnativeService", mock.Anything, "test-svc-enricher-1", testNs, timeout, false)
-	controller.AssertCalled(t, "DeleteKnativeService", mock.Anything, "test-svc-ensembler-1", testNs, timeout, false)
-	controller.AssertCalled(t, "DeleteKnativeService", mock.Anything, "test-svc-router-1", testNs, timeout, false)
+	controller.AssertCalled(t, "DeleteKnativeService", mock.Anything, "test-svc-enricher-1", testNs, false)
+	controller.AssertCalled(t, "DeleteKnativeService", mock.Anything, "test-svc-ensembler-1", testNs, false)
+	controller.AssertCalled(t, "DeleteKnativeService", mock.Anything, "test-svc-router-1", testNs, false)
 	controller.AssertCalled(t, "DeleteSecret", mock.Anything, "test-svc-svc-acct-secret-1", testNs, false)
 	controller.AssertCalled(t, "DeletePersistentVolumeClaim", mock.Anything, "pvc", testNs, false)
 	controller.AssertNumberOfCalls(t, "DeleteKnativeService", 3)


### PR DESCRIPTION
### Bug
Turing's dependency on Kubernetes API was updated in https://github.com/gojek/turing/pull/183 and most Kubernetes APIs now require context to be passed which caused a regression. When [ctx.Done()](https://github.com/gojek/turing/blob/main/api/turing/cluster/controller.go#L721) is called, the context was cancelled and ctx.Err() returns a non-nil error. Thus, when passed to [ListPods API](https://github.com/gojek/turing/blob/main/api/turing/cluster/controller.go#L751), when the ctx.Err() value is first checked, the call exits given a non-nil error and pods that satisfy the provided labels are never returned, causing termination logs to NOT be propagated to the user.

### Fix
The fix uses a new empty context via context.Background(), which will not be cancelled and that allows Kubernetes Go Client ListPods API to retrieve the correct pods based on provided labels. Then, the container error logs from Terminated state can be propagated as event logs to the user.

![image](https://user-images.githubusercontent.com/25025366/179706321-fd22bfb1-9da4-4d27-b7c6-3ad0d1eb5f0e.png)

### Enhancements
In addition, this PR standardizes how context is being used for the following workflows:
- Creation/Updation: Use ctx with Deployment timeout as specified in config
- Deletion: Use context.Background() with no timeouts (Some functions in api/turing/cluster/controller.go have their timeout parameter removed)
  - GracePeriodSeconds exposed by Kubernetes Go client's `metav1.DeleteOptions{}` is optional
