### PR TITLE
Increase default timeout values for router components

### DIFF
--- a/ui/src/services/ensembler/DockerEnsembler.js
+++ b/ui/src/services/ensembler/DockerEnsembler.js
@@ -18,7 +18,7 @@ export class DockerEnsembler extends Ensembler {
 
   static newConfig() {
     return {
-      timeout: "60ms",
+      timeout: "100ms",
       endpoint: "/",
       port: 8080,
       resource_request: {

--- a/ui/src/services/ensembler/PyFuncEnsembler.js
+++ b/ui/src/services/ensembler/PyFuncEnsembler.js
@@ -29,7 +29,7 @@ export class PyFuncEnsembler extends Ensembler {
         max_replica: 2,
       },
       env: [],
-      timeout: "60ms",
+      timeout: "100ms",
     };
   }
 }

--- a/ui/src/services/router/TuringRouter.js
+++ b/ui/src/services/router/TuringRouter.js
@@ -25,11 +25,11 @@ export class TuringRouter {
         min_replica: 0,
         max_replica: 2,
       },
-      timeout: "100ms",
+      timeout: "300ms",
       experiment_engine: new NopExperimentEngine(),
       enricher: {
         type: "nop",
-        timeout: "60ms",
+        timeout: "100ms",
         endpoint: "/",
         port: 8080,
         resource_request: {
@@ -150,7 +150,7 @@ export class TuringRouter {
 export const newRoute = () => ({
   id: "",
   type: "PROXY",
-  timeout: "20ms",
+  timeout: "100ms",
 });
 
 export const newRule = () => ({


### PR DESCRIPTION
This is a straightforward change to increase the default timeout values for the router components (overall timeout, enricher/router/ensembler timeout), to more realistic values, based on internal feedback.