### PR TITLE
[BUG] Fix NavBar MLP logo to redirect to the MLP dashboard

### DIFF
--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -382,7 +382,7 @@ jobs:
         working-directory: sdk
         run: make setup
 
-      - name: Run End-to-End Test Suite
+      - name: Run End-to-End Test Suite with Turing API
         if: ${{ !matrix.useSDK }}
         id: run-e2e-test
         working-directory: api

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@elastic/datemath": "5.0.3",
     "@elastic/eui": "32.3.0",
-    "@gojek/mlp-ui": "1.4.19",
+    "@gojek/mlp-ui": "1.5.5",
     "@overgear/yup-ast": "^1.0.3",
     "@reach/router": "1.3.4",
     "@sentry/browser": "5.15.5",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1310,10 +1310,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gojek/mlp-ui@1.4.19":
-  version "1.4.19"
-  resolved "https://registry.yarnpkg.com/@gojek/mlp-ui/-/mlp-ui-1.4.19.tgz#aea3aa9d97f6b3f5b0386423c8728e0f4214ecac"
-  integrity sha512-S7dvuTRj+2e7k2u3zWLyZbBjItCNBA3WfbcmXMamKEJ1cx395Sbig1gCwQQC1zSVSi9khI59gmjSxYZJDdDDdw==
+"@gojek/mlp-ui@1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@gojek/mlp-ui/-/mlp-ui-1.5.5.tgz#7f62b9196cbe80bcfd5d0f1d71ffdaa5348a9a7e"
+  integrity sha512-6AmPx3jtSFAH0dYxP7wUSLtpSJSrVT7WaVrUfBQbI+MF81x312Vf3yi3JbVmovl+0TOdlBOMenuxAKlk5xb/hg==
   dependencies:
     classnames "^2.2.6"
     json-bigint "1.0.0"


### PR DESCRIPTION
## Context
The MLP logo on Turing UI uses a different version of `mlp-ui` which causes the MLP logo to redirect the user to the landing page of Turing instead of the MLP project landing page. With the changes made in https://github.com/gojek/mlp/pull/52, this PR simply updates the `mlp-ui` version it is using as a dependency to ensure the new changes get incorporated. 

Also made a tiny addition to the GitHub step name that corresponds to the API e2e tests for clarity.

## Modifications 
- `ui/package.json` - Dependency updates to `mlp-ui`
- `ui/yarn.lock` - Dependency updates to `mlp-ui`
- `.github/workflows/turing.yaml` - Update to the API e2e test step name for clarity