### PR TITLE
Set ensembler log level to WARNING from INFO

### DIFF
--- a/engines/pyfunc-ensembler-service/app.Dockerfile
+++ b/engines/pyfunc-ensembler-service/app.Dockerfile
@@ -52,4 +52,4 @@ RUN if [ "${MLFLOW_ARTIFACT_STORAGE_TYPE}" = "gcs" ]; then  \
 ENV FOLDER_NAME=$FOLDER_NAME
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT . activate ${CONDA_ENV_NAME} && \
-  python -m pyfunc_ensembler_runner --mlflow_ensembler_dir ./${FOLDER_NAME} -l WARNING
+  python -m pyfunc_ensembler_runner --mlflow_ensembler_dir ./${FOLDER_NAME}

--- a/engines/pyfunc-ensembler-service/app.Dockerfile
+++ b/engines/pyfunc-ensembler-service/app.Dockerfile
@@ -52,4 +52,4 @@ RUN if [ "${MLFLOW_ARTIFACT_STORAGE_TYPE}" = "gcs" ]; then  \
 ENV FOLDER_NAME=$FOLDER_NAME
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT . activate ${CONDA_ENV_NAME} && \
-  python -m pyfunc_ensembler_runner --mlflow_ensembler_dir ./${FOLDER_NAME} -l INFO
+  python -m pyfunc_ensembler_runner --mlflow_ensembler_dir ./${FOLDER_NAME} -l WARNING

--- a/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/__main__.py
+++ b/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/__main__.py
@@ -28,7 +28,7 @@ parser.add_argument(
     dest="log_level",
     choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
     help="Set the logging level",
-    default=logging.DEBUG,
+    default=logging.WARNING,
 )
 
 args, _ = parser.parse_known_args()

--- a/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/__main__.py
+++ b/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import traceback
+import os
 
 import tornado.ioloop
 
@@ -32,10 +33,10 @@ parser.add_argument(
 )
 
 args, _ = parser.parse_known_args()
-
+log_level = os.getenv("LOG_LEVEL_ENV", args.log_level)
 
 if __name__ == "__main__":
-    logging.basicConfig(level=args.log_level)
+    logging.basicConfig(level=log_level)
     logging.info(
         "Called with arguments:\n%s\n",
         "\n".join([f"{k}: {v}" for k, v in vars(args).items()]),

--- a/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/__main__.py
+++ b/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/__main__.py
@@ -25,7 +25,7 @@ parser.add_argument(
 )
 
 args, _ = parser.parse_known_args()
-log_level = os.getenv("LOG_LEVEL_ENV", logging.WARNING)
+log_level = os.getenv("LOG_LEVEL", logging.WARNING)
 
 if __name__ == "__main__":
     logging.basicConfig(level=log_level)

--- a/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/__main__.py
+++ b/engines/pyfunc-ensembler-service/pyfunc_ensembler_runner/__main__.py
@@ -23,17 +23,9 @@ parser.add_argument(
     help="Dry run pyfunc ensembler by loading the specified ensembler "
     "in --mlflow_ensembler_dir without starting webserver",
 )
-parser.add_argument(
-    "-l",
-    "--log-level",
-    dest="log_level",
-    choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-    help="Set the logging level",
-    default=logging.WARNING,
-)
 
 args, _ = parser.parse_known_args()
-log_level = os.getenv("LOG_LEVEL_ENV", args.log_level)
+log_level = os.getenv("LOG_LEVEL_ENV", logging.WARNING)
 
 if __name__ == "__main__":
     logging.basicConfig(level=log_level)

--- a/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
+++ b/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
@@ -27,7 +27,7 @@ with open(os.path.join(data_dir, "request_invalid.json")) as f:
             "simple_ensembler_uri",
             dummy_short_request,
             {"Key": "Value"},
-            {"headers": {"Key": "Value"}, "enricher_response" : None},
+            {"headers": {"Key": "Value"}, "enricher_response": None},
         ),
     ],
 )


### PR DESCRIPTION
The default turing ensembler log level is set to INFO but this spams with too many logs thus causing memory consumption in downstream logging platform.

The goal of this very simple MR is to modify this log level to WARNING from INFO - [python logging loglevels](https://docs.python.org/3/library/logging.html#logging-levels)

Also there is an added capability for DS folks to change the ensembler log levels to INFO using env