### PR TITLE
Add UI handling with batch ensembling disabled

### DIFF
--- a/infra/charts/turing/values.yaml
+++ b/infra/charts/turing/values.yaml
@@ -118,7 +118,7 @@ turing:
     AlertConfig:
       Enabled: false
     BatchEnsemblingConfig:
-      Enabled: false
+      Enabled: &batchEnsemblingEnabled false
     EnsemblerServiceBuilderConfig:
       DefaultEnvironment: dev
       ImageBuildingConfig:
@@ -182,6 +182,7 @@ turing:
           href: https://github.com/gojek/turing/tree/main/docs
       scaling:
         maxAllowedReplica: 20
+      batchEnsemblingEnabled: *batchEnsemblingEnabled
     authConfig:
       oauthClientId: ""
     sentryConfig: { }

--- a/ui/.env
+++ b/ui/.env
@@ -34,3 +34,6 @@ REACT_APP_DEFAULT_EXPERIMENT_ENGINE={"name":"","url":"","config":""}
 # and value being the URL to proxy to. Used only in local development mode, to bypass CORS.
 # More info: https://create-react-app.dev/docs/proxying-api-requests-in-development/
 REMOTE_COMPONENTS_PROXY_PATHS=
+
+# Indicates whether batch ensembling is enabled in the API
+REACT_APP_BATCH_ENSEMBLING_ENABLED=*** set batch ensembling enabled option ***

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -60,6 +60,8 @@ const appConfig = {
     // Default number of tail log entries to be fetched
     defaultTailLines: 1000,
   },
+  batchEnsemblingEnabled:
+    process.env.REACT_APP_BATCH_ENSEMBLING_ENABLED === "true",
 };
 
 const sentryConfig = {

--- a/ui/src/jobs/EnsemblingJobsRouter.js
+++ b/ui/src/jobs/EnsemblingJobsRouter.js
@@ -1,13 +1,13 @@
 import React from "react";
 import { Redirect, Router } from "@reach/router";
-import { ListEnsemblingJobsView } from "./list/ListEnsemblingJobsView";
+import { ListEnsemblingJobsLandingView } from "./list/ListEnsemblingJobsLandingView";
 import { EnsemblingJobDetailsView } from "./details/EnsemblingJobDetailsView";
 import { EnsemblersContextContextProvider } from "../providers/ensemblers/context";
 
 export const EnsemblingJobsRouter = ({ projectId }) => (
   <EnsemblersContextContextProvider projectId={projectId}>
     <Router>
-      <ListEnsemblingJobsView path="/" />
+      <ListEnsemblingJobsLandingView path="/" />
 
       <EnsemblingJobDetailsView path=":jobId/*" />
 

--- a/ui/src/jobs/list/ListEnsemblingJobsLandingView.js
+++ b/ui/src/jobs/list/ListEnsemblingJobsLandingView.js
@@ -1,0 +1,32 @@
+import { EuiPage, EuiPanel, EuiSpacer, EuiText } from "@elastic/eui";
+import React from "react";
+import { useConfig } from "../../config";
+import { ListEnsemblingJobsView } from "./ListEnsemblingJobsView";
+
+export const ListEnsemblingJobsLandingView = (props) => {
+  const {
+    appConfig: { batchEnsemblingEnabled },
+  } = useConfig();
+
+  return (
+    <>
+      {batchEnsemblingEnabled ? (
+        <ListEnsemblingJobsView {...props} />
+      ) : (
+        <EuiPage>
+          <EuiPanel>
+            <EuiText>
+              Batch ensembling has not been enabled for this deployment of
+              Turing.
+            </EuiText>
+            <EuiSpacer />
+            <EuiText>
+              To use batch ensembling, please enable it in the configuration
+              file used to deploy the Turing API.
+            </EuiText>
+          </EuiPanel>
+        </EuiPage>
+      )}
+    </>
+  );
+};

--- a/ui/src/jobs/list/ListEnsemblingJobsLandingView.js
+++ b/ui/src/jobs/list/ListEnsemblingJobsLandingView.js
@@ -22,7 +22,7 @@ export const ListEnsemblingJobsLandingView = (props) => {
             <EuiSpacer />
             <EuiText>
               To use batch ensembling, please enable it in the configuration
-              file used to deploy the Turing API.
+              file used to deploy the Turing app.
             </EuiText>
           </EuiPanel>
         </EuiPage>

--- a/ui/src/jobs/list/ListEnsemblingJobsView.js
+++ b/ui/src/jobs/list/ListEnsemblingJobsView.js
@@ -14,7 +14,8 @@ import { replaceBreadcrumbs } from "@gojek/mlp-ui";
 import { useConfig } from "../../config";
 import { parse, stringify } from "query-string";
 
-export const ListEnsemblingJobsView = ({ projectId, ...props }) => {
+export const ListEnsemblingJobsView = (props) => {
+  const projectId = props.projectId;
   const {
     appConfig: {
       pagination: { defaultPageSize },


### PR DESCRIPTION
## Context
If batch ensembling is disabled on the Turing API, any attempts by the UI to display the ensembling jobs page will result in an error being shown. This is because the Turing API does not initialise a `EnsemblingJobController` to handle the ensembling job endpoints when batch ensembling is disabled, leading to a `404` response when the UI tries to send a request to the inexistent`/projects/{project_id}/jobs` endpoint when attempting to display the ensembling jobs page.

In order to gracefully avoid such a scenario, this PR introduces an additional landing view for the ensembling jobs page, displaying the usual `ListEnsemblingJobsView` if batch ensembling is enabled or a placeholder message when batch ensembling is disabled. This prevents the UI from sending requests to the inexistent endpoint and having to manually handle any resultant errors.

![Screenshot 2022-08-04 at 7 39 38 PM](https://user-images.githubusercontent.com/36802364/182838221-771e64e0-20c8-45ad-8fae-e1ce0300fb1c.png)

To track whether batch ensembling is enabled/disabled, the UI now consumes a new config variable `batchEnsemblingEnabled`. This is either passed through the `.env` file or via the helm chart values.

## Modifications
- `infra/charts/turing/values.yaml` - Addition of `batchEnsemblingEnabled` to `uiConfig.appConfig` in the helm chart values
- `ui/.env` - Addition of the env var `REACT_APP_BATCH_ENSEMBLING_ENABLED` that corresponds to `batchEnsemblingEnabled`
- `ui/src/config.js` - Addtion of config handling for the updated `appConfig`
- `ui/src/jobs/EnsemblingJobsRouter.js` - Replacement of `ListEnsemblingJobsView` with `ListEnsemblingJobsLandingView` to handle the ensembling jobs path
- `ui/src/jobs/list/ListEnsemblingJobsLandingView.js` - Addition of a new component to determine if the original `ListEnsemblingJobsView` or a placeholder message should be shown, depending on whether batch ensembling is enabled
- `ui/src/jobs/list/ListEnsemblingJobsView.js` - Minor refactoring to enable this class to become a child component of the new landing page