### PR TITLE
Pass original request headers merged with enricher response headers to Pyfunc ensembler

### DIFF
--- a/docs/how-to/create-a-router/configure-ensembler.md
+++ b/docs/how-to/create-a-router/configure-ensembler.md
@@ -26,7 +26,7 @@ It is not possible to select as the fallback response a route that has traffic r
 {% endhint %}
 
 ## Docker
-Turing will deploy specified image as a post-processor and will send the in the request payload the original request, responses from all routes, and the treatment configuration (if a Experiment Engine is selected, in Configure Experiment Engine), for ensembling. The ensembler's request headers will contain the original request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in the enricher's response headers will take precedence). To configure a Docker ensembler, there are 3 sections to be filled.
+Turing will deploy the specified image as a post-processor and will send the in the request payload the original request, responses from all routes, and the treatment configuration (if an Experiment Engine is selected, in Configure Experiment Engine), for ensembling. The ensembler's request headers will contain the original request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in the enricher's response headers will take precedence). To configure a Docker ensembler, there are 3 sections to be filled.
 
 Configure the Docker Container. There are 4 required inputs.
 

--- a/docs/how-to/create-a-router/configure-ensembler.md
+++ b/docs/how-to/create-a-router/configure-ensembler.md
@@ -2,7 +2,7 @@
 
 Turing currently supports ensemblers in the same fashion as the enrichers. The ensembling is controlled by the policy from the rule engine.
 
-Currently, there are 4 options available - no ensembler, a standard ensembler, Docker and an external ensembler.
+Currently, there are 4 options available - no ensembler, a standard ensembler, Docker and Pyfunc ensembler.
 
 ## No Ensembler
 The router will return a response from the route configured to act as the final response. This option is available only when **no experiment engine** is configured in Configure Experiment Engine.
@@ -26,7 +26,7 @@ It is not possible to select as the fallback response a route that has traffic r
 {% endhint %}
 
 ## Docker
-Turing will deploy specified image as a post-processor and will send the original request, responses from all routes, and the treatment configuration (if a Experiment Engine is selected, in Configure Experiment Engine), for ensembling. To configure a Docker ensembler, there are 3 sections to be filled.
+Turing will deploy specified image as a post-processor and will send the in the request payload the original request, responses from all routes, and the treatment configuration (if a Experiment Engine is selected, in Configure Experiment Engine), for ensembling. The ensembler's request headers will contain the original request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in the enricher's response headers will take precedence). To configure a Docker ensembler, there are 3 sections to be filled.
 
 Configure the Docker Container. There are 4 required inputs.
 

--- a/docs/how-to/create-a-router/configure-ensembler.md
+++ b/docs/how-to/create-a-router/configure-ensembler.md
@@ -26,7 +26,7 @@ It is not possible to select as the fallback response a route that has traffic r
 {% endhint %}
 
 ## Docker
-Turing will deploy the specified image as a post-processor and will send the in the request payload the original request, responses from all routes, and the treatment configuration (if an Experiment Engine is selected, in Configure Experiment Engine), for ensembling. The ensembler's request headers will contain the original request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in the enricher's response headers will take precedence). To configure a Docker ensembler, there are 3 sections to be filled.
+Turing will deploy the specified image as a post-processor and will send in the request payload the following, for ensembling - the original request, responses from all routes, and the treatment configuration (if an Experiment Engine is selected, in Configure Experiment Engine). The ensembler's request headers will contain the original request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in the enricher's response headers will take precedence). To configure a Docker ensembler, there are 3 sections to be filled.
 
 Configure the Docker Container. There are 4 required inputs.
 

--- a/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/ensembler_runner.py
+++ b/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/ensembler_runner.py
@@ -16,11 +16,10 @@ class PyFuncEnsemblerRunner:
 
     def load(self):
         self._ensembler = pyfunc.load_model(self.artifact_dir)
-        # If the predict_legacy method is found on the ensembler, it is created from a newer SDK version
-        # that supports both versions of the predict API.
+        # If the VERSION attribute is not found on the ensembler, it is created from an older SDK version
+        # that is not adapted to receive request headers.
         try:
             self._is_legacy_ensembler = not hasattr(self._ensembler._model_impl.python_model, "VERSION")
-            print(dir(self._ensembler._model_impl.python_model))
         except:
             pass
 

--- a/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/ensembler_runner.py
+++ b/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/ensembler_runner.py
@@ -12,23 +12,12 @@ class PyFuncEnsemblerRunner:
     def __init__(self, artifact_dir: str):
         self.artifact_dir = artifact_dir
         self._ensembler = None
-        self._is_legacy_ensembler = False
 
     def load(self):
         self._ensembler = pyfunc.load_model(self.artifact_dir)
-        # If the VERSION attribute is not found on the ensembler, it is created from an older SDK version
-        # that is not adapted to receive request headers.
-        try:
-            self._is_legacy_ensembler = not hasattr(self._ensembler._model_impl.python_model, "VERSION")
-        except:
-            pass
 
     def predict(self, body: Dict[str, Any], headers: Dict[str, str]) -> List[Any]:
         logging.info(f"Input request payload: {body}")
-        if self._is_legacy_ensembler:
-            output = self._ensembler.predict(body)
-        else:
-            # Wrap request headers and body into a Dict
-            output = self._ensembler.predict({"headers": headers, "body": body})
+        output = self._ensembler.predict({"headers": headers, "body": body})
         logging.info(f"Output response: {output}")
         return output

--- a/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/ensembler_runner.py
+++ b/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/ensembler_runner.py
@@ -12,12 +12,24 @@ class PyFuncEnsemblerRunner:
     def __init__(self, artifact_dir: str):
         self.artifact_dir = artifact_dir
         self._ensembler = None
+        self._is_legacy_ensembler = False
 
     def load(self):
         self._ensembler = pyfunc.load_model(self.artifact_dir)
+        # If the predict_legacy method is found on the ensembler, it is created from a newer SDK version
+        # that supports both versions of the predict API.
+        try:
+            self._is_legacy_ensembler = not hasattr(self._ensembler._model_impl.python_model, "VERSION")
+            print(dir(self._ensembler._model_impl.python_model))
+        except:
+            pass
 
-    def predict(self, inputs: Dict[str, Any]) -> List[Any]:
-        logging.info(f"Input request payload: {inputs}")
-        output = self._ensembler.predict(inputs)
+    def predict(self, body: Dict[str, Any], headers: Dict[str, str]) -> List[Any]:
+        logging.info(f"Input request payload: {body}")
+        if self._is_legacy_ensembler:
+            output = self._ensembler.predict(body)
+        else:
+            # Wrap request headers and body into a Dict
+            output = self._ensembler.predict({"headers": headers, "body": body})
         logging.info(f"Output response: {output}")
         return output

--- a/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/ensembler_runner.py
+++ b/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/ensembler_runner.py
@@ -18,6 +18,6 @@ class PyFuncEnsemblerRunner:
 
     def predict(self, body: Dict[str, Any], headers: Dict[str, str]) -> List[Any]:
         logging.info(f"Input request payload: {body}")
-        output = self._ensembler.predict({"headers": headers, "body": body})
+        output = self._ensembler.predict({"headers": dict(headers), "body": body})
         logging.info(f"Output response: {output}")
         return output

--- a/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/handler.py
+++ b/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/handler.py
@@ -12,9 +12,8 @@ class EnsemblerHandler(tornado.web.RequestHandler):
         self.ensembler = ensembler
 
     def post(self):
-        request = EnsemblerHandler.validate_request(self.request)
-        response = self.ensembler.predict(request)
-
+        body = EnsemblerHandler.validate_request(self.request)
+        response = self.ensembler.predict(body, self.request.headers)
         response_json = orjson.dumps(response)
         self.write(response_json)
         self.set_header("Content-Type", "application/json; charset=UTF-8")

--- a/engines/pyfunc-ensembler-service/tests/conftest.py
+++ b/engines/pyfunc-ensembler-service/tests/conftest.py
@@ -18,7 +18,7 @@ class TestEnsembler(PyFunc):
         if treatment_config['configuration']['name'] == "choose_the_control":
             return predictions['control']['data']['predictions']
         else:
-            return [0, 0]
+            return kwargs
 
 
 @pytest.fixture

--- a/engines/pyfunc-ensembler-service/tests/conftest.py
+++ b/engines/pyfunc-ensembler-service/tests/conftest.py
@@ -6,7 +6,7 @@ from turing.ensembler import PyFunc
 
 class TestEnsembler(PyFunc):
 
-    def initialize(self, artifacts: dict):
+    def initialize(self, artifacts: Dict):
         pass
 
     def ensemble(
@@ -22,7 +22,7 @@ class TestEnsembler(PyFunc):
 
 class LegacyEnsembler(PyFunc):
 
-    def initialize(self, artifacts: dict):
+    def initialize(self, artifacts: Dict):
         pass
 
     def ensemble(

--- a/engines/pyfunc-ensembler-service/tests/conftest.py
+++ b/engines/pyfunc-ensembler-service/tests/conftest.py
@@ -20,17 +20,39 @@ class TestEnsembler(PyFunc):
         else:
             return kwargs
 
+class LegacyEnsembler(PyFunc):
 
-@pytest.fixture
-def simple_ensembler_uri():
+    def initialize(self, artifacts: dict):
+        pass
+
+    def ensemble(
+            self,
+            input: Dict,
+            predictions: Dict,
+            treatment_config: Dict) -> Any:
+        if treatment_config['configuration']['name'] == "choose_the_control":
+            return predictions['control']['data']['predictions']
+        else:
+            return [0, 0]
+
+
+def get_ensembler_path(model):
     import os
     import mlflow
     from mlflow.pyfunc import log_model
     log_model(
         artifact_path='ensembler',
-        python_model=TestEnsembler(),
+        python_model=model,
         code_path=[os.path.join(os.path.dirname(__file__), '../pyfunc_ensembler_runner')])
 
     ensembler_path = os.path.join(mlflow.get_artifact_uri(), 'ensembler')
 
     return ensembler_path
+
+@pytest.fixture
+def simple_ensembler_uri():
+    return get_ensembler_path(TestEnsembler())
+
+@pytest.fixture
+def legacy_ensembler_uri():
+    return get_ensembler_path(LegacyEnsembler())

--- a/engines/pyfunc-ensembler-service/tests/conftest.py
+++ b/engines/pyfunc-ensembler-service/tests/conftest.py
@@ -13,7 +13,8 @@ class TestEnsembler(PyFunc):
             self,
             input: Dict,
             predictions: Dict,
-            treatment_config: Dict) -> Any:
+            treatment_config: Dict,
+            **kwargs) -> Any:
         if treatment_config['configuration']['name'] == "choose_the_control":
             return predictions['control']['data']['predictions']
         else:

--- a/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
+++ b/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
@@ -32,7 +32,7 @@ with open(os.path.join(data_dir, "request_invalid.json")) as f:
 def test_ensembler_prediction(simple_ensembler_uri, inputs, expected):
     ensembler = PyFuncEnsemblerRunner(simple_ensembler_uri)
     ensembler.load()
-    actual = ensembler.predict(orjson.loads(inputs))
+    actual = ensembler.predict(orjson.loads(inputs), {"Key": "Value"})
     assert actual == expected
 
 

--- a/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
+++ b/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
@@ -20,8 +20,9 @@ with open(os.path.join(data_dir, "request_invalid.json")) as f:
 
 
 @pytest.mark.parametrize(
-    "inputs,headers,expected", [
+    "ensembler_uri,inputs,headers,expected", [
         pytest.param(
+            "simple_ensembler_uri",
             dummy_long_request,
             {},
             [
@@ -30,13 +31,29 @@ with open(os.path.join(data_dir, "request_invalid.json")) as f:
             ]
         ),
         pytest.param(
+            "simple_ensembler_uri",
             dummy_short_request,
             {"Key": "Value"},
             {"headers": {"Key": "Value"}}
+        ),
+        pytest.param(
+            "legacy_ensembler_uri",
+            dummy_long_request,
+            {},
+            [
+                296.15732,
+                0
+            ]
+        ),
+        pytest.param(
+            "legacy_ensembler_uri",
+            dummy_short_request,
+            {"Key": "Value"},
+            [0, 0]
         )
     ])
-def test_ensembler_prediction(simple_ensembler_uri, inputs, headers, expected):
-    ensembler = PyFuncEnsemblerRunner(simple_ensembler_uri)
+def test_ensembler_prediction(ensembler_uri, inputs, headers, expected, request):
+    ensembler = PyFuncEnsemblerRunner(request.getfixturevalue(ensembler_uri))
     ensembler.load()
     actual = ensembler.predict(orjson.loads(inputs), headers)
     assert actual == expected

--- a/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
+++ b/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
@@ -20,9 +20,10 @@ with open(os.path.join(data_dir, "request_invalid.json")) as f:
 
 
 @pytest.mark.parametrize(
-    "inputs,expected", [
+    "inputs,headers,expected", [
         pytest.param(
             dummy_long_request,
+            {},
             [
                 296.15732,
                 0
@@ -30,14 +31,14 @@ with open(os.path.join(data_dir, "request_invalid.json")) as f:
         ),
         pytest.param(
             dummy_short_request,
+            {"Key": "Value"},
             {"headers": {"Key": "Value"}}
         )
     ])
-def test_ensembler_prediction(simple_ensembler_uri, inputs, expected):
+def test_ensembler_prediction(simple_ensembler_uri, inputs, headers, expected):
     ensembler = PyFuncEnsemblerRunner(simple_ensembler_uri)
     ensembler.load()
-    actual = ensembler.predict(orjson.loads(inputs), {"Key": "Value"})
-    print(actual)
+    actual = ensembler.predict(orjson.loads(inputs), headers)
     assert actual == expected
 
 

--- a/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
+++ b/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
@@ -27,12 +27,17 @@ with open(os.path.join(data_dir, "request_invalid.json")) as f:
                 296.15732,
                 0
             ]
+        ),
+        pytest.param(
+            dummy_short_request,
+            {"headers": {"Key": "Value"}}
         )
     ])
 def test_ensembler_prediction(simple_ensembler_uri, inputs, expected):
     ensembler = PyFuncEnsemblerRunner(simple_ensembler_uri)
     ensembler.load()
     actual = ensembler.predict(orjson.loads(inputs), {"Key": "Value"})
+    print(actual)
     assert actual == expected
 
 
@@ -52,12 +57,12 @@ class TestEnsemblerService(AsyncHTTPTestCase):
         return PyFuncEnsemblerServer(ensembler).create_application()
 
     def test_valid_request(self):
-        response = self.fetch('/ensemble', method="POST", body=dummy_long_request)
+        response = self.fetch("/ensemble", method="POST", body=dummy_long_request)
         self.assertEqual(response.code, 200)
         self.assertEqual(orjson.loads(response.body), [296.15732, 0])
 
     def test_invalid_request(self):
-        response = self.fetch('/ensemble', method="POST", body=dummy_invalid_request)
+        response = self.fetch("/ensemble", method="POST", body=dummy_invalid_request)
         self.assertEqual(response.code, 400)
         self.assertEqual(type(response.error), HTTPError)
 

--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -131,7 +131,7 @@ func (h *httpHandler) getPrediction(
 
 	// Ensemble
 	if h.IsEnsemblerEnabled() {
-		resp, httpErr = h.Ensemble(ctx, req.Header, requestBody, payload)
+		resp, httpErr = h.Ensemble(ctx, postEnrichmentResponseHeader, requestBody, payload)
 		copyResponseToLogChannel(ctx, respCh, resultlog.ResultLogKeys.Ensembler, resp, httpErr)
 		if httpErr != nil {
 			return nil, httpErr

--- a/engines/router/missionctl/handlers/http_handler_test.go
+++ b/engines/router/missionctl/handlers/http_handler_test.go
@@ -191,7 +191,8 @@ func TestHTTPService(t *testing.T) {
 	assert.JSONEq(t, expectedResponse, rr.Body.String(), "Response body mismatch.")
 
 	// Check that ensembler was called with the expected headers
-	mc.AssertCalled(t, "Ensemble", http.Header{"Context-Type": []string{"application/json"}, "Enricher": []string{"value"}})
+	mc.AssertCalled(t, "Ensemble",
+		http.Header{"Context-Type": []string{"application/json"}, "Enricher": []string{"value"}})
 }
 
 // TestHTTPServiceBadRequest tests for a HTTP InternalServerError on bad
@@ -368,7 +369,11 @@ func doTestRequest(mc missionctl.MissionControl, req *http.Request, rr *httptest
 	http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
 }
 
-func modifyRequestBody(body []byte, responseHeaders map[string]string, caller string) (mchttp.Response, *errors.HTTPError) {
+func modifyRequestBody(
+	body []byte,
+	responseHeaders map[string]string,
+	caller string,
+) (mchttp.Response, *errors.HTTPError) {
 	// Parse the body
 	var t testBody
 	err := json.Unmarshal(body, &t)

--- a/engines/router/missionctl/handlers/http_handler_test.go
+++ b/engines/router/missionctl/handlers/http_handler_test.go
@@ -59,7 +59,7 @@ func (mc *BaseMockMissionControl) Enrich(
 	body []byte,
 ) (mchttp.Response, *errors.HTTPError) {
 	mc.Called()
-	return modifyRequestBody(body, "Enrich")
+	return modifyRequestBody(body, map[string]string{"Enricher": "value"}, "Enrich")
 }
 
 // Route appends ":Route" to the value in the json payload
@@ -69,7 +69,7 @@ func (mc *BaseMockMissionControl) Route(
 	body []byte,
 ) (*experiment.Response, mchttp.Response, *errors.HTTPError) {
 	mc.Called()
-	resp, err := modifyRequestBody(body, "Route")
+	resp, err := modifyRequestBody(body, map[string]string{}, "Route")
 	return nil, resp, err
 }
 
@@ -80,8 +80,8 @@ func (mc *BaseMockMissionControl) Ensemble(
 	requestBody []byte,
 	routerResponse []byte,
 ) (mchttp.Response, *errors.HTTPError) {
-	mc.Called()
-	return modifyRequestBody(routerResponse, "Ensemble")
+	mc.Called(header)
+	return modifyRequestBody(routerResponse, map[string]string{}, "Ensemble")
 }
 
 // MockMissionControl simply inherits from BaseMockMissionControl
@@ -189,6 +189,9 @@ func TestHTTPService(t *testing.T) {
 
 	// Check the result body is expected
 	assert.JSONEq(t, expectedResponse, rr.Body.String(), "Response body mismatch.")
+
+	// Check that ensembler was called with the expected headers
+	mc.AssertCalled(t, "Ensemble", http.Header{"Context-Type": []string{"application/json"}, "Enricher": []string{"value"}})
 }
 
 // TestHTTPServiceBadRequest tests for a HTTP InternalServerError on bad
@@ -350,7 +353,7 @@ func createTestBaseMissionControl() *BaseMockMissionControl {
 	mc := &BaseMockMissionControl{}
 	mc.On("Enrich").Return(nil)
 	mc.On("Route").Return(nil)
-	mc.On("Ensemble").Return(nil)
+	mc.On("Ensemble", mock.Anything).Return(nil)
 	return mc
 }
 
@@ -365,7 +368,7 @@ func doTestRequest(mc missionctl.MissionControl, req *http.Request, rr *httptest
 	http.HandlerFunc(handler.ServeHTTP).ServeHTTP(rr, req)
 }
 
-func modifyRequestBody(body []byte, caller string) (mchttp.Response, *errors.HTTPError) {
+func modifyRequestBody(body []byte, responseHeaders map[string]string, caller string) (mchttp.Response, *errors.HTTPError) {
 	// Parse the body
 	var t testBody
 	err := json.Unmarshal(body, &t)
@@ -382,13 +385,18 @@ func modifyRequestBody(body []byte, caller string) (mchttp.Response, *errors.HTT
 		return nil, errors.NewHTTPError(fmt.Errorf("Error occurred in %s: %v", caller, err))
 	}
 
+	httpHeader := http.Header{
+		"Context-Type": []string{"application/json"},
+	}
+	for key, value := range responseHeaders {
+		httpHeader.Set(key, value)
+	}
+
 	// Return response
 	httpResponse := &http.Response{
 		StatusCode: 200,
 		Body:       ioutil.NopCloser(bytes.NewBuffer(tBytes)),
-		Header: http.Header{
-			"Context-Type": []string{"application/json"},
-		},
+		Header:     httpHeader,
 	}
 	mcResp, err := mchttp.NewCachedResponseFromHTTP(httpResponse)
 	if err != nil {

--- a/sdk/samples/common/__init__.py
+++ b/sdk/samples/common/__init__.py
@@ -16,7 +16,8 @@ class MyEnsembler(turing.ensembler.PyFunc):
             self,
             input: pandas.Series,
             predictions: pandas.Series,
-            treatment_config: Optional[dict]) -> Any:
+            treatment_config: Optional[dict],
+            **kwargs: Optional[dict]) -> Any:
         customer_id = input["customer_id"]
         if (customer_id % 2) == 0:
             return predictions['model_even']

--- a/sdk/turing/ensembler.py
+++ b/sdk/turing/ensembler.py
@@ -1,4 +1,6 @@
 import abc
+import deprecation
+
 from typing import Optional, Union, List, Any, Dict, Tuple
 import mlflow
 import numpy
@@ -21,7 +23,8 @@ class EnsemblerBase(abc.ABC):
             self,
             input: Union[pandas.Series, Dict[str, Any]],
             predictions: Union[pandas.Series, Dict[str, Any]],
-            treatment_config: Optional[Union[pandas.Series, Dict[str, Any]]]) -> Any:
+            treatment_config: Optional[Union[pandas.Series, Dict[str, Any]]],
+            **kwargs: Optional[Dict[str, Any]]) -> Any:
         """
         Ensembler should have an ensemble method, that implements the logic on how to
         ensemble final prediction results from individual model predictions and a treatment
@@ -33,6 +36,8 @@ class EnsemblerBase(abc.ABC):
         :param treatment_config: Optional[Union[pandas.Series, Dict[str, Any]]], representing the configuration of a
                 treatment, that should be applied to a given record/payload. If the experiment
                 engine is not configured, then `treatment_config` will be `None`
+        :param kwargs: Optional[Dict[str, Any]], representing a flexible list of keyword-arguments to send additional
+               contextual info for ensembling.
 
         :returns ensembling result (one of str, int, float, double or array)
         """
@@ -46,6 +51,8 @@ class PyFunc(EnsemblerBase, mlflow.pyfunc.PythonModel, abc.ABC):
     """
     PREDICTION_COLUMN_PREFIX = '__predictions__'
     TREATMENT_CONFIG_COLUMN_PREFIX = '__treatment_config__'
+    # Version is used to store metadata about the ensembler
+    VERSION='v2'
 
     def load_context(self, context):
         self.initialize(context.artifacts)
@@ -87,17 +94,19 @@ class PyFunc(EnsemblerBase, mlflow.pyfunc.PythonModel, abc.ABC):
         Helper function to ensemble single requests; works on dictionary input in a single request made to the pyfunc
         ensembler service (run by the pyfunc ensembler service engine)
         """
+        request_body = model_input['body']
         # Get a mapping between route names and their corresponding responses
         routes_to_response = dict()
-        for prediction in model_input['response']['route_responses']:
+        for prediction in request_body['response']['route_responses']:
             routes_to_response[prediction["route"]] = prediction.copy()
             # Deletes route from the dictionary as it is a duplicate of the key
             del routes_to_response[prediction["route"]]["route"]
 
         return self.ensemble(
-            input=model_input['request'],
+            input=request_body['request'],
             predictions=routes_to_response,
-            treatment_config=model_input['response']['experiment']
+            treatment_config=request_body['response']['experiment'],
+            headers=model_input['headers']
         )
 
     @staticmethod

--- a/sdk/turing/ensembler.py
+++ b/sdk/turing/ensembler.py
@@ -1,12 +1,12 @@
 import abc
-import deprecation
-
+import logging
+from sys import version_info
 from typing import Optional, Union, List, Any, Dict, Tuple
+
 import mlflow
 import numpy
 import pandas
 import re
-from sys import version_info
 import yaml
 
 import turing.generated.models
@@ -109,6 +109,7 @@ class PyFunc(EnsemblerBase, mlflow.pyfunc.PythonModel, abc.ABC):
             )
         except TypeError as e:
             if "got an unexpected keyword argument 'headers'" in str(e):
+                logging.warn("ensemble() uses a deprecated signature, please refer to samples.")
                 # This handles the legacy ensemblers
                 # TODO: Deprecate support for legacy ensemblers
                 return self.ensemble(


### PR DESCRIPTION
This PR makes 2 user-facing changes:
* `engines/router/missionctl/handlers/http_handler.go` - Make the Enricher's response headers available to the Ensembler in the request headers. The merging of the headers was introduced in https://github.com/gojek/turing/pull/176, intended to be used for the routing step and we hadn't propagated it down to the Ensembler. However, allowing the Ensembler access to those values would help the Ensembler make decisions based on values computed by the Enricher.
* Pass request headers to the Pyfunc Ensembler. Previously, request headers were not available to Pyfunc ensemblers. The changes are described in detail below.

### Passing Ensembler Request Headers to the Pyfunc Ensembler
To support this, the optional `**kwargs` argument has been added to the `EnsemblerBase.ensemble` method, meant to take in contextual information. This will be used by the Pyfunc Ensembler Service to propagate request headers. The main changes are below.
* `engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/handler.py` - Nest request headers and body under a single dict, when calling the MlFlow Pyfunc model's [predict](https://github.com/mlflow/mlflow/blob/v1.20.0/mlflow/pyfunc/__init__.py#L592).
* `sdk/turing/ensembler.py` - Pick up the headers from the model input and pass them to the `ensemble()` method. The signature of the `ensemble` method now takes in `**kwargs` which should be included in the custom implementation to take advantage of the headers. However, since some users may be on the older Pyfunc ensemblers, a `try-except` has been added to issue the call without headers if there is an associated exception. This special handling can be removed in a few releases, when users have started to include `**kwargs` in their implementation.

### Tests
The following scenarios have been tested to be working with the new Pyfunc service as of this PR:
* Deploying images already built using older SDK versions
* Building and deploying images from artifacts created by older SDK versions
* Building and deploying images from artifacts created by the new SDK version as of this PR, with or without the `**kwargs`