### PR TITLE
Satisfy Istio's requirement for named ports

### DIFF
--- a/infra/charts/turing/Chart.yaml
+++ b/infra/charts/turing/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: "Turing: ML Experimentation System"
 name: turing
-version: 0.2.11
+version: 0.2.12
 appVersion: v1.0.0

--- a/infra/charts/turing/templates/service-turing.yaml
+++ b/infra/charts/turing/templates/service-turing.yaml
@@ -14,7 +14,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.turing.service.externalPort }}
+    - name: http
+      port: {{ .Values.turing.service.externalPort }}
       targetPort: {{ .Values.turing.service.internalPort }}
       protocol: TCP
   selector:


### PR DESCRIPTION
### Context:

Istio [requires](https://istio.io/v1.0/docs/setup/kubernetes/spec-requirements/) service ports to be named in order to work correctly with the routing features. (It is also explained here in detail: [Protocol Selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/)). While the current chart works correctly with some basic usage of Istio (i.e. exposing a service via `VirtualService`), it fails to work as expected inside Istio's Service mesh.

This MR adds `http` name to Turing's `Service` and bumps up a patch version of the chart. 